### PR TITLE
Add Cloudflare D&D map reveal app

### DIFF
--- a/apps/pages/index.html
+++ b/apps/pages/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>D&D Map Reveal</title>
+  </head>
+  <body class="bg-surface-light dark:bg-surface-dark">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/pages/package.json
+++ b/apps/pages/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "dnd-map-reveal",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "clsx": "^2.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.4",
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "autoprefixer": "^10.4.16",
+    "postcss": "^8.4.31",
+    "tailwindcss": "^3.3.5",
+    "typescript": "^5.2.2",
+    "vite": "^4.5.0"
+  }
+}

--- a/apps/pages/postcss.config.cjs
+++ b/apps/pages/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/apps/pages/src/App.tsx
+++ b/apps/pages/src/App.tsx
@@ -1,0 +1,189 @@
+import React, { useEffect, useMemo, useState } from "react";
+import BuildPage from "./pages/BuildPage";
+import PlayPage from "./pages/PlayPage";
+import { AuthProvider, useAuth } from "./context/AuthContext";
+
+const App: React.FC = () => {
+  return (
+    <AuthProvider>
+      <AppShell />
+    </AuthProvider>
+  );
+};
+
+const AppShell: React.FC = () => {
+  const { user, login, signup, logout, loading } = useAuth();
+  const [mode, setMode] = useState<"play" | "build">("play");
+  const [theme, setTheme] = useState<"light" | "dark">(() => {
+    if (typeof window !== "undefined" && window.matchMedia("(prefers-color-scheme: dark)").matches) {
+      return "dark";
+    }
+    return "light";
+  });
+  const [authMode, setAuthMode] = useState<"login" | "signup">("login");
+  const [authForm, setAuthForm] = useState({ email: "", password: "", displayName: "Dungeon Master" });
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (theme === "dark") {
+      root.classList.add("dark");
+    } else {
+      root.classList.remove("dark");
+    }
+    localStorage.setItem("dnd-map-reveal/theme", theme);
+  }, [theme]);
+
+  useEffect(() => {
+    const storedTheme = localStorage.getItem("dnd-map-reveal/theme");
+    if (storedTheme === "dark" || storedTheme === "light") {
+      setTheme(storedTheme);
+    }
+  }, []);
+
+  const handleAuthSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setError(null);
+    try {
+      if (authMode === "login") {
+        await login(authForm.email, authForm.password);
+      } else {
+        await signup(authForm.email, authForm.password, authForm.displayName);
+      }
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  };
+
+  const canAccessBuild = Boolean(user);
+
+  const modeLabel = useMemo(() => (mode === "play" ? "Player View" : "DM Build"), [mode]);
+
+  if (loading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-surface-light/90 text-slate-600 dark:bg-surface-dark/95 dark:text-slate-300">
+        Loading account…
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-surface-light/90 pb-16 text-slate-900 transition-colors duration-300 dark:bg-surface-dark/95 dark:text-slate-100">
+      <header className="sticky top-0 z-20 border-b border-slate-200 bg-white/80 backdrop-blur dark:border-slate-800 dark:bg-slate-900/70">
+        <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
+          <div>
+            <h1 className="text-lg font-semibold tracking-wide">D&D Map Reveal</h1>
+            <p className="text-xs uppercase tracking-[0.3em] text-slate-500 dark:text-slate-400">Cloudflare Pages + Workers</p>
+          </div>
+          <div className="flex items-center gap-3">
+            <div className="flex items-center gap-2 rounded-full border border-slate-200 bg-white/80 px-2 py-1 text-xs font-semibold shadow-sm dark:border-slate-700 dark:bg-slate-800/60">
+              <button
+                type="button"
+                onClick={() => setMode("play")}
+                className={`rounded-full px-3 py-1 ${mode === "play" ? "bg-indigo-600 text-white shadow" : "text-slate-600 dark:text-slate-300"}`}
+              >
+                Play Mode
+              </button>
+              <button
+                type="button"
+                onClick={() => setMode("build")}
+                className={`rounded-full px-3 py-1 ${mode === "build" ? "bg-emerald-600 text-white shadow" : "text-slate-600 dark:text-slate-300"}`}
+              >
+                Build Mode
+              </button>
+            </div>
+            <button
+              type="button"
+              onClick={() => setTheme((prev) => (prev === "light" ? "dark" : "light"))}
+              className="rounded-full border border-slate-200 bg-white/90 px-3 py-2 text-xs font-semibold text-slate-600 shadow-sm hover:bg-slate-100 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200"
+            >
+              {theme === "light" ? "☀️" : "🌙"}
+            </button>
+            {user ? (
+              <div className="flex items-center gap-2 text-xs">
+                <span className="rounded-full bg-slate-900/80 px-3 py-1 font-semibold text-white dark:bg-slate-100 dark:text-slate-900">{user.displayName}</span>
+                <button
+                  type="button"
+                  onClick={logout}
+                  className="rounded-md border border-slate-200 px-3 py-1 text-xs font-semibold text-slate-600 hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200"
+                >
+                  Logout
+                </button>
+              </div>
+            ) : (
+              <span className="text-xs text-slate-500 dark:text-slate-400">Guest</span>
+            )}
+          </div>
+        </div>
+      </header>
+      <main className="mx-auto mt-8 flex max-w-6xl flex-col gap-6 px-6">
+        <p className="text-sm text-slate-500 dark:text-slate-400">
+          {modeLabel}: DM uploads maps to R2, stores metadata in D1, and orchestrates live reveals through Durable Objects-backed WebSockets.
+        </p>
+        {mode === "build" && !canAccessBuild ? (
+          <section className="mx-auto w-full max-w-2xl rounded-xl border border-slate-200 bg-white/80 p-8 text-slate-900 shadow-lg dark:border-slate-700 dark:bg-slate-900/80 dark:text-slate-100">
+            <h2 className="text-xl font-semibold">Sign in as Dungeon Master</h2>
+            <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">Create an account to manage campaigns and sessions.</p>
+            <form onSubmit={handleAuthSubmit} className="mt-4 space-y-4">
+              <label className="block text-sm">
+                <span className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Email</span>
+                <input
+                  type="email"
+                  required
+                  value={authForm.email}
+                  onChange={(e) => setAuthForm((prev) => ({ ...prev, email: e.target.value }))}
+                  className="mt-1 w-full rounded-md border border-slate-300 bg-white/90 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none dark:border-slate-600 dark:bg-slate-900"
+                />
+              </label>
+              <label className="block text-sm">
+                <span className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Password</span>
+                <input
+                  type="password"
+                  required
+                  value={authForm.password}
+                  onChange={(e) => setAuthForm((prev) => ({ ...prev, password: e.target.value }))}
+                  className="mt-1 w-full rounded-md border border-slate-300 bg-white/90 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none dark:border-slate-600 dark:bg-slate-900"
+                />
+              </label>
+              {authMode === "signup" && (
+                <label className="block text-sm">
+                  <span className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Display name</span>
+                  <input
+                    type="text"
+                    required
+                    value={authForm.displayName}
+                    onChange={(e) => setAuthForm((prev) => ({ ...prev, displayName: e.target.value }))}
+                    className="mt-1 w-full rounded-md border border-slate-300 bg-white/90 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none dark:border-slate-600 dark:bg-slate-900"
+                  />
+                </label>
+              )}
+              {error && <div className="rounded-md border border-rose-400 bg-rose-100 px-3 py-2 text-sm text-rose-700">{error}</div>}
+              <button
+                type="submit"
+                className="w-full rounded-md bg-emerald-600 px-3 py-2 text-sm font-semibold text-white shadow hover:bg-emerald-500"
+              >
+                {authMode === "login" ? "Login" : "Sign Up"}
+              </button>
+              <button
+                type="button"
+                onClick={() => setAuthMode((prev) => (prev === "login" ? "signup" : "login"))}
+                className="w-full text-center text-xs font-semibold text-indigo-600 hover:underline dark:text-indigo-300"
+              >
+                {authMode === "login" ? "Need an account? Sign up" : "Already have an account? Login"}
+              </button>
+            </form>
+          </section>
+        ) : mode === "build" ? (
+          <BuildPage />
+        ) : (
+          <PlayPage />
+        )}
+      </main>
+      <footer className="mt-16 border-t border-slate-200 bg-white/80 py-6 text-center text-xs text-slate-500 dark:border-slate-800 dark:bg-slate-900/80 dark:text-slate-400">
+        Built for Cloudflare Pages & Workers — R2 for assets, D1 for metadata, Durable Objects for realtime reveals.
+      </footer>
+    </div>
+  );
+};
+
+export default App;

--- a/apps/pages/src/api/client.ts
+++ b/apps/pages/src/api/client.ts
@@ -1,0 +1,277 @@
+export interface ApiUser {
+  id: string;
+  email: string;
+  displayName: string;
+}
+
+export interface ApiCampaign {
+  id: string;
+  name: string;
+  description?: string | null;
+  isPublic?: boolean;
+}
+
+export interface ApiMap {
+  id: string;
+  campaignId: string;
+  name: string;
+  description?: string | null;
+  displayKey?: string | null;
+  width?: number | null;
+  height?: number | null;
+}
+
+export interface ApiRegion {
+  id: string;
+  mapId: string;
+  name: string;
+  polygon: number[][];
+  orderIndex: number;
+}
+
+export interface ApiMarker {
+  id: string;
+  mapId: string;
+  name: string;
+  markerType: string;
+  position: { x: number; y: number };
+  data?: Record<string, unknown> | null;
+}
+
+export interface ApiSession {
+  id: string;
+  campaignId: string;
+  mapId: string;
+  name: string;
+  status: string;
+}
+
+interface ApiRequestOptions extends RequestInit {
+  auth?: boolean;
+}
+
+class APIClient {
+  private token: string | null;
+  readonly baseUrl: string;
+
+  constructor(baseUrl?: string) {
+    this.baseUrl = baseUrl ?? import.meta.env.VITE_API_BASE_URL ?? "";
+    this.token = null;
+  }
+
+  setToken(token: string | null) {
+    this.token = token;
+  }
+
+  async request<T>(path: string, options: ApiRequestOptions = {}): Promise<T> {
+    const headers = new Headers(options.headers ?? {});
+    if (!headers.has("content-type") && options.body && typeof options.body === "string") {
+      headers.set("content-type", "application/json");
+    }
+    if (options.auth && this.token) {
+      headers.set("authorization", `Bearer ${this.token}`);
+    }
+    const response = await fetch(`${this.baseUrl}${path}`, {
+      ...options,
+      headers
+    });
+    if (!response.ok) {
+      let message = response.statusText;
+      try {
+        const data = await response.json();
+        message = data.error ?? message;
+      } catch (err) {
+        // ignore json parse errors
+      }
+      throw new Error(message || `Request failed: ${response.status}`);
+    }
+    const text = await response.text();
+    return text ? (JSON.parse(text) as T) : ({} as T);
+  }
+
+  async signup(email: string, password: string, displayName: string) {
+    const result = await this.request<{ user: ApiUser; token: string }>("/api/auth/signup", {
+      method: "POST",
+      body: JSON.stringify({ email, password, displayName })
+    });
+    this.setToken(result.token);
+    return result;
+  }
+
+  async login(email: string, password: string) {
+    const result = await this.request<{ user: ApiUser; token: string }>("/api/auth/login", {
+      method: "POST",
+      body: JSON.stringify({ email, password })
+    });
+    this.setToken(result.token);
+    return result;
+  }
+
+  async listCampaigns(publicOnly = false) {
+    const query = publicOnly ? "?public=1" : "";
+    const result = await this.request<{ campaigns: ApiCampaign[] }>(`/api/campaigns${query}`, {
+      auth: !publicOnly
+    });
+    return result.campaigns;
+  }
+
+  async createCampaign(payload: { name: string; description?: string; isPublic?: boolean }) {
+    const result = await this.request<{ campaign: ApiCampaign }>("/api/campaigns", {
+      method: "POST",
+      auth: true,
+      body: JSON.stringify(payload)
+    });
+    return result.campaign;
+  }
+
+  async listMaps(campaignId?: string) {
+    const query = campaignId ? `?campaignId=${encodeURIComponent(campaignId)}` : "";
+    const result = await this.request<{ maps: ApiMap[] }>(`/api/maps${query}`);
+    return result.maps;
+  }
+
+  async createMap(payload: {
+    campaignId: string;
+    name: string;
+    description?: string;
+    fileExtension?: string;
+    width?: number;
+    height?: number;
+    contentType?: string;
+  }) {
+    const result = await this.request<{ map: ApiMap; uploads: Record<string, unknown> }>("/api/maps", {
+      method: "POST",
+      auth: true,
+      body: JSON.stringify(payload)
+    });
+    return result;
+  }
+
+  async listRegions(mapId: string) {
+    const result = await this.request<{ regions: any[] }>(`/api/maps/${mapId}/regions`);
+    return result.regions.map((region) => ({
+      id: region.id,
+      mapId: region.mapId,
+      name: region.name,
+      polygon: Array.isArray(region.polygon)
+        ? region.polygon
+        : JSON.parse(region.polygonJson ?? region.polygon ?? "[]"),
+      orderIndex: region.orderIndex ?? 0
+    }));
+  }
+
+  async createRegion(mapId: string, payload: { name: string; polygon: number[][]; orderIndex?: number }) {
+    const result = await this.request<{ region: ApiRegion }>(`/api/maps/${mapId}/regions`, {
+      method: "POST",
+      auth: true,
+      body: JSON.stringify(payload)
+    });
+    return result.region;
+  }
+
+  async updateRegion(regionId: string, payload: Partial<{ name: string; polygon: number[][]; orderIndex: number }>) {
+    await this.request(`/api/regions/${regionId}`, {
+      method: "PUT",
+      auth: true,
+      body: JSON.stringify(payload)
+    });
+  }
+
+  async deleteRegion(regionId: string) {
+    await this.request(`/api/regions/${regionId}`, {
+      method: "DELETE",
+      auth: true
+    });
+  }
+
+  async listMarkers(mapId: string) {
+    const result = await this.request<{ markers: any[] }>(`/api/maps/${mapId}/markers`);
+    return result.markers.map((marker) => ({
+      id: marker.id,
+      mapId: marker.mapId,
+      name: marker.name,
+      markerType: marker.markerType,
+      position: typeof marker.position === "object" && marker.position !== null
+        ? marker.position
+        : JSON.parse(marker.positionJson ?? marker.position ?? "{}"),
+      data: typeof marker.data === "object" || marker.data == null
+        ? marker.data
+        : JSON.parse(marker.dataJson ?? marker.data ?? "{}")
+    }));
+  }
+
+  async createMarker(mapId: string, payload: { name: string; markerType: string; position: { x: number; y: number }; data?: Record<string, unknown> }) {
+    const result = await this.request<{ marker: ApiMarker }>(`/api/maps/${mapId}/markers`, {
+      method: "POST",
+      auth: true,
+      body: JSON.stringify(payload)
+    });
+    return result.marker;
+  }
+
+  async updateMarker(markerId: string, payload: Partial<{ name: string; markerType: string; position: { x: number; y: number }; data: Record<string, unknown> }>) {
+    await this.request(`/api/markers/${markerId}`, {
+      method: "PUT",
+      auth: true,
+      body: JSON.stringify(payload)
+    });
+  }
+
+  async deleteMarker(markerId: string) {
+    await this.request(`/api/markers/${markerId}`, {
+      method: "DELETE",
+      auth: true
+    });
+  }
+
+  async createSession(payload: { campaignId: string; mapId: string; name: string }) {
+    const result = await this.request<{ session: ApiSession }>("/api/sessions", {
+      method: "POST",
+      auth: true,
+      body: JSON.stringify(payload)
+    });
+    return result.session;
+  }
+
+  async listLobby() {
+    const result = await this.request<{ sessions: ApiSession[] }>("/api/lobby");
+    return result.sessions;
+  }
+
+  async saveSession(sessionId: string) {
+    const result = await this.request<{ backupKey: string }>(`/api/sessions/${sessionId}/save`, {
+      method: "POST",
+      auth: true
+    });
+    return result;
+  }
+
+  async endSession(sessionId: string) {
+    await this.request(`/api/sessions/${sessionId}/end`, {
+      method: "POST",
+      auth: true
+    });
+  }
+
+  async restoreSession(sessionId: string, payload: { backupKey: string; clone?: boolean }) {
+    const result = await this.request(`/api/sessions/${sessionId}/restore`, {
+      method: "POST",
+      auth: true,
+      body: JSON.stringify(payload)
+    });
+    return result;
+  }
+
+  socketUrl(sessionId: string) {
+    if (!this.baseUrl) {
+      throw new Error("API base URL not configured");
+    }
+    const url = new URL(`/api/sessions/${sessionId}/socket`, this.baseUrl);
+    if (url.protocol.startsWith("http")) {
+      url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
+    }
+    return url.toString();
+  }
+}
+
+export const apiClient = new APIClient();

--- a/apps/pages/src/components/MapStage.tsx
+++ b/apps/pages/src/components/MapStage.tsx
@@ -1,0 +1,76 @@
+import React, { useEffect, useMemo, useState } from "react";
+import MaskCanvas from "./MaskCanvas";
+import MarkerLayer from "./MarkerLayer";
+
+type MapStageProps = {
+  map: { displayKey?: string | null; width?: number | null; height?: number | null } | null;
+  regions: any[];
+  revealedRegionIds: string[];
+  markers: Record<string, any>;
+  onMarkerSelect?: (markerId: string) => void;
+  selectedMarkerId?: string | null;
+  r2PublicBase?: string | null;
+};
+
+const fallbackSize = { width: 1280, height: 720 };
+
+const MapStage: React.FC<MapStageProps> = ({ map, regions, revealedRegionIds, markers, onMarkerSelect, selectedMarkerId, r2PublicBase }) => {
+  const [dimensions, setDimensions] = useState({ width: fallbackSize.width, height: fallbackSize.height });
+  const [imageUrl, setImageUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!map?.displayKey) {
+      setImageUrl(null);
+      return;
+    }
+    if (map.displayKey.startsWith("http")) {
+      setImageUrl(map.displayKey);
+      return;
+    }
+    if (r2PublicBase) {
+      const url = new URL(map.displayKey, r2PublicBase);
+      setImageUrl(url.toString());
+    } else {
+      setImageUrl(map.displayKey);
+    }
+  }, [map?.displayKey, r2PublicBase]);
+
+  useEffect(() => {
+    if (!imageUrl) return;
+    const img = new Image();
+    img.src = imageUrl;
+    img.onload = () => {
+      setDimensions({ width: img.naturalWidth || fallbackSize.width, height: img.naturalHeight || fallbackSize.height });
+    };
+  }, [imageUrl]);
+
+  const revealedPolygons = useMemo(() => {
+    return regions
+      .filter((region) => revealedRegionIds.includes(region.id))
+      .map((region) => region.polygon ?? []);
+  }, [regions, revealedRegionIds]);
+
+  return (
+    <div className="relative flex w-full flex-1 items-center justify-center overflow-hidden rounded-xl border border-slate-200 bg-slate-800/80">
+      {imageUrl ? (
+        <div
+          className="relative"
+          style={{ width: `${dimensions.width}px`, height: `${dimensions.height}px` }}
+        >
+          <img src={imageUrl} alt={map?.name ?? "Map"} className="block h-full w-full select-none object-contain" />
+          <MaskCanvas width={dimensions.width} height={dimensions.height} revealedPolygons={revealedPolygons} />
+          <div className="absolute inset-0">
+            <MarkerLayer markers={markers} onSelect={onMarkerSelect} selectedMarkerId={selectedMarkerId} />
+          </div>
+        </div>
+      ) : (
+        <div className="flex h-96 w-full flex-col items-center justify-center gap-3 text-slate-100">
+          <span className="text-lg font-semibold">No map selected</span>
+          <span className="text-sm text-slate-300">Choose a campaign map to preview the fog-of-war.</span>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default MapStage;

--- a/apps/pages/src/components/MarkerLayer.tsx
+++ b/apps/pages/src/components/MarkerLayer.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import clsx from "clsx";
+
+export type MarkerLayerProps = {
+  markers: Record<string, any>;
+  onSelect?: (markerId: string) => void;
+  selectedMarkerId?: string | null;
+};
+
+const markerColors: Record<string, string> = {
+  enemy: "bg-red-500",
+  ally: "bg-emerald-500",
+  note: "bg-sky-500",
+  trap: "bg-amber-500"
+};
+
+const MarkerLayer: React.FC<MarkerLayerProps> = ({ markers, onSelect, selectedMarkerId }) => {
+  return (
+    <>
+      {Object.values(markers).map((marker: any) => {
+        const color = markerColors[marker.markerType] ?? "bg-slate-500";
+        return (
+          <button
+            key={marker.id}
+            onClick={() => onSelect?.(marker.id)}
+            className={clsx(
+              "absolute -translate-x-1/2 -translate-y-1/2 rounded-full border border-white/80 px-2 py-1 text-xs font-semibold text-white shadow-lg focus:outline-none focus:ring",
+              color,
+              selectedMarkerId === marker.id ? "ring-2 ring-white" : "ring-0"
+            )}
+            style={{ left: `${marker.position?.x ?? 0}px`, top: `${marker.position?.y ?? 0}px` }}
+          >
+            {marker.name ?? marker.markerType}
+          </button>
+        );
+      })}
+    </>
+  );
+};
+
+export default MarkerLayer;

--- a/apps/pages/src/components/MaskCanvas.tsx
+++ b/apps/pages/src/components/MaskCanvas.tsx
@@ -1,0 +1,48 @@
+import React, { useEffect, useRef } from "react";
+
+type MaskCanvasProps = {
+  width: number;
+  height: number;
+  revealedPolygons: number[][][];
+  opacity?: number;
+};
+
+const MaskCanvas: React.FC<MaskCanvasProps> = ({ width, height, revealedPolygons, opacity = 0.92 }) => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    canvas.width = width;
+    canvas.height = height;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    ctx.clearRect(0, 0, width, height);
+    ctx.globalCompositeOperation = "source-over";
+    ctx.fillStyle = `rgba(15, 23, 42, ${opacity})`;
+    ctx.fillRect(0, 0, width, height);
+
+    ctx.globalCompositeOperation = "destination-out";
+    ctx.fillStyle = "rgba(0,0,0,1)";
+    revealedPolygons.forEach((points) => {
+      if (!points.length) return;
+      ctx.beginPath();
+      points.forEach(([x, y], index) => {
+        if (index === 0) {
+          ctx.moveTo(x, y);
+        } else {
+          ctx.lineTo(x, y);
+        }
+      });
+      ctx.closePath();
+      ctx.fill();
+    });
+
+    ctx.globalCompositeOperation = "source-over";
+  }, [width, height, revealedPolygons, opacity]);
+
+  return <canvas ref={canvasRef} className="absolute inset-0" />;
+};
+
+export default MaskCanvas;

--- a/apps/pages/src/components/SessionSidebar.tsx
+++ b/apps/pages/src/components/SessionSidebar.tsx
@@ -1,0 +1,83 @@
+import React from "react";
+import clsx from "clsx";
+
+interface SessionSidebarProps {
+  players: { id: string; name: string; role: string }[];
+  lastEvent: string | null;
+  connection: "idle" | "connecting" | "open" | "closed";
+  onReconnect: () => void;
+}
+
+const roleBadges: Record<string, string> = {
+  dm: "bg-purple-500/20 text-purple-200 border border-purple-500/50",
+  player: "bg-slate-600/30 text-slate-200 border border-slate-500/60"
+};
+
+const SessionSidebar: React.FC<SessionSidebarProps> = ({ players, lastEvent, connection, onReconnect }) => {
+  return (
+    <aside className="flex w-full max-w-sm flex-col gap-4 rounded-xl border border-slate-200/40 bg-slate-900/70 p-4 text-slate-100">
+      <header className="flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-semibold">Session Presence</h2>
+          <p className="text-xs text-slate-400">Realtime updates from the virtual tabletop</p>
+        </div>
+        <span className={clsx("rounded-full px-2 py-1 text-xs font-semibold", connectionClass(connection))}>{connectionLabel(connection)}</span>
+      </header>
+      <div className="space-y-2">
+        {players.length === 0 ? (
+          <p className="text-sm text-slate-400">No connected players yet.</p>
+        ) : (
+          players.map((player) => (
+            <div key={player.id} className="flex items-center justify-between rounded-lg bg-slate-800/60 px-3 py-2 text-sm">
+              <span className="font-medium">{player.name}</span>
+              <span className={clsx("rounded-full px-2 py-1 text-xs capitalize", roleBadges[player.role] ?? roleBadges.player)}>
+                {player.role}
+              </span>
+            </div>
+          ))
+        )}
+      </div>
+      <div className="rounded-lg bg-slate-800/60 p-3 text-xs text-slate-300">
+        <div className="font-semibold uppercase tracking-wide text-slate-400">Last event</div>
+        <div className="mt-1 text-sm text-slate-200">{lastEvent ?? "—"}</div>
+      </div>
+      <button
+        type="button"
+        className="rounded-lg bg-slate-700 px-3 py-2 text-sm font-semibold text-slate-100 hover:bg-slate-600 focus:outline-none focus:ring"
+        onClick={onReconnect}
+      >
+        Reconnect Socket
+      </button>
+    </aside>
+  );
+};
+
+function connectionLabel(state: SessionSidebarProps["connection"]) {
+  switch (state) {
+    case "idle":
+      return "Idle";
+    case "connecting":
+      return "Connecting";
+    case "open":
+      return "Live";
+    case "closed":
+      return "Closed";
+    default:
+      return state;
+  }
+}
+
+function connectionClass(state: SessionSidebarProps["connection"]) {
+  switch (state) {
+    case "open":
+      return "bg-emerald-500/20 text-emerald-200 border border-emerald-500/60";
+    case "connecting":
+      return "bg-amber-500/20 text-amber-200 border border-amber-500/60";
+    case "closed":
+      return "bg-rose-500/20 text-rose-200 border border-rose-500/60";
+    default:
+      return "bg-slate-600/20 text-slate-200 border border-slate-500/60";
+  }
+}
+
+export default SessionSidebar;

--- a/apps/pages/src/context/AuthContext.tsx
+++ b/apps/pages/src/context/AuthContext.tsx
@@ -1,0 +1,82 @@
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { apiClient, ApiUser } from "../api/client";
+
+type AuthState = {
+  user: ApiUser | null;
+  token: string | null;
+  loading: boolean;
+  login: (email: string, password: string) => Promise<void>;
+  signup: (email: string, password: string, displayName: string) => Promise<void>;
+  logout: () => void;
+};
+
+const AuthContext = createContext<AuthState | undefined>(undefined);
+
+const TOKEN_KEY = "dnd-map-reveal/token";
+const USER_KEY = "dnd-map-reveal/user";
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [user, setUser] = useState<ApiUser | null>(null);
+  const [token, setToken] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const storedToken = localStorage.getItem(TOKEN_KEY);
+    const storedUser = localStorage.getItem(USER_KEY);
+    if (storedToken && storedUser) {
+      try {
+        const parsed = JSON.parse(storedUser) as ApiUser;
+        setUser(parsed);
+        setToken(storedToken);
+        apiClient.setToken(storedToken);
+      } catch (err) {
+        console.warn("Failed to parse stored user", err);
+        localStorage.removeItem(TOKEN_KEY);
+        localStorage.removeItem(USER_KEY);
+      }
+    }
+    setLoading(false);
+  }, []);
+
+  const saveAuth = useCallback((nextUser: ApiUser, nextToken: string) => {
+    setUser(nextUser);
+    setToken(nextToken);
+    apiClient.setToken(nextToken);
+    localStorage.setItem(TOKEN_KEY, nextToken);
+    localStorage.setItem(USER_KEY, JSON.stringify(nextUser));
+  }, []);
+
+  const clearAuth = useCallback(() => {
+    setUser(null);
+    setToken(null);
+    apiClient.setToken(null);
+    localStorage.removeItem(TOKEN_KEY);
+    localStorage.removeItem(USER_KEY);
+  }, []);
+
+  const login = useCallback(async (email: string, password: string) => {
+    const { user: loggedInUser, token: authToken } = await apiClient.login(email, password);
+    saveAuth(loggedInUser, authToken);
+  }, [saveAuth]);
+
+  const signup = useCallback(async (email: string, password: string, displayName: string) => {
+    const { user: newUser, token: authToken } = await apiClient.signup(email, password, displayName);
+    saveAuth(newUser, authToken);
+  }, [saveAuth]);
+
+  const logout = useCallback(() => {
+    clearAuth();
+  }, [clearAuth]);
+
+  const value = useMemo(() => ({ user, token, loading, login, signup, logout }), [user, token, loading, login, signup, logout]);
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
+
+export const useAuth = () => {
+  const ctx = useContext(AuthContext);
+  if (!ctx) {
+    throw new Error("useAuth must be used within AuthProvider");
+  }
+  return ctx;
+};

--- a/apps/pages/src/hooks/useSessionSocket.ts
+++ b/apps/pages/src/hooks/useSessionSocket.ts
@@ -1,0 +1,131 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { apiClient } from "../api/client";
+
+export interface SessionStateMessage {
+  sessionId: string | null;
+  campaignId: string | null;
+  mapId: string | null;
+  map: any;
+  regions: any[];
+  revealedRegions: string[];
+  markers: Record<string, any>;
+  status: string;
+}
+
+export interface SessionSocketState {
+  connection: "idle" | "connecting" | "open" | "closed";
+  lastEvent: string | null;
+  state: SessionStateMessage | null;
+  players: { id: string; name: string; role: string }[];
+  send: (payload: unknown) => void;
+  reconnect: () => void;
+}
+
+export const useSessionSocket = (sessionId: string | null, identity: { name: string; role: "dm" | "player" }) => {
+  const [connection, setConnection] = useState<SessionSocketState["connection"]>("idle");
+  const [state, setState] = useState<SessionStateMessage | null>(null);
+  const [players, setPlayers] = useState<SessionSocketState["players"]>([]);
+  const [lastEvent, setLastEvent] = useState<string | null>(null);
+  const wsRef = useRef<WebSocket | null>(null);
+  const reconnectToken = useRef(0);
+
+  const connect = useCallback(() => {
+    if (!sessionId) return;
+    const url = apiClient.socketUrl(sessionId);
+    const ws = new WebSocket(url);
+    wsRef.current = ws;
+    setConnection("connecting");
+
+    ws.addEventListener("open", () => {
+      setConnection("open");
+      ws.send(JSON.stringify({ type: "join", name: identity.name, role: identity.role }));
+    });
+
+    ws.addEventListener("message", (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        switch (data.type) {
+          case "state":
+            setState(data.state ?? null);
+            break;
+          case "regionsRevealed":
+            setLastEvent(`Revealed ${data.regionIds?.length ?? 0} region(s)`);
+            setState((prev) => (prev ? { ...prev, revealedRegions: Array.from(new Set([...(prev.revealedRegions ?? []), ...(data.regionIds ?? [])])) } : prev));
+            break;
+          case "regionsHidden":
+            setLastEvent(`Hid ${data.regionIds?.length ?? 0} region(s)`);
+            setState((prev) => (prev ? { ...prev, revealedRegions: prev.revealedRegions.filter((id) => !(data.regionIds ?? []).includes(id)) } : prev));
+            break;
+          case "markerAdded":
+          case "markerUpdated":
+            setLastEvent(`Marker ${data.marker?.name ?? data.marker?.id ?? "updated"}`);
+            setState((prev) => {
+              if (!prev) return prev;
+              const markers = { ...prev.markers, [data.marker.id]: data.marker };
+              return { ...prev, markers };
+            });
+            break;
+          case "markerRemoved":
+            setLastEvent(`Marker removed`);
+            setState((prev) => {
+              if (!prev) return prev;
+              const markers = { ...prev.markers };
+              delete markers[data.markerId];
+              return { ...prev, markers };
+            });
+            break;
+          case "players":
+            setPlayers(data.players ?? []);
+            break;
+          case "pong":
+            setLastEvent("pong");
+            break;
+          default:
+            break;
+        }
+      } catch (err) {
+        console.warn("Failed to parse session message", err);
+      }
+    });
+
+    ws.addEventListener("close", () => {
+      setConnection("closed");
+    });
+
+    ws.addEventListener("error", () => {
+      setConnection("closed");
+    });
+  }, [identity.name, identity.role, sessionId]);
+
+  useEffect(() => {
+    if (!sessionId) return;
+    connect();
+    return () => {
+      wsRef.current?.close();
+    };
+  }, [sessionId, reconnectToken.current, connect]);
+
+  useEffect(() => {
+    const pingInterval = setInterval(() => {
+      if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) {
+        wsRef.current.send(JSON.stringify({ type: "ping" }));
+      }
+    }, 30000);
+    return () => clearInterval(pingInterval);
+  }, []);
+
+  const send = useCallback((payload: unknown) => {
+    const ws = wsRef.current;
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify(payload));
+    }
+  }, []);
+
+  const reconnect = useCallback(() => {
+    reconnectToken.current += 1;
+    wsRef.current?.close();
+    connect();
+  }, [connect]);
+
+  return useMemo<SessionSocketState>(() => ({ connection, state, players, lastEvent, send, reconnect }), [connection, state, players, lastEvent, send, reconnect]);
+};

--- a/apps/pages/src/main.tsx
+++ b/apps/pages/src/main.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+import "./styles.css";
+
+ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/apps/pages/src/pages/BuildPage.tsx
+++ b/apps/pages/src/pages/BuildPage.tsx
@@ -1,0 +1,429 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { apiClient, ApiCampaign, ApiMap, ApiRegion, ApiMarker } from "../api/client";
+import { useAuth } from "../context/AuthContext";
+import MapStage from "../components/MapStage";
+import SessionSidebar from "../components/SessionSidebar";
+import { useSessionSocket } from "../hooks/useSessionSocket";
+
+const defaultRegion = "[[0,0],[100,0],[100,100],[0,100]]";
+
+const BuildPage: React.FC = () => {
+  const { user } = useAuth();
+  const [campaigns, setCampaigns] = useState<ApiCampaign[]>([]);
+  const [maps, setMaps] = useState<ApiMap[]>([]);
+  const [regions, setRegions] = useState<ApiRegion[]>([]);
+  const [markers, setMarkers] = useState<ApiMarker[]>([]);
+  const [selectedCampaignId, setSelectedCampaignId] = useState<string>("");
+  const [selectedMapId, setSelectedMapId] = useState<string>("");
+  const [campaignForm, setCampaignForm] = useState({ name: "", description: "", isPublic: false });
+  const [regionForm, setRegionForm] = useState({ name: "New Region", polygon: defaultRegion, orderIndex: 0 });
+  const [markerForm, setMarkerForm] = useState({ name: "", markerType: "note", x: 100, y: 100 });
+  const [sessionName, setSessionName] = useState("Live Session");
+  const [activeSessionId, setActiveSessionId] = useState<string | null>(null);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+
+  const selectedMap = useMemo(() => maps.find((m) => m.id === selectedMapId) ?? null, [maps, selectedMapId]);
+
+  const sessionSocket = useSessionSocket(activeSessionId, { name: user?.displayName ?? "DM", role: "dm" });
+
+  useEffect(() => {
+    if (!user) return;
+    const load = async () => {
+      try {
+        const data = await apiClient.listCampaigns(false);
+        setCampaigns(data);
+        if (data.length > 0) {
+          setSelectedCampaignId((prev) => prev || data[0].id);
+        }
+      } catch (err) {
+        console.error(err);
+        setStatusMessage((err as Error).message);
+      }
+    };
+    load();
+  }, [user]);
+
+  useEffect(() => {
+    if (!selectedCampaignId) return;
+    const loadMaps = async () => {
+      try {
+        const result = await apiClient.listMaps(selectedCampaignId);
+        setMaps(result);
+        if (result.length > 0) {
+          setSelectedMapId((prev) => prev || result[0].id);
+        }
+      } catch (err) {
+        setStatusMessage((err as Error).message);
+      }
+    };
+    loadMaps();
+  }, [selectedCampaignId]);
+
+  useEffect(() => {
+    if (!selectedMapId) return;
+    const loadRegions = async () => {
+      try {
+        const regionData = await apiClient.listRegions(selectedMapId);
+        setRegions(regionData);
+      } catch (err) {
+        setStatusMessage((err as Error).message);
+      }
+    };
+    const loadMarkers = async () => {
+      try {
+        const markerData = await apiClient.listMarkers(selectedMapId);
+        setMarkers(markerData);
+      } catch (err) {
+        setStatusMessage((err as Error).message);
+      }
+    };
+    loadRegions();
+    loadMarkers();
+  }, [selectedMapId]);
+
+  const handleCreateCampaign = async (event: React.FormEvent) => {
+    event.preventDefault();
+    try {
+      const created = await apiClient.createCampaign(campaignForm);
+      setCampaigns((prev) => [created, ...prev]);
+      setSelectedCampaignId(created.id);
+      setCampaignForm({ name: "", description: "", isPublic: false });
+      setStatusMessage("Campaign created");
+    } catch (err) {
+      setStatusMessage((err as Error).message);
+    }
+  };
+
+  const handleCreateRegion = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!selectedMapId) return;
+    try {
+      const polygon = JSON.parse(regionForm.polygon);
+      const created = await apiClient.createRegion(selectedMapId, {
+        name: regionForm.name,
+        polygon,
+        orderIndex: regionForm.orderIndex
+      });
+      setRegions((prev) => [...prev, created]);
+      setRegionForm({ name: "New Region", polygon: defaultRegion, orderIndex: 0 });
+      setStatusMessage("Region saved");
+    } catch (err) {
+      setStatusMessage((err as Error).message);
+    }
+  };
+
+  const handleCreateMarker = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!selectedMapId) return;
+    try {
+      const created = await apiClient.createMarker(selectedMapId, {
+        name: markerForm.name,
+        markerType: markerForm.markerType,
+        position: { x: markerForm.x, y: markerForm.y }
+      });
+      setMarkers((prev) => [...prev, created]);
+      setMarkerForm({ name: "", markerType: "note", x: 100, y: 100 });
+      setStatusMessage("Marker saved");
+    } catch (err) {
+      setStatusMessage((err as Error).message);
+    }
+  };
+
+  const handleStartSession = async () => {
+    if (!selectedCampaignId || !selectedMapId) return;
+    try {
+      const session = await apiClient.createSession({ campaignId: selectedCampaignId, mapId: selectedMapId, name: sessionName });
+      setActiveSessionId(session.id);
+      setStatusMessage(`Session ${session.name} created`);
+    } catch (err) {
+      setStatusMessage((err as Error).message);
+    }
+  };
+
+  const handleReveal = (regionId: string) => {
+    if (!sessionSocket.send || !activeSessionId) return;
+    sessionSocket.send({ type: "revealRegions", regionIds: [regionId] });
+  };
+
+  const handleHide = (regionId: string) => {
+    if (!sessionSocket.send || !activeSessionId) return;
+    sessionSocket.send({ type: "hideRegions", regionIds: [regionId] });
+  };
+
+  const handleDropMarker = (marker: ApiMarker) => {
+    if (!sessionSocket.send || !activeSessionId) return;
+    sessionSocket.send({ type: "placeMarker", marker });
+  };
+
+  const handleSaveSession = async () => {
+    if (!activeSessionId) return;
+    try {
+      const result = await apiClient.saveSession(activeSessionId);
+      setStatusMessage(`Session snapshot saved: ${result.backupKey}`);
+    } catch (err) {
+      setStatusMessage((err as Error).message);
+    }
+  };
+
+  const handleEndSession = async () => {
+    if (!activeSessionId) return;
+    try {
+      await apiClient.endSession(activeSessionId);
+      setStatusMessage("Session ended");
+    } catch (err) {
+      setStatusMessage((err as Error).message);
+    }
+  };
+
+  const liveMarkers = sessionSocket.state?.markers ?? Object.fromEntries(markers.map((m) => [m.id, m]));
+  const liveRegions = sessionSocket.state?.regions ?? regions;
+  const revealedIds = sessionSocket.state?.revealedRegions ?? [];
+  const liveMap = sessionSocket.state?.map ?? selectedMap;
+
+  return (
+    <div className="flex flex-col gap-6">
+      <section className="rounded-xl border border-slate-200 bg-white/70 p-6 shadow-sm dark:border-slate-700 dark:bg-slate-900/80">
+        <header className="mb-4 flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-semibold text-slate-900 dark:text-slate-100">Dungeon Master Build Mode</h1>
+            <p className="text-sm text-slate-500 dark:text-slate-400">Prepare campaigns, sculpt fog-of-war, and manage live sessions.</p>
+          </div>
+          <div className="text-sm font-medium text-emerald-600 dark:text-emerald-300">{statusMessage}</div>
+        </header>
+        <div className="grid gap-6 md:grid-cols-3">
+          <form onSubmit={handleCreateCampaign} className="space-y-3 rounded-lg border border-slate-200 bg-white/80 p-4 dark:border-slate-700 dark:bg-slate-800/60">
+            <h2 className="text-lg font-semibold text-slate-800 dark:text-slate-100">Create Campaign</h2>
+            <input
+              type="text"
+              required
+              placeholder="Campaign name"
+              value={campaignForm.name}
+              onChange={(e) => setCampaignForm((prev) => ({ ...prev, name: e.target.value }))}
+              className="w-full rounded-md border border-slate-300 bg-white/90 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none dark:border-slate-600 dark:bg-slate-900"
+            />
+            <textarea
+              placeholder="Description"
+              value={campaignForm.description}
+              onChange={(e) => setCampaignForm((prev) => ({ ...prev, description: e.target.value }))}
+              className="h-24 w-full rounded-md border border-slate-300 bg-white/90 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none dark:border-slate-600 dark:bg-slate-900"
+            />
+            <label className="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+              <input
+                type="checkbox"
+                checked={campaignForm.isPublic}
+                onChange={(e) => setCampaignForm((prev) => ({ ...prev, isPublic: e.target.checked }))}
+              />
+              Public listing
+            </label>
+            <button type="submit" className="w-full rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow hover:bg-indigo-500">
+              Save Campaign
+            </button>
+          </form>
+          <div className="space-y-3 rounded-lg border border-slate-200 bg-white/80 p-4 dark:border-slate-700 dark:bg-slate-800/60">
+            <h2 className="text-lg font-semibold text-slate-800 dark:text-slate-100">Campaign Assets</h2>
+            <label className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Select Campaign</label>
+            <select
+              value={selectedCampaignId}
+              onChange={(e) => setSelectedCampaignId(e.target.value)}
+              className="w-full rounded-md border border-slate-300 bg-white/90 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none dark:border-slate-600 dark:bg-slate-900"
+            >
+              {campaigns.map((campaign) => (
+                <option key={campaign.id} value={campaign.id}>
+                  {campaign.name}
+                </option>
+              ))}
+            </select>
+            <label className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Select Map</label>
+            <select
+              value={selectedMapId}
+              onChange={(e) => setSelectedMapId(e.target.value)}
+              className="w-full rounded-md border border-slate-300 bg-white/90 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none dark:border-slate-600 dark:bg-slate-900"
+            >
+              {maps.map((map) => (
+                <option key={map.id} value={map.id}>
+                  {map.name}
+                </option>
+              ))}
+            </select>
+            <p className="text-xs text-slate-500 dark:text-slate-400">
+              Upload map art by calling <span className="font-semibold">Create Map</span> from the API to receive temporary R2 uploads.
+            </p>
+          </div>
+          <form onSubmit={handleCreateRegion} className="space-y-3 rounded-lg border border-slate-200 bg-white/80 p-4 dark:border-slate-700 dark:bg-slate-800/60">
+            <h2 className="text-lg font-semibold text-slate-800 dark:text-slate-100">Add Region</h2>
+            <input
+              type="text"
+              required
+              placeholder="Region name"
+              value={regionForm.name}
+              onChange={(e) => setRegionForm((prev) => ({ ...prev, name: e.target.value }))}
+              className="w-full rounded-md border border-slate-300 bg-white/90 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none dark:border-slate-600 dark:bg-slate-900"
+            />
+            <textarea
+              required
+              value={regionForm.polygon}
+              onChange={(e) => setRegionForm((prev) => ({ ...prev, polygon: e.target.value }))}
+              className="h-24 w-full rounded-md border border-slate-300 bg-white/90 px-3 py-2 text-xs font-mono focus:border-indigo-500 focus:outline-none dark:border-slate-600 dark:bg-slate-900"
+            />
+            <input
+              type="number"
+              value={regionForm.orderIndex}
+              onChange={(e) => setRegionForm((prev) => ({ ...prev, orderIndex: Number(e.target.value) }))}
+              className="w-full rounded-md border border-slate-300 bg-white/90 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none dark:border-slate-600 dark:bg-slate-900"
+            />
+            <button type="submit" className="w-full rounded-md bg-emerald-600 px-3 py-2 text-sm font-semibold text-white shadow hover:bg-emerald-500">
+              Save Region
+            </button>
+          </form>
+        </div>
+      </section>
+
+      <section className="grid gap-6 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
+        <div className="flex flex-col gap-4">
+          <MapStage
+            map={liveMap as any}
+            regions={liveRegions}
+            revealedRegionIds={revealedIds}
+            markers={liveMarkers}
+            onMarkerSelect={() => {}}
+          />
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="rounded-lg border border-slate-200 bg-white/80 p-4 dark:border-slate-700 dark:bg-slate-800/60">
+              <h3 className="mb-2 text-lg font-semibold text-slate-800 dark:text-slate-100">Reveal Control</h3>
+              <ul className="space-y-2 text-sm">
+                {regions.map((region) => {
+                  const revealed = revealedIds.includes(region.id);
+                  return (
+                    <li key={region.id} className="flex items-center justify-between rounded-md border border-slate-200/60 bg-white/70 px-3 py-2 dark:border-slate-700 dark:bg-slate-900/50">
+                      <div>
+                        <div className="font-semibold text-slate-700 dark:text-slate-200">{region.name}</div>
+                        <div className="text-xs text-slate-500 dark:text-slate-400">Order {region.orderIndex}</div>
+                      </div>
+                      <div className="flex gap-2">
+                        <button
+                          type="button"
+                          onClick={() => handleReveal(region.id)}
+                          className="rounded-md bg-emerald-600 px-2 py-1 text-xs font-semibold text-white shadow hover:bg-emerald-500"
+                        >
+                          Reveal
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => handleHide(region.id)}
+                          className="rounded-md bg-slate-600 px-2 py-1 text-xs font-semibold text-white shadow hover:bg-slate-500"
+                          disabled={!revealed}
+                        >
+                          Hide
+                        </button>
+                      </div>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+            <form onSubmit={handleCreateMarker} className="space-y-3 rounded-lg border border-slate-200 bg-white/80 p-4 dark:border-slate-700 dark:bg-slate-800/60">
+              <h3 className="text-lg font-semibold text-slate-800 dark:text-slate-100">Add Marker</h3>
+              <input
+                type="text"
+                required
+                placeholder="Marker label"
+                value={markerForm.name}
+                onChange={(e) => setMarkerForm((prev) => ({ ...prev, name: e.target.value }))}
+                className="w-full rounded-md border border-slate-300 bg-white/90 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none dark:border-slate-600 dark:bg-slate-900"
+              />
+              <select
+                value={markerForm.markerType}
+                onChange={(e) => setMarkerForm((prev) => ({ ...prev, markerType: e.target.value }))}
+                className="w-full rounded-md border border-slate-300 bg-white/90 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none dark:border-slate-600 dark:bg-slate-900"
+              >
+                <option value="note">Note</option>
+                <option value="enemy">Enemy</option>
+                <option value="ally">Ally</option>
+                <option value="trap">Trap</option>
+              </select>
+              <div className="grid grid-cols-2 gap-3">
+                <label className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                  X
+                  <input
+                    type="number"
+                    value={markerForm.x}
+                    onChange={(e) => setMarkerForm((prev) => ({ ...prev, x: Number(e.target.value) }))}
+                    className="mt-1 w-full rounded-md border border-slate-300 bg-white/90 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none dark:border-slate-600 dark:bg-slate-900"
+                  />
+                </label>
+                <label className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                  Y
+                  <input
+                    type="number"
+                    value={markerForm.y}
+                    onChange={(e) => setMarkerForm((prev) => ({ ...prev, y: Number(e.target.value) }))}
+                    className="mt-1 w-full rounded-md border border-slate-300 bg-white/90 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none dark:border-slate-600 dark:bg-slate-900"
+                  />
+                </label>
+              </div>
+              <div className="flex gap-2">
+                <button type="submit" className="flex-1 rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow hover:bg-indigo-500">
+                  Save Marker
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    const marker = markers.find((m) => m.name === markerForm.name);
+                    if (marker) handleDropMarker(marker);
+                  }}
+                  className="rounded-md bg-slate-700 px-3 py-2 text-xs font-semibold text-white shadow hover:bg-slate-600"
+                >
+                  Push Live
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+        <SessionSidebar
+          players={sessionSocket.players}
+          lastEvent={sessionSocket.lastEvent}
+          connection={sessionSocket.connection}
+          onReconnect={sessionSocket.reconnect}
+        />
+      </section>
+
+      <section className="rounded-xl border border-slate-200 bg-white/70 p-6 shadow-sm dark:border-slate-700 dark:bg-slate-900/80">
+        <h2 className="mb-3 text-xl font-semibold text-slate-900 dark:text-slate-100">Live Session Lifecycle</h2>
+        <div className="grid gap-4 md:grid-cols-4">
+          <label className="md:col-span-2">
+            <span className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Session name</span>
+            <input
+              type="text"
+              value={sessionName}
+              onChange={(e) => setSessionName(e.target.value)}
+              className="mt-1 w-full rounded-md border border-slate-300 bg-white/90 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none dark:border-slate-600 dark:bg-slate-900"
+            />
+          </label>
+          <button
+            type="button"
+            onClick={handleStartSession}
+            className="rounded-md bg-emerald-600 px-3 py-2 text-sm font-semibold text-white shadow hover:bg-emerald-500"
+          >
+            Start Session
+          </button>
+          <button
+            type="button"
+            onClick={handleSaveSession}
+            className="rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow hover:bg-indigo-500"
+          >
+            Save Snapshot
+          </button>
+          <button
+            type="button"
+            onClick={handleEndSession}
+            className="rounded-md bg-rose-600 px-3 py-2 text-sm font-semibold text-white shadow hover:bg-rose-500"
+          >
+            End Session
+          </button>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default BuildPage;

--- a/apps/pages/src/pages/PlayPage.tsx
+++ b/apps/pages/src/pages/PlayPage.tsx
@@ -1,0 +1,149 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { apiClient, ApiSession } from "../api/client";
+import MapStage from "../components/MapStage";
+import SessionSidebar from "../components/SessionSidebar";
+import { useSessionSocket } from "../hooks/useSessionSocket";
+
+const PlayPage: React.FC = () => {
+  const [lobby, setLobby] = useState<ApiSession[]>([]);
+  const [selectedSessionId, setSelectedSessionId] = useState<string>("");
+  const [activeSessionId, setActiveSessionId] = useState<string | null>(null);
+  const [displayName, setDisplayName] = useState("Adventurer");
+  const [status, setStatus] = useState<string | null>(null);
+
+  const sessionSocket = useSessionSocket(activeSessionId, { name: displayName, role: "player" });
+
+  useEffect(() => {
+    const loadLobby = async () => {
+      try {
+        const sessions = await apiClient.listLobby();
+        setLobby(sessions);
+        if (sessions.length > 0) {
+          setSelectedSessionId((prev) => prev || sessions[0].id);
+        }
+      } catch (err) {
+        setStatus((err as Error).message);
+      }
+    };
+    loadLobby();
+    const interval = setInterval(loadLobby, 15000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const handleJoin = () => {
+    if (!selectedSessionId) return;
+    setActiveSessionId(selectedSessionId);
+    setStatus(`Joined session ${selectedSessionId}`);
+  };
+
+  const sessionState = sessionSocket.state;
+  const revealedCount = sessionState?.revealedRegions?.length ?? 0;
+  const markerCount = Object.keys(sessionState?.markers ?? {}).length;
+
+  const map = sessionState?.map ?? null;
+  const regions = sessionState?.regions ?? [];
+  const markers = sessionState?.markers ?? {};
+  const revealed = sessionState?.revealedRegions ?? [];
+
+  const lobbyDetails = useMemo(() => lobby.find((s) => s.id === selectedSessionId) ?? null, [lobby, selectedSessionId]);
+
+  return (
+    <div className="flex flex-col gap-6">
+      <section className="rounded-xl border border-slate-200 bg-white/70 p-6 shadow-sm dark:border-slate-700 dark:bg-slate-900/80">
+        <header className="mb-4 flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h1 className="text-2xl font-semibold text-slate-900 dark:text-slate-100">Player Portal</h1>
+            <p className="text-sm text-slate-500 dark:text-slate-400">Join a live tabletop reveal session from your Dungeon Master.</p>
+          </div>
+          <div className="text-sm font-medium text-emerald-600 dark:text-emerald-300">{status}</div>
+        </header>
+        <div className="grid gap-4 md:grid-cols-4">
+          <label className="md:col-span-2">
+            <span className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Display name</span>
+            <input
+              type="text"
+              value={displayName}
+              onChange={(e) => setDisplayName(e.target.value)}
+              className="mt-1 w-full rounded-md border border-slate-300 bg-white/90 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none dark:border-slate-600 dark:bg-slate-900"
+            />
+          </label>
+          <label className="md:col-span-2">
+            <span className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Active lobby session</span>
+            <select
+              value={selectedSessionId}
+              onChange={(e) => setSelectedSessionId(e.target.value)}
+              className="mt-1 w-full rounded-md border border-slate-300 bg-white/90 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none dark:border-slate-600 dark:bg-slate-900"
+            >
+              {lobby.map((session) => (
+                <option key={session.id} value={session.id}>
+                  {session.name}
+                </option>
+              ))}
+            </select>
+          </label>
+          <button
+            type="button"
+            onClick={handleJoin}
+            className="rounded-md bg-emerald-600 px-3 py-2 text-sm font-semibold text-white shadow hover:bg-emerald-500"
+          >
+            Join Session
+          </button>
+          <div className="rounded-lg border border-slate-200 bg-white/60 p-4 text-xs dark:border-slate-700 dark:bg-slate-800/60">
+            <div className="font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Session Stats</div>
+            <dl className="mt-2 space-y-1 text-slate-600 dark:text-slate-300">
+              <div className="flex justify-between">
+                <dt>Revealed regions</dt>
+                <dd className="font-semibold text-slate-900 dark:text-slate-100">{revealedCount}</dd>
+              </div>
+              <div className="flex justify-between">
+                <dt>Markers live</dt>
+                <dd className="font-semibold text-slate-900 dark:text-slate-100">{markerCount}</dd>
+              </div>
+              <div className="flex justify-between">
+                <dt>Connection</dt>
+                <dd className="font-semibold text-slate-900 dark:text-slate-100">{sessionSocket.connection}</dd>
+              </div>
+            </dl>
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-6 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
+        <MapStage map={map} regions={regions} revealedRegionIds={revealed} markers={markers} />
+        <SessionSidebar
+          players={sessionSocket.players}
+          lastEvent={sessionSocket.lastEvent}
+          connection={sessionSocket.connection}
+          onReconnect={sessionSocket.reconnect}
+        />
+      </section>
+
+      <section className="rounded-xl border border-slate-200 bg-white/70 p-6 shadow-sm dark:border-slate-700 dark:bg-slate-900/80">
+        <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">How the reveal works</h2>
+        <div className="mt-3 grid gap-4 md:grid-cols-3">
+          <div className="rounded-lg border border-slate-200 bg-white/70 p-4 text-sm text-slate-600 dark:border-slate-700 dark:bg-slate-800/60 dark:text-slate-300">
+            <h3 className="mb-2 text-base font-semibold text-slate-800 dark:text-slate-100">1. Watch the fog clear</h3>
+            Your DM reveals regions in real time. The mask above uses a destination-out canvas to uncover art seamlessly in your browser.
+          </div>
+          <div className="rounded-lg border border-slate-200 bg-white/70 p-4 text-sm text-slate-600 dark:border-slate-700 dark:bg-slate-800/60 dark:text-slate-300">
+            <h3 className="mb-2 text-base font-semibold text-slate-800 dark:text-slate-100">2. React to markers</h3>
+            Markers appear as the party interacts with the dungeon. Hover or tap to see titles supplied by your storyteller.
+          </div>
+          <div className="rounded-lg border border-slate-200 bg-white/70 p-4 text-sm text-slate-600 dark:border-slate-700 dark:bg-slate-800/60 dark:text-slate-300">
+            <h3 className="mb-2 text-base font-semibold text-slate-800 dark:text-slate-100">3. Stay synced</h3>
+            Durable Objects stream updates so every player sees the same battlefield. If you disconnect, reconnect with one tap.
+          </div>
+        </div>
+        {lobbyDetails && (
+          <div className="mt-4 rounded-lg border border-indigo-200 bg-indigo-50 p-4 text-sm text-indigo-800 dark:border-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-200">
+            <div className="font-semibold">Currently selected: {lobbyDetails.name}</div>
+            <div>Campaign ID: {lobbyDetails.campaignId}</div>
+            <div>Map ID: {lobbyDetails.mapId}</div>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+};
+
+export default PlayPage;

--- a/apps/pages/src/styles.css
+++ b/apps/pages/src/styles.css
@@ -1,0 +1,25 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light dark;
+}
+
+html, body, #root {
+  height: 100%;
+}
+
+body {
+  @apply text-slate-900 dark:text-slate-100 transition-colors duration-300;
+}
+
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+::-webkit-scrollbar-thumb {
+  background-color: rgba(148, 163, 184, 0.5);
+  border-radius: 4px;
+}

--- a/apps/pages/tailwind.config.cjs
+++ b/apps/pages/tailwind.config.cjs
@@ -1,0 +1,15 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ["./index.html", "./src/**/*.{ts,tsx}"],
+  theme: {
+    extend: {
+      colors: {
+        surface: {
+          light: "#f7f5f2",
+          dark: "#1f1f24"
+        }
+      }
+    }
+  },
+  plugins: []
+};

--- a/apps/pages/tsconfig.json
+++ b/apps/pages/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": []
+}

--- a/apps/pages/vite.config.ts
+++ b/apps/pages/vite.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  base: "/",
+  server: {
+    port: 5173,
+    host: "0.0.0.0"
+  },
+  build: {
+    outDir: "dist"
+  }
+});

--- a/cloudflare/api.js
+++ b/cloudflare/api.js
@@ -1,0 +1,758 @@
+const JSON_HEADERS = {
+  "content-type": "application/json; charset=utf-8"
+};
+
+const CORS_HEADERS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "Authorization, Content-Type",
+  "Access-Control-Allow-Methods": "GET,POST,PUT,DELETE,OPTIONS"
+};
+
+export default {
+  async fetch(request, env, ctx) {
+    if (request.method === "OPTIONS") {
+      return new Response(null, { status: 204, headers: { ...CORS_HEADERS } });
+    }
+    const api = new ApiHandler(env, ctx);
+    try {
+      return await api.route(request);
+    } catch (err) {
+      console.error("Unhandled error", err);
+      return jsonResponse({ error: "Internal Server Error" }, 500);
+    }
+  }
+};
+
+class ApiHandler {
+  constructor(env, ctx) {
+    this.env = env;
+    this.ctx = ctx;
+  }
+
+  async route(request) {
+    const url = new URL(request.url);
+    let pathname = url.pathname;
+    if (pathname !== "/" && pathname.endsWith("/")) {
+      pathname = pathname.slice(0, -1);
+    }
+
+    const authUser = await this.getAuthenticatedUser(request.headers.get("authorization"));
+
+    // Auth routes
+    if (request.method === "POST" && pathname === "/api/auth/signup") {
+      const body = await readJsonBody(request);
+      return this.handleSignup(body);
+    }
+
+    if (request.method === "POST" && pathname === "/api/auth/login") {
+      const body = await readJsonBody(request);
+      return this.handleLogin(body);
+    }
+
+    // Campaigns
+    if (request.method === "POST" && pathname === "/api/campaigns") {
+      if (!authUser) return unauthorizedResponse();
+      const body = await readJsonBody(request);
+      return this.createCampaign(authUser, body);
+    }
+
+    if (request.method === "GET" && pathname === "/api/campaigns") {
+      const isPublic = url.searchParams.get("public") === "1";
+      return this.listCampaigns(authUser, isPublic);
+    }
+
+    // Maps
+    if (request.method === "GET" && pathname === "/api/maps") {
+      const campaignId = url.searchParams.get("campaignId");
+      return this.listMaps(campaignId, authUser);
+    }
+
+    if (request.method === "POST" && pathname === "/api/maps") {
+      if (!authUser) return unauthorizedResponse();
+      const body = await readJsonBody(request);
+      return this.createMap(authUser, body);
+    }
+
+    const regionListMatch = pathname.match(/^\/api\/maps\/(.+)\/regions$/);
+    if (regionListMatch) {
+      const mapId = regionListMatch[1];
+      if (request.method === "GET") {
+        return this.listRegions(mapId, authUser);
+      }
+      if (request.method === "POST") {
+        if (!authUser) return unauthorizedResponse();
+        const body = await readJsonBody(request);
+        return this.createRegion(authUser, mapId, body);
+      }
+    }
+
+    const regionItemMatch = pathname.match(/^\/api\/regions\/([^/]+)$/);
+    if (regionItemMatch) {
+      const regionId = regionItemMatch[1];
+      if (!authUser) return unauthorizedResponse();
+      if (request.method === "PUT") {
+        const body = await readJsonBody(request);
+        return this.updateRegion(authUser, regionId, body);
+      }
+      if (request.method === "DELETE") {
+        return this.deleteRegion(authUser, regionId);
+      }
+    }
+
+    const markerListMatch = pathname.match(/^\/api\/maps\/(.+)\/markers$/);
+    if (markerListMatch) {
+      const mapId = markerListMatch[1];
+      if (request.method === "GET") {
+        return this.listMarkers(mapId, authUser);
+      }
+      if (request.method === "POST") {
+        if (!authUser) return unauthorizedResponse();
+        const body = await readJsonBody(request);
+        return this.createMarker(authUser, mapId, body);
+      }
+    }
+
+    const markerItemMatch = pathname.match(/^\/api\/markers\/([^/]+)$/);
+    if (markerItemMatch) {
+      const markerId = markerItemMatch[1];
+      if (!authUser) return unauthorizedResponse();
+      if (request.method === "PUT") {
+        const body = await readJsonBody(request);
+        return this.updateMarker(authUser, markerId, body);
+      }
+      if (request.method === "DELETE") {
+        return this.deleteMarker(authUser, markerId);
+      }
+    }
+
+    // Sessions
+    if (request.method === "POST" && pathname === "/api/sessions") {
+      if (!authUser) return unauthorizedResponse();
+      const body = await readJsonBody(request);
+      return this.createSession(authUser, body);
+    }
+
+    const sessionSaveMatch = pathname.match(/^\/api\/sessions\/([^/]+)\/save$/);
+    if (sessionSaveMatch && request.method === "POST") {
+      if (!authUser) return unauthorizedResponse();
+      return this.saveSession(authUser, sessionSaveMatch[1]);
+    }
+
+    const sessionEndMatch = pathname.match(/^\/api\/sessions\/([^/]+)\/end$/);
+    if (sessionEndMatch && request.method === "POST") {
+      if (!authUser) return unauthorizedResponse();
+      return this.endSession(authUser, sessionEndMatch[1]);
+    }
+
+    const sessionRestoreMatch = pathname.match(/^\/api\/sessions\/([^/]+)\/restore$/);
+    if (sessionRestoreMatch && request.method === "POST") {
+      if (!authUser) return unauthorizedResponse();
+      const body = await readJsonBody(request);
+      return this.restoreSession(authUser, sessionRestoreMatch[1], body);
+    }
+
+    const sessionSocketMatch = pathname.match(/^\/api\/sessions\/([^/]+)\/socket$/);
+    if (sessionSocketMatch && request.headers.get("upgrade") === "websocket") {
+      return this.sessionSocket(sessionSocketMatch[1], request);
+    }
+
+    if (request.method === "GET" && pathname === "/api/lobby") {
+      return this.listLobby();
+    }
+
+    // Assets
+    if (request.method === "POST" && pathname === "/api/assets/marker") {
+      if (!authUser) return unauthorizedResponse();
+      const body = await readJsonBody(request);
+      return this.createMarkerUpload(authUser, body);
+    }
+
+    const assetGetMatch = pathname.match(/^\/api\/assets\/marker\/(.+)$/);
+    if (assetGetMatch && request.method === "GET") {
+      const assetKey = decodeURIComponent(assetGetMatch[1]);
+      return this.getMarkerAsset(assetKey);
+    }
+
+    return jsonResponse({ error: "Not Found" }, 404);
+  }
+
+  async handleSignup(body) {
+    const { email, password, displayName } = body ?? {};
+    if (!email || !password || password.length < 8 || !displayName) {
+      return jsonResponse({ error: "Missing or invalid fields" }, 400);
+    }
+
+    const existing = await this.env.MAPS_DB.prepare("SELECT id FROM users WHERE email = ?").bind(email.toLowerCase()).first();
+    if (existing) {
+      return jsonResponse({ error: "Email already registered" }, 409);
+    }
+
+    const saltBytes = crypto.getRandomValues(new Uint8Array(16));
+    const salt = toBase64Url(saltBytes);
+    const hash = await hashPassword(password, salt);
+    const userId = crypto.randomUUID();
+
+    await this.env.MAPS_DB.prepare(
+      "INSERT INTO users (id, email, password_hash, password_salt, display_name) VALUES (?,?,?,?,?)"
+    ).bind(userId, email.toLowerCase(), hash, salt, displayName).run();
+
+    const token = await createJWT({ sub: userId, email: email.toLowerCase(), name: displayName }, this.env.SESSION_SECRET);
+    return jsonResponse({ user: { id: userId, email: email.toLowerCase(), displayName }, token }, 201);
+  }
+
+  async handleLogin(body) {
+    const { email, password } = body ?? {};
+    if (!email || !password) {
+      return jsonResponse({ error: "Missing credentials" }, 400);
+    }
+
+    const user = await this.env.MAPS_DB.prepare(
+      "SELECT id, email, display_name AS displayName, password_hash AS passwordHash, password_salt AS passwordSalt FROM users WHERE email = ?"
+    ).bind(email.toLowerCase()).first();
+    if (!user) {
+      return jsonResponse({ error: "Invalid credentials" }, 401);
+    }
+
+    const hash = await hashPassword(password, user.passwordSalt);
+    if (hash !== user.passwordHash) {
+      return jsonResponse({ error: "Invalid credentials" }, 401);
+    }
+
+    const token = await createJWT({ sub: user.id, email: user.email, name: user.displayName }, this.env.SESSION_SECRET);
+    return jsonResponse({ user: { id: user.id, email: user.email, displayName: user.displayName }, token });
+  }
+
+  async listCampaigns(authUser, isPublic) {
+    if (isPublic) {
+      const campaigns = await this.env.MAPS_DB.prepare(
+        "SELECT c.id, c.name, c.description, c.is_public AS isPublic, u.display_name AS ownerName FROM campaigns c JOIN users u ON c.owner_id = u.id WHERE c.is_public = 1 ORDER BY c.created_at DESC"
+      ).all();
+      return jsonResponse({ campaigns: campaigns.results });
+    }
+
+    if (!authUser) return unauthorizedResponse();
+    const campaigns = await this.env.MAPS_DB.prepare(
+      "SELECT id, name, description, is_public AS isPublic FROM campaigns WHERE owner_id = ? ORDER BY created_at DESC"
+    ).bind(authUser.id).all();
+    return jsonResponse({ campaigns: campaigns.results });
+  }
+
+  async createCampaign(authUser, body) {
+    const { name, description, isPublic } = body ?? {};
+    if (!name) return jsonResponse({ error: "Name required" }, 400);
+    const id = crypto.randomUUID();
+    await this.env.MAPS_DB.prepare(
+      "INSERT INTO campaigns (id, owner_id, name, description, is_public) VALUES (?,?,?,?,?)"
+    ).bind(id, authUser.id, name, description ?? null, isPublic ? 1 : 0).run();
+    return jsonResponse({ campaign: { id, name, description, isPublic: !!isPublic } }, 201);
+  }
+
+  async listMaps(campaignId, authUser) {
+    let query = "SELECT id, campaign_id AS campaignId, name, description, display_key AS displayKey, width, height FROM maps";
+    const params = [];
+    if (campaignId) {
+      query += " WHERE campaign_id = ?";
+      params.push(campaignId);
+    }
+    query += " ORDER BY created_at DESC";
+
+    const maps = await this.env.MAPS_DB.prepare(query).bind(...params).all();
+    return jsonResponse({ maps: maps.results });
+  }
+
+  async createMap(authUser, body) {
+    const { campaignId, name, description, fileExtension = "png", width, height } = body ?? {};
+    if (!campaignId || !name) {
+      return jsonResponse({ error: "Missing required fields" }, 400);
+    }
+
+    const campaign = await this.env.MAPS_DB.prepare(
+      "SELECT id FROM campaigns WHERE id = ? AND owner_id = ?"
+    ).bind(campaignId, authUser.id).first();
+    if (!campaign) {
+      return jsonResponse({ error: "Campaign not found" }, 404);
+    }
+
+    const mapId = crypto.randomUUID();
+    const originalKey = `maps/${campaignId}/${mapId}/original.${fileExtension}`;
+    const displayKey = `maps/${campaignId}/${mapId}/display.${fileExtension}`;
+
+    await this.env.MAPS_DB.prepare(
+      "INSERT INTO maps (id, campaign_id, name, description, original_key, display_key, width, height) VALUES (?,?,?,?,?,?,?,?)"
+    ).bind(mapId, campaignId, name, description ?? null, originalKey, displayKey, width ?? null, height ?? null).run();
+
+    const originalUpload = await this.createPresignedPost(originalKey, body?.contentType ?? "image/png");
+    const displayUpload = await this.createPresignedPost(displayKey, body?.contentType ?? "image/png");
+
+    return jsonResponse({
+      map: {
+        id: mapId,
+        campaignId,
+        name,
+        description,
+        originalKey,
+        displayKey,
+        width: width ?? null,
+        height: height ?? null
+      },
+      uploads: {
+        original: originalUpload,
+        display: displayUpload
+      }
+    }, 201);
+  }
+
+  async listRegions(mapId, authUser) {
+    const regions = await this.env.MAPS_DB.prepare(
+      "SELECT id, map_id AS mapId, name, polygon_json AS polygonJson, order_index AS orderIndex FROM regions WHERE map_id = ? ORDER BY order_index ASC"
+    ).bind(mapId).all();
+    return jsonResponse({ regions: regions.results });
+  }
+
+  async createRegion(authUser, mapId, body) {
+    const { name, polygon, orderIndex = 0 } = body ?? {};
+    if (!name || !Array.isArray(polygon)) {
+      return jsonResponse({ error: "Invalid region data" }, 400);
+    }
+    const map = await this.getMapOwnedByUser(mapId, authUser.id);
+    if (!map) return jsonResponse({ error: "Map not found" }, 404);
+
+    const id = crypto.randomUUID();
+    await this.env.MAPS_DB.prepare(
+      "INSERT INTO regions (id, map_id, name, polygon_json, order_index) VALUES (?,?,?,?,?)"
+    ).bind(id, mapId, name, JSON.stringify(polygon), orderIndex).run();
+
+    return jsonResponse({ region: { id, mapId, name, polygon, orderIndex } }, 201);
+  }
+
+  async updateRegion(authUser, regionId, body) {
+    const region = await this.env.MAPS_DB.prepare(
+      "SELECT r.id, r.map_id AS mapId, m.campaign_id AS campaignId FROM regions r JOIN maps m ON r.map_id = m.id WHERE r.id = ?"
+    ).bind(regionId).first();
+    if (!region) return jsonResponse({ error: "Region not found" }, 404);
+
+    const campaign = await this.env.MAPS_DB.prepare(
+      "SELECT id FROM campaigns WHERE id = ? AND owner_id = ?"
+    ).bind(region.campaignId, authUser.id).first();
+    if (!campaign) return unauthorizedResponse();
+
+    const fields = [];
+    const values = [];
+    if (body?.name) {
+      fields.push("name = ?");
+      values.push(body.name);
+    }
+    if (body?.polygon) {
+      fields.push("polygon_json = ?");
+      values.push(JSON.stringify(body.polygon));
+    }
+    if (typeof body?.orderIndex === "number") {
+      fields.push("order_index = ?");
+      values.push(body.orderIndex);
+    }
+    if (!fields.length) {
+      return jsonResponse({ error: "No updates provided" }, 400);
+    }
+
+    await this.env.MAPS_DB.prepare(
+      `UPDATE regions SET ${fields.join(", ")} WHERE id = ?`
+    ).bind(...values, regionId).run();
+
+    return jsonResponse({ success: true });
+  }
+
+  async deleteRegion(authUser, regionId) {
+    const region = await this.env.MAPS_DB.prepare(
+      "SELECT r.id, m.campaign_id AS campaignId FROM regions r JOIN maps m ON r.map_id = m.id WHERE r.id = ?"
+    ).bind(regionId).first();
+    if (!region) return jsonResponse({ error: "Region not found" }, 404);
+    const campaign = await this.env.MAPS_DB.prepare(
+      "SELECT id FROM campaigns WHERE id = ? AND owner_id = ?"
+    ).bind(region.campaignId, authUser.id).first();
+    if (!campaign) return unauthorizedResponse();
+
+    await this.env.MAPS_DB.prepare("DELETE FROM regions WHERE id = ?").bind(regionId).run();
+    return jsonResponse({ success: true });
+  }
+
+  async listMarkers(mapId) {
+    const markers = await this.env.MAPS_DB.prepare(
+      "SELECT id, map_id AS mapId, name, marker_type AS markerType, position_json AS positionJson, data_json AS dataJson FROM markers WHERE map_id = ? ORDER BY created_at ASC"
+    ).bind(mapId).all();
+    return jsonResponse({ markers: markers.results });
+  }
+
+  async createMarker(authUser, mapId, body) {
+    const { name, markerType, position, data } = body ?? {};
+    if (!name || !markerType || !position) {
+      return jsonResponse({ error: "Invalid marker data" }, 400);
+    }
+    const map = await this.getMapOwnedByUser(mapId, authUser.id);
+    if (!map) return jsonResponse({ error: "Map not found" }, 404);
+
+    const id = crypto.randomUUID();
+    await this.env.MAPS_DB.prepare(
+      "INSERT INTO markers (id, map_id, name, marker_type, position_json, data_json) VALUES (?,?,?,?,?,?)"
+    ).bind(id, mapId, name, markerType, JSON.stringify(position), data ? JSON.stringify(data) : null).run();
+
+    return jsonResponse({ marker: { id, mapId, name, markerType, position, data } }, 201);
+  }
+
+  async updateMarker(authUser, markerId, body) {
+    const marker = await this.env.MAPS_DB.prepare(
+      "SELECT mk.id, mk.map_id AS mapId, m.campaign_id AS campaignId FROM markers mk JOIN maps m ON mk.map_id = m.id WHERE mk.id = ?"
+    ).bind(markerId).first();
+    if (!marker) return jsonResponse({ error: "Marker not found" }, 404);
+    const campaign = await this.env.MAPS_DB.prepare(
+      "SELECT id FROM campaigns WHERE id = ? AND owner_id = ?"
+    ).bind(marker.campaignId, authUser.id).first();
+    if (!campaign) return unauthorizedResponse();
+
+    const fields = [];
+    const values = [];
+    if (body?.name) {
+      fields.push("name = ?");
+      values.push(body.name);
+    }
+    if (body?.markerType) {
+      fields.push("marker_type = ?");
+      values.push(body.markerType);
+    }
+    if (body?.position) {
+      fields.push("position_json = ?");
+      values.push(JSON.stringify(body.position));
+    }
+    if (body?.data) {
+      fields.push("data_json = ?");
+      values.push(JSON.stringify(body.data));
+    }
+    if (!fields.length) {
+      return jsonResponse({ error: "No updates provided" }, 400);
+    }
+    await this.env.MAPS_DB.prepare(
+      `UPDATE markers SET ${fields.join(", ")} WHERE id = ?`
+    ).bind(...values, markerId).run();
+    return jsonResponse({ success: true });
+  }
+
+  async deleteMarker(authUser, markerId) {
+    const marker = await this.env.MAPS_DB.prepare(
+      "SELECT mk.id, m.campaign_id AS campaignId FROM markers mk JOIN maps m ON mk.map_id = m.id WHERE mk.id = ?"
+    ).bind(markerId).first();
+    if (!marker) return jsonResponse({ error: "Marker not found" }, 404);
+    const campaign = await this.env.MAPS_DB.prepare(
+      "SELECT id FROM campaigns WHERE id = ? AND owner_id = ?"
+    ).bind(marker.campaignId, authUser.id).first();
+    if (!campaign) return unauthorizedResponse();
+
+    await this.env.MAPS_DB.prepare("DELETE FROM markers WHERE id = ?").bind(markerId).run();
+    return jsonResponse({ success: true });
+  }
+
+  async createSession(authUser, body) {
+    const { campaignId, name, mapId } = body ?? {};
+    if (!campaignId || !name || !mapId) {
+      return jsonResponse({ error: "Missing required fields" }, 400);
+    }
+
+    const campaign = await this.env.MAPS_DB.prepare(
+      "SELECT id FROM campaigns WHERE id = ? AND owner_id = ?"
+    ).bind(campaignId, authUser.id).first();
+    if (!campaign) {
+      return jsonResponse({ error: "Campaign not found" }, 404);
+    }
+
+    const map = await this.env.MAPS_DB.prepare(
+      "SELECT id, display_key AS displayKey, width, height FROM maps WHERE id = ? AND campaign_id = ?"
+    ).bind(mapId, campaignId).first();
+    if (!map) return jsonResponse({ error: "Map not found" }, 404);
+
+    const sessionId = crypto.randomUUID();
+    await this.env.MAPS_DB.prepare(
+      "INSERT INTO sessions (id, campaign_id, map_id, name, status) VALUES (?,?,?,?,?)"
+    ).bind(sessionId, campaignId, mapId, name, "active").run();
+
+    const regions = await this.env.MAPS_DB.prepare(
+      "SELECT id, polygon_json AS polygonJson, name, order_index AS orderIndex FROM regions WHERE map_id = ? ORDER BY order_index ASC"
+    ).bind(mapId).all();
+    const markers = await this.env.MAPS_DB.prepare(
+      "SELECT id, name, marker_type AS markerType, position_json AS positionJson, data_json AS dataJson FROM markers WHERE map_id = ?"
+    ).bind(mapId).all();
+
+    const stub = this.env.SESSION_HUB.get(this.env.SESSION_HUB.idFromName(sessionId));
+    await stub.fetch("https://session/init", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        sessionId,
+        campaignId,
+        mapId,
+        map,
+        regions: regions.results.map((r) => ({
+          id: r.id,
+          name: r.name,
+          polygon: JSON.parse(r.polygonJson),
+          orderIndex: r.orderIndex
+        })),
+        markers: markers.results.map((m) => ({
+          id: m.id,
+          name: m.name,
+          markerType: m.markerType,
+          position: JSON.parse(m.positionJson),
+          data: m.dataJson ? JSON.parse(m.dataJson) : null
+        }))
+      })
+    });
+
+    return jsonResponse({ session: { id: sessionId, campaignId, mapId, name, status: "active" } }, 201);
+  }
+
+  async saveSession(authUser, sessionId) {
+    const session = await this.getSessionForUser(sessionId, authUser.id);
+    if (!session) return jsonResponse({ error: "Session not found" }, 404);
+
+    const stub = this.env.SESSION_HUB.get(this.env.SESSION_HUB.idFromName(sessionId));
+    const res = await stub.fetch("https://session/state");
+    if (!res.ok) {
+      return jsonResponse({ error: "Unable to snapshot session" }, 500);
+    }
+    const state = await res.json();
+
+    const key = buildBackupKey(session.campaign_id ?? session.campaignId);
+    await this.env.MAPS_BUCKET.put(key, JSON.stringify(state), {
+      httpMetadata: { contentType: "application/json" }
+    });
+
+    const backupId = crypto.randomUUID();
+    await this.env.MAPS_DB.prepare(
+      "INSERT INTO session_backups (id, session_id, backup_key) VALUES (?,?,?)"
+    ).bind(backupId, sessionId, key).run();
+
+    return jsonResponse({ backupKey: key, state });
+  }
+
+  async endSession(authUser, sessionId) {
+    const session = await this.getSessionForUser(sessionId, authUser.id);
+    if (!session) return jsonResponse({ error: "Session not found" }, 404);
+
+    await this.env.MAPS_DB.prepare(
+      "UPDATE sessions SET status = 'ended', updated_at = datetime('now') WHERE id = ?"
+    ).bind(sessionId).run();
+
+    const stub = this.env.SESSION_HUB.get(this.env.SESSION_HUB.idFromName(sessionId));
+    await stub.fetch("https://session/end", { method: "POST" });
+
+    return jsonResponse({ success: true });
+  }
+
+  async restoreSession(authUser, sessionId, body) {
+    const { backupKey, clone } = body ?? {};
+    if (!backupKey) return jsonResponse({ error: "backupKey required" }, 400);
+
+    const session = await this.getSessionForUser(sessionId, authUser.id);
+    if (!session) return jsonResponse({ error: "Session not found" }, 404);
+
+    const object = await this.env.MAPS_BUCKET.get(backupKey);
+    if (!object) return jsonResponse({ error: "Backup not found" }, 404);
+    const stateText = await object.text();
+    const state = JSON.parse(stateText || "{}");
+
+    if (clone) {
+      const newSessionId = crypto.randomUUID();
+      await this.env.MAPS_DB.prepare(
+        "INSERT INTO sessions (id, campaign_id, map_id, name, status) VALUES (?,?,?,?,?)"
+      ).bind(newSessionId, session.campaign_id, session.map_id, `${session.name} (Clone)`, "active").run();
+      const stub = this.env.SESSION_HUB.get(this.env.SESSION_HUB.idFromName(newSessionId));
+      await stub.fetch("https://session/restore", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(state)
+      });
+      return jsonResponse({ session: { id: newSessionId, campaignId: session.campaign_id, mapId: session.map_id, name: `${session.name} (Clone)`, status: "active" } }, 201);
+    }
+
+    const stub = this.env.SESSION_HUB.get(this.env.SESSION_HUB.idFromName(sessionId));
+    await stub.fetch("https://session/restore", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(state)
+    });
+
+    return jsonResponse({ success: true });
+  }
+
+  async sessionSocket(sessionId, request) {
+    const stub = this.env.SESSION_HUB.get(this.env.SESSION_HUB.idFromName(sessionId));
+    return stub.fetch(request);
+  }
+
+  async listLobby() {
+    const results = await this.env.MAPS_DB.prepare(
+      "SELECT s.id, s.name, s.status, s.campaign_id AS campaignId, s.map_id AS mapId, m.display_key AS displayKey FROM sessions s JOIN maps m ON s.map_id = m.id WHERE s.status = 'active' ORDER BY s.created_at DESC"
+    ).all();
+    return jsonResponse({ sessions: results.results });
+  }
+
+  async createMarkerUpload(authUser, body) {
+    const { extension = "png", contentType = "image/png" } = body ?? {};
+    const key = `assets/${authUser.id}/${crypto.randomUUID()}.${extension}`;
+    const upload = await this.createPresignedPost(key, contentType);
+    return jsonResponse({ key, upload });
+  }
+
+  async getMarkerAsset(assetKey) {
+    try {
+      const signed = await this.env.MAPS_BUCKET.createSignedUrl({
+        key: assetKey,
+        expiration: 60
+      });
+      return jsonResponse({ url: signed.toString() });
+    } catch (err) {
+      console.error("Signed URL error", err);
+      return jsonResponse({ error: "Unable to sign asset" }, 500);
+    }
+  }
+
+  async getAuthenticatedUser(authHeader) {
+    if (!authHeader) return null;
+    const parts = authHeader.split(" ");
+    if (parts.length !== 2 || parts[0] !== "Bearer") return null;
+    try {
+      const payload = await verifyJWT(parts[1], this.env.SESSION_SECRET);
+      if (!payload) return null;
+      const user = await this.env.MAPS_DB.prepare(
+        "SELECT id, email, display_name AS displayName FROM users WHERE id = ?"
+      ).bind(payload.sub).first();
+      return user ?? null;
+    } catch (err) {
+      console.error("Auth parse error", err);
+      return null;
+    }
+  }
+
+  async getMapOwnedByUser(mapId, userId) {
+    return this.env.MAPS_DB.prepare(
+      "SELECT m.id FROM maps m JOIN campaigns c ON m.campaign_id = c.id WHERE m.id = ? AND c.owner_id = ?"
+    ).bind(mapId, userId).first();
+  }
+
+  async getSessionForUser(sessionId, userId) {
+    return this.env.MAPS_DB.prepare(
+      "SELECT s.id, s.campaign_id, s.map_id, s.name FROM sessions s JOIN campaigns c ON s.campaign_id = c.id WHERE s.id = ? AND c.owner_id = ?"
+    ).bind(sessionId, userId).first();
+  }
+
+  async createPresignedPost(key, contentType) {
+    const presigned = await this.env.MAPS_BUCKET.createPresignedPost({
+      key,
+      expiration: 60 * 10,
+      fields: {
+        "Content-Type": contentType
+      }
+    });
+    return {
+      url: presigned.url,
+      fields: presigned.fields
+    };
+  }
+}
+
+function jsonResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      ...JSON_HEADERS,
+      ...CORS_HEADERS
+    }
+  });
+}
+
+function unauthorizedResponse() {
+  return jsonResponse({ error: "Unauthorized" }, 401);
+}
+
+async function readJsonBody(request) {
+  const text = await request.text();
+  if (!text) return {};
+  try {
+    return JSON.parse(text);
+  } catch (err) {
+    throw new Error("Invalid JSON body");
+  }
+}
+
+async function hashPassword(password, salt) {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(`${salt}:${password}`);
+  const digest = await crypto.subtle.digest("SHA-256", data);
+  return toBase64Url(new Uint8Array(digest));
+}
+
+async function createJWT(payload, secret) {
+  const header = { alg: "HS256", typ: "JWT" };
+  const exp = Math.floor(Date.now() / 1000) + 60 * 60 * 24 * 7; // 7 days
+  const fullPayload = { ...payload, exp };
+  const encoder = new TextEncoder();
+  const base = `${toBase64Url(encoder.encode(JSON.stringify(header)))}.${toBase64Url(encoder.encode(JSON.stringify(fullPayload)))}`;
+  const key = await getHmacKey(secret);
+  const signature = await crypto.subtle.sign("HMAC", key, encoder.encode(base));
+  return `${base}.${toBase64Url(new Uint8Array(signature))}`;
+}
+
+async function verifyJWT(token, secret) {
+  const parts = token.split(".");
+  if (parts.length !== 3) return null;
+  const encoder = new TextEncoder();
+  const base = `${parts[0]}.${parts[1]}`;
+  const key = await getHmacKey(secret);
+  const signature = fromBase64Url(parts[2]);
+  const valid = await crypto.subtle.verify("HMAC", key, signature, encoder.encode(base));
+  if (!valid) return null;
+  const payloadJson = JSON.parse(new TextDecoder().decode(fromBase64Url(parts[1])));
+  if (payloadJson.exp && payloadJson.exp < Math.floor(Date.now() / 1000)) {
+    return null;
+  }
+  return payloadJson;
+}
+
+async function getHmacKey(secret) {
+  const encoder = new TextEncoder();
+  return crypto.subtle.importKey("raw", encoder.encode(secret), {
+    name: "HMAC",
+    hash: "SHA-256"
+  }, false, ["sign", "verify"]);
+}
+
+function toBase64Url(uint8) {
+  if (uint8 instanceof Uint8Array) {
+    let str = "";
+    const chunkSize = 0x8000;
+    for (let i = 0; i < uint8.length; i += chunkSize) {
+      str += String.fromCharCode.apply(null, uint8.slice(i, i + chunkSize));
+    }
+    return btoa(str).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+  }
+  return btoa(uint8).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function fromBase64Url(str) {
+  const pad = str.length % 4 === 0 ? "" : "=".repeat(4 - (str.length % 4));
+  const normalized = str.replace(/-/g, "+").replace(/_/g, "/") + pad;
+  const binary = atob(normalized);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+function buildBackupKey(campaignId) {
+  const now = new Date();
+  const yyyy = now.getUTCFullYear();
+  const mm = String(now.getUTCMonth() + 1).padStart(2, "0");
+  const dd = String(now.getUTCDate()).padStart(2, "0");
+  const hh = String(now.getUTCHours()).padStart(2, "0");
+  const min = String(now.getUTCMinutes()).padStart(2, "0");
+  const ss = String(now.getUTCSeconds()).padStart(2, "0");
+  return `backups/${campaignId}/${yyyy}/${mm}/${dd}/${hh}${min}${ss}.json`;
+}

--- a/cloudflare/session-do.js
+++ b/cloudflare/session-do.js
@@ -1,0 +1,286 @@
+export class SessionHub {
+  constructor(state, env) {
+    this.state = state;
+    this.env = env;
+    this.clients = new Map();
+    this.loaded = false;
+    this.data = null;
+  }
+
+  async fetch(request) {
+    const url = new URL(request.url);
+    if (request.headers.get("upgrade") === "websocket") {
+      const pair = new WebSocketPair();
+      const client = pair[0];
+      const server = pair[1];
+      await this.ensureState();
+      this.handleSocket(server, url);
+      return new Response(null, { status: 101, webSocket: client });
+    }
+
+    if (url.pathname === "/init" && request.method === "POST") {
+      const body = await request.json();
+      await this.initializeState(body);
+      return new Response(null, { status: 204 });
+    }
+
+    if (url.pathname === "/state") {
+      await this.ensureState();
+      return jsonResponse(this.serializeState());
+    }
+
+    if (url.pathname === "/restore" && request.method === "POST") {
+      const body = await request.json();
+      await this.restoreState(body);
+      return new Response(null, { status: 204 });
+    }
+
+    if (url.pathname === "/end" && request.method === "POST") {
+      await this.ensureState();
+      this.data.status = "ended";
+      await this.saveState();
+      this.broadcast({ type: "state", state: this.serializeState() });
+      for (const [id, info] of this.clients.entries()) {
+        info.socket.close(1000, "Session ended");
+      }
+      this.clients.clear();
+      return new Response(null, { status: 204 });
+    }
+
+    return jsonResponse({ ok: true });
+  }
+
+  async ensureState() {
+    if (this.loaded) return;
+    this.data = await this.state.storage.get("state");
+    if (!this.data) {
+      this.data = {
+        sessionId: null,
+        campaignId: null,
+        mapId: null,
+        map: null,
+        regions: [],
+        revealedRegions: [],
+        markers: {},
+        status: "pending",
+        players: {}
+      };
+    }
+    this.loaded = true;
+  }
+
+  async initializeState(body) {
+    await this.ensureState();
+    this.data = {
+      sessionId: body.sessionId,
+      campaignId: body.campaignId,
+      mapId: body.mapId,
+      map: body.map ?? null,
+      regions: body.regions ?? [],
+      revealedRegions: [],
+      markers: Object.fromEntries((body.markers ?? []).map((m) => [m.id, m])),
+      status: "active",
+      players: {}
+    };
+    await this.saveState();
+    this.broadcast({ type: "state", state: this.serializeState() });
+  }
+
+  async restoreState(body) {
+    await this.ensureState();
+    const next = {
+      sessionId: body.sessionId ?? this.data.sessionId,
+      campaignId: body.campaignId ?? this.data.campaignId,
+      mapId: body.mapId ?? this.data.mapId,
+      map: body.map ?? this.data.map,
+      regions: body.regions ?? this.data.regions,
+      revealedRegions: body.revealedRegions ?? body.revealed ?? [],
+      markers: body.markers ?? {},
+      status: body.status ?? "active",
+      players: {}
+    };
+    if (!next.revealedRegions || !Array.isArray(next.revealedRegions)) {
+      next.revealedRegions = [];
+    }
+    if (!next.markers || typeof next.markers !== "object") {
+      next.markers = {};
+    }
+    this.data = next;
+    await this.saveState();
+    this.broadcast({ type: "state", state: this.serializeState() });
+  }
+
+  serializeState() {
+    return {
+      sessionId: this.data.sessionId,
+      campaignId: this.data.campaignId,
+      mapId: this.data.mapId,
+      map: this.data.map,
+      regions: this.data.regions,
+      revealedRegions: this.data.revealedRegions,
+      markers: this.data.markers,
+      status: this.data.status
+    };
+  }
+
+  async saveState() {
+    const { players, ...rest } = this.data;
+    await this.state.storage.put("state", rest);
+  }
+
+  handleSocket(socket, url) {
+    const clientId = crypto.randomUUID();
+    const info = { socket, id: clientId, role: "player", name: "" };
+    this.clients.set(clientId, info);
+
+    socket.accept();
+    socket.addEventListener("message", (event) => {
+      this.onMessage(info, event.data);
+    });
+
+    socket.addEventListener("close", () => {
+      this.clients.delete(clientId);
+      delete this.data.players[clientId];
+      this.broadcastPlayers();
+    });
+
+    socket.send(JSON.stringify({ type: "state", state: this.serializeState() }));
+    this.broadcastPlayers();
+  }
+
+  async onMessage(clientInfo, raw) {
+    let message;
+    try {
+      message = JSON.parse(raw);
+    } catch (err) {
+      console.warn("Invalid message", raw);
+      return;
+    }
+    switch (message.type) {
+      case "join":
+        clientInfo.role = message.role ?? "player";
+        clientInfo.name = message.name ?? "Player";
+        this.data.players[clientInfo.id] = {
+          id: clientInfo.id,
+          name: clientInfo.name,
+          role: clientInfo.role,
+          connectedAt: Date.now()
+        };
+        this.send(clientInfo.socket, { type: "state", state: this.serializeState() });
+        this.broadcastPlayers();
+        break;
+      case "revealRegions":
+        await this.ensureState();
+        this.applyReveal(Array.isArray(message.regionIds) ? message.regionIds : []);
+        break;
+      case "hideRegions":
+        await this.ensureState();
+        this.applyHide(Array.isArray(message.regionIds) ? message.regionIds : []);
+        break;
+      case "placeMarker":
+        await this.ensureState();
+        this.placeMarker(message.marker ?? {});
+        break;
+      case "updateMarker":
+        await this.ensureState();
+        this.updateMarker(message.markerId, message.changes ?? {});
+        break;
+      case "removeMarker":
+        await this.ensureState();
+        this.removeMarker(message.markerId);
+        break;
+      case "ping":
+        this.send(clientInfo.socket, { type: "pong", ts: Date.now() });
+        break;
+      default:
+        console.warn("Unknown message type", message.type);
+    }
+  }
+
+  async applyReveal(regionIds) {
+    let changed = false;
+    for (const id of regionIds) {
+      if (!this.data.revealedRegions.includes(id)) {
+        this.data.revealedRegions.push(id);
+        changed = true;
+      }
+    }
+    if (changed) {
+      await this.saveState();
+      this.broadcast({ type: "regionsRevealed", regionIds });
+    }
+  }
+
+  async applyHide(regionIds) {
+    const before = this.data.revealedRegions.length;
+    this.data.revealedRegions = this.data.revealedRegions.filter((id) => !regionIds.includes(id));
+    if (this.data.revealedRegions.length !== before) {
+      await this.saveState();
+      this.broadcast({ type: "regionsHidden", regionIds });
+    }
+  }
+
+  async placeMarker(marker) {
+    if (!marker) return;
+    if (!marker.id) {
+      marker.id = crypto.randomUUID();
+    }
+    marker.createdAt = marker.createdAt ?? Date.now();
+    this.data.markers[marker.id] = marker;
+    await this.saveState();
+    this.broadcast({ type: "markerAdded", marker });
+  }
+
+  async updateMarker(markerId, changes) {
+    if (!markerId || !this.data.markers[markerId]) return;
+    const marker = this.data.markers[markerId];
+    Object.assign(marker, changes ?? {});
+    marker.updatedAt = Date.now();
+    await this.saveState();
+    this.broadcast({ type: "markerUpdated", marker });
+  }
+
+  async removeMarker(markerId) {
+    if (!markerId || !this.data.markers[markerId]) return;
+    delete this.data.markers[markerId];
+    await this.saveState();
+    this.broadcast({ type: "markerRemoved", markerId });
+  }
+
+  send(socket, payload) {
+    try {
+      socket.send(JSON.stringify(payload));
+    } catch (err) {
+      console.warn("Failed to send", err);
+    }
+  }
+
+  broadcast(payload) {
+    const message = JSON.stringify(payload);
+    for (const { socket } of this.clients.values()) {
+      try {
+        socket.send(message);
+      } catch (err) {
+        console.warn("Broadcast error", err);
+      }
+    }
+  }
+
+  broadcastPlayers() {
+    const players = Object.values(this.data.players ?? {});
+    this.broadcast({ type: "players", players });
+  }
+}
+
+export default {
+  fetch(request) {
+    return new Response("Session Durable Object", { status: 200 });
+  }
+};
+
+function jsonResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json; charset=utf-8" }
+  });
+}

--- a/readme-api.txt
+++ b/readme-api.txt
@@ -1,0 +1,58 @@
+Cloudflare Worker: API (REST + Auth + R2)
+========================================
+
+Service Overview
+----------------
+* Worker filename: `cloudflare/api.js`
+* Purpose: Handles authentication, campaign/map CRUD, R2 presigned uploads, Durable Object coordination, and session lifecycle for the D&D map reveal platform.
+
+Prerequisites (Cloudflare Dashboard)
+------------------------------------
+1. **R2 Bucket** (for map and asset storage)
+   * Navigate to **R2** → **Create bucket**.
+   * Suggested name: `dnd-map-assets`.
+2. **D1 Database** (for metadata)
+   * Navigate to **Workers & Pages** → **D1** → **Create database**.
+   * Suggested name: `dnd-map-db`.
+   * After creation, go to the database → **Query editor** → paste the contents of `schema/d1.sql` and run them to create tables.
+3. **Durable Object Namespace**
+   * Create a namespace that will be bound to the session Durable Object worker (`session-do.js`).
+   * Suggested name: `SESSION_HUB`.
+
+Deploying the API Worker
+------------------------
+1. In the Cloudflare dashboard, go to **Workers & Pages** → **Create application** → **Create Worker**.
+2. Name the worker (e.g., `dnd-api`). Choose **Quick edit** and replace the default code with the contents of `/cloudflare/api.js`.
+3. Under **Settings** → **Variables & Secrets**, add the following bindings:
+
+   Environment Variables / Bindings
+   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   * **D1 Database Binding**
+     * Type: D1 Database
+     * Variable name: `MAPS_DB`
+     * Select the `dnd-map-db` (or your chosen database).
+   * **R2 Bucket Binding**
+     * Type: R2 Bucket
+     * Variable name: `MAPS_BUCKET`
+     * Select the `dnd-map-assets` bucket.
+   * **Durable Object Binding**
+     * Type: Durable Object Namespace
+     * Variable name: `SESSION_HUB`
+     * Class name: `SessionHub`
+     * Select the namespace created earlier.
+   * **Text Secret**
+     * Name: `SESSION_SECRET`
+     * Value: any strong random string (used to sign JWTs).
+
+4. Under **Triggers** → **Routes**, add a route that maps your desired domain/path to the worker (e.g., `https://api.example.com/*`). This URL will become the base for `VITE_API_BASE_URL`.
+5. Save and deploy the worker.
+
+D1 Schema & Seed Data
+---------------------
+* Paste `schema/d1.sql` into the D1 query editor and execute once.
+* Optionally load `seed-data.json` manually using the query editor or API Explorer to pre-populate demo data.
+
+Post-Deployment Checklist
+-------------------------
+* Confirm the worker responds at `https://<your-worker>.<account>.workers.dev/api/lobby`.
+* Record the public API base URL for use in the Pages project (`VITE_API_BASE_URL`).

--- a/readme-pages.txt
+++ b/readme-pages.txt
@@ -1,0 +1,47 @@
+Cloudflare Pages Frontend (React + Vite)
+=======================================
+
+Project Location
+----------------
+* Directory: `apps/pages`
+* Framework: React 18 + TypeScript + Tailwind CSS (built with Vite)
+
+Creating the Pages Project
+--------------------------
+1. Commit this repository to your source control (GitHub/GitLab/Bitbucket) or upload manually.
+2. In the Cloudflare dashboard, go to **Workers & Pages** → **Create application** → **Pages**.
+3. Choose **Connect to Git** and authorize the repository.
+4. When prompted for build settings, use:
+   * **Production branch:** `main` (or your default branch)
+   * **Build command:** `npm install && npm run build`
+   * **Build output directory:** `apps/pages/dist`
+   * **Node version:** 18 or newer (Pages defaults to a modern Node runtime).
+5. Click **Save and Deploy**. The first deployment will install dependencies and generate the static build.
+
+Environment Variables
+---------------------
+* Navigate to the Pages project → **Settings** → **Environment Variables**.
+* Add the variable below for both Production and Preview environments:
+  * Name: `VITE_API_BASE_URL`
+  * Value: The full HTTPS base URL of the API worker route (e.g., `https://api.example.com`).
+* Re-deploy after saving to ensure the frontend picks up the configuration.
+
+Preview Deployments
+-------------------
+* Every commit/PR automatically triggers a Preview build.
+* You can override `VITE_API_BASE_URL` for Preview deployments (e.g., point to a staging API Worker) under the **Preview** tab in Environment Variables.
+
+Connecting to the API & DO Workers
+----------------------------------
+* Ensure the API worker exposes the `/api/*` routes on the hostname used in `VITE_API_BASE_URL`.
+* The API worker internally proxies WebSocket upgrades to the Durable Object (`/api/sessions/:id/socket`), so no extra configuration is needed in Pages.
+
+Local Development (Optional)
+----------------------------
+While all deployment steps can be performed via the dashboard, you can test locally by running:
+```
+cd apps/pages
+npm install
+npm run dev
+```
+Then visit `http://localhost:5173` with `VITE_API_BASE_URL` set in a `.env` file or shell environment.

--- a/readme-session-do.txt
+++ b/readme-session-do.txt
@@ -1,0 +1,35 @@
+Cloudflare Worker: Durable Object (Session Hub)
+===============================================
+
+Service Overview
+----------------
+* Worker filename: `cloudflare/session-do.js`
+* Class exported: `SessionHub`
+* Role: Maintains per-session realtime state (revealed regions, live markers, connected players) and powers WebSocket fan-out.
+
+Setup Steps (Dashboard)
+-----------------------
+1. Navigate to **Workers & Pages** → **Create application** → **Create Worker**.
+2. Name this worker (e.g., `dnd-session-hub`).
+3. Click **Quick edit** and replace the default script with the contents of `/cloudflare/session-do.js`.
+4. Press **Save and deploy**.
+
+Durable Object Namespace
+------------------------
+1. From the deployed worker's settings, locate **Durable Objects** → **Add binding**.
+2. Add a namespace with:
+   * Class name: `SessionHub`
+   * Binding name: `SESSION_HUB`
+3. When prompted, create a new namespace (e.g., `dnd-session-hub`).
+4. After saving, this namespace can now be bound to other workers.
+
+Connecting to the API Worker
+----------------------------
+* In the API worker (`readme-api.txt`), add a Durable Object namespace binding pointing at the namespace created above. The binding must use the same class name (`SessionHub`) and binding variable (`SESSION_HUB`).
+* No additional environment variables are required for the Durable Object worker itself.
+
+Testing
+-------
+* From the Workers dashboard, open the Durable Object worker → **Quick edit** → **Preview**.
+* Send an HTTP request to `/state` to verify it returns default JSON.
+* Use the API worker WebSocket endpoint (`/api/sessions/:id/socket`) after session creation to validate realtime messaging.

--- a/schema/d1.sql
+++ b/schema/d1.sql
@@ -1,0 +1,91 @@
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS users (
+    id TEXT PRIMARY KEY,
+    email TEXT NOT NULL UNIQUE,
+    password_hash TEXT NOT NULL,
+    password_salt TEXT NOT NULL,
+    display_name TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS campaigns (
+    id TEXT PRIMARY KEY,
+    owner_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    description TEXT,
+    is_public INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    FOREIGN KEY (owner_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS maps (
+    id TEXT PRIMARY KEY,
+    campaign_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    description TEXT,
+    original_key TEXT,
+    display_key TEXT,
+    width INTEGER,
+    height INTEGER,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    FOREIGN KEY (campaign_id) REFERENCES campaigns(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS regions (
+    id TEXT PRIMARY KEY,
+    map_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    polygon_json TEXT NOT NULL,
+    order_index INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    FOREIGN KEY (map_id) REFERENCES maps(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS markers (
+    id TEXT PRIMARY KEY,
+    map_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    marker_type TEXT NOT NULL,
+    position_json TEXT NOT NULL,
+    data_json TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    FOREIGN KEY (map_id) REFERENCES maps(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS sessions (
+    id TEXT PRIMARY KEY,
+    campaign_id TEXT NOT NULL,
+    map_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'active',
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+    FOREIGN KEY (campaign_id) REFERENCES campaigns(id) ON DELETE CASCADE,
+    FOREIGN KEY (map_id) REFERENCES maps(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS reveals (
+    id TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL,
+    region_id TEXT NOT NULL,
+    revealed_at TEXT NOT NULL DEFAULT (datetime('now')),
+    FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE,
+    FOREIGN KEY (region_id) REFERENCES regions(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS session_backups (
+    id TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL,
+    backup_key TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_campaigns_owner ON campaigns(owner_id);
+CREATE INDEX IF NOT EXISTS idx_maps_campaign ON maps(campaign_id);
+CREATE INDEX IF NOT EXISTS idx_regions_map ON regions(map_id);
+CREATE INDEX IF NOT EXISTS idx_markers_map ON markers(map_id);
+CREATE INDEX IF NOT EXISTS idx_sessions_campaign ON sessions(campaign_id);
+CREATE INDEX IF NOT EXISTS idx_reveals_session ON reveals(session_id);
+CREATE INDEX IF NOT EXISTS idx_reveals_region ON reveals(region_id);

--- a/seed-data.json
+++ b/seed-data.json
@@ -1,0 +1,89 @@
+{
+  "users": [
+    {
+      "id": "user-demo-0001",
+      "email": "demo@example.com",
+      "password_hash": "{SHA256}demo-hash-placeholder",
+      "password_salt": "demo-salt-placeholder",
+      "display_name": "Demo DM"
+    }
+  ],
+  "campaigns": [
+    {
+      "id": "camp-goblin-warrens",
+      "owner_id": "user-demo-0001",
+      "name": "Goblin Warrens",
+      "description": "A twisting tunnel complex beneath the ruined keep.",
+      "is_public": 1
+    }
+  ],
+  "maps": [
+    {
+      "id": "map-warrens-entrance",
+      "campaign_id": "camp-goblin-warrens",
+      "name": "Warrens Entrance",
+      "description": "Surface approach and cavern mouth.",
+      "original_key": "maps/camp-goblin-warrens/map-warrens-entrance/original.png",
+      "display_key": "maps/camp-goblin-warrens/map-warrens-entrance/display.png",
+      "width": 2048,
+      "height": 1536
+    }
+  ],
+  "regions": [
+    {
+      "id": "region-entrance",
+      "map_id": "map-warrens-entrance",
+      "name": "Entrance Clearing",
+      "polygon_json": "[[100,120],[420,130],[410,320],[120,300]]",
+      "order_index": 0
+    },
+    {
+      "id": "region-tunnel",
+      "map_id": "map-warrens-entrance",
+      "name": "Sloping Tunnel",
+      "polygon_json": "[[430,150],[780,160],[790,380],[450,360]]",
+      "order_index": 1
+    }
+  ],
+  "markers": [
+    {
+      "id": "marker-goblin-scouts",
+      "map_id": "map-warrens-entrance",
+      "name": "Goblin Scouts",
+      "marker_type": "enemy",
+      "position_json": "{\"x\":520,\"y\":210}",
+      "data_json": "{\"notes\":\"Two goblins on watch\",\"icon\":\"goblin.png\"}"
+    },
+    {
+      "id": "marker-hidden-trap",
+      "map_id": "map-warrens-entrance",
+      "name": "Snare Trap",
+      "marker_type": "trap",
+      "position_json": "{\"x\":360,\"y\":280}",
+      "data_json": "{\"notes\":\"DC 13 Perception\"}"
+    }
+  ],
+  "sessions": [
+    {
+      "id": "sess-demo-001",
+      "campaign_id": "camp-goblin-warrens",
+      "map_id": "map-warrens-entrance",
+      "name": "Session Zero",
+      "status": "active"
+    }
+  ],
+  "reveals": [
+    {
+      "id": "reveal-1",
+      "session_id": "sess-demo-001",
+      "region_id": "region-entrance"
+    }
+  ],
+  "session_backups": [
+    {
+      "id": "backup-1",
+      "session_id": "sess-demo-001",
+      "backup_key": "backups/camp-goblin-warrens/2024/01/01/120000.json"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add API worker powering auth, CRUD routes, R2 presigned uploads, and session lifecycle hooks
- add Durable Object worker managing realtime WebSocket state for map reveals
- scaffold React + Vite Cloudflare Pages frontend with build/play modes, auth, and fog-of-war canvas
- document Cloudflare dashboard setup for workers, pages, D1 schema, and R2 storage

## Testing
- npm install (fails: npm error code E403)
- npm run build (fails: npm error code E403)

------
https://chatgpt.com/codex/tasks/task_e_68cc17e81d548323b177e34aec7985cd