### PR TITLE
Refactor workers into deployable projects

### DIFF
--- a/workers/README.md
+++ b/workers/README.md
@@ -1,31 +1,17 @@
-# Cloudflare Workers packages
+# Cloudflare Workers
 
-This directory exposes the Cloudflare runtime code as standalone npm packages so
-you can consume them from other repositories (including via git subpath
-installs or `wrangler` remote module imports).
+This directory hosts the Cloudflare Workers that power the Dand application. Each folder is a self-contained [Wrangler](https://developers.cloudflare.com/workers/wrangler/) project that can be deployed directly to your Cloudflare account.
 
-## Packages
+## Projects
 
-- `@dand/workers-api` – REST API Worker published from `workers/api/worker.js`.
-- `@dand/session-hub-do` – Durable Object Worker published from
-  `workers/session-do/worker.js`.
+- `api/` – REST API Worker that exposes authentication, campaign, map, asset, and session endpoints. The worker expects bindings to a D1 database, an R2 bucket, and the Session Hub Durable Object namespace.
+- `session-do/` – Durable Object Worker that maintains real-time session state and coordinates WebSocket connections between the API and clients.
 
-Each package declares `type: "module"` and ships a default export compatible
-with Cloudflare's module worker syntax.
+Each project ships with:
 
-### Installing directly from git
+- TypeScript source in `src/`.
+- Ambient binding definitions in `worker-configuration.d.ts`.
+- A `wrangler.toml` file that you can customize with your account-specific resource IDs.
+- Scripts in `package.json` for local development (`npm run dev`), deployment (`npm run deploy`), and type checking (`npm run typecheck`).
 
-```bash
-npm install git+https://github.com/your-org/dand.git#path:workers/api
-npm install git+https://github.com/your-org/dand.git#path:workers/session-do
-```
-
-After installing you can import the worker module and re-export it from your own
-Wrangler project or consume it as a remote module:
-
-```js
-import apiWorker from '@dand/workers-api';
-export default apiWorker;
-```
-
-Update the git URL above to match wherever this repository is hosted.
+Refer to the README within each project for detailed setup and deployment instructions.

--- a/workers/api/.gitignore
+++ b/workers/api/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.wrangler/
+dist/
+*.log

--- a/workers/api/README.md
+++ b/workers/api/README.md
@@ -1,0 +1,47 @@
+# Dand API Worker
+
+This project packages the Dand REST API as a standalone [Cloudflare Worker](https://developers.cloudflare.com/workers/). It exposes the JSON API that backs the battle map application and is ready to deploy with [Wrangler](https://developers.cloudflare.com/workers/wrangler/).
+
+## Project structure
+
+```
+workers/api/
+├── src/index.ts              # Worker entry point
+├── worker-configuration.d.ts # Type definitions for bindings
+├── wrangler.toml             # Wrangler deployment config
+├── tsconfig.json             # TypeScript configuration
+├── package.json              # Scripts and dev dependencies
+└── .gitignore
+```
+
+## Getting started
+
+Install dependencies and run the worker locally:
+
+```bash
+npm install
+npm run dev
+```
+
+`npm run dev` executes `wrangler dev`, which spins up the worker using the bindings defined in `wrangler.toml`. Update the binding placeholders (database IDs, bucket names, secrets, etc.) before running it against your own Cloudflare account.
+
+## Deploying
+
+Deploy with Wrangler once the configuration matches your Cloudflare resources:
+
+```bash
+npm run deploy
+```
+
+You can set per-environment overrides in `[env.production]` or other sections inside `wrangler.toml` if you need different bindings between environments.
+
+## Environment bindings
+
+The worker expects the following Cloudflare resources:
+
+- `MAPS_DB` – D1 database containing campaign, map, and user tables.
+- `MAPS_BUCKET` – R2 bucket used for map images, assets, and backups.
+- `SESSION_SECRET` – secret string used to sign session tokens.
+- `SESSION_HUB` – Durable Object namespace that points at the Session Hub worker.
+
+Refer to `worker-configuration.d.ts` for the full type definitions.

--- a/workers/api/package.json
+++ b/workers/api/package.json
@@ -1,13 +1,16 @@
 {
   "name": "@dand/workers-api",
-  "version": "1.0.0",
+  "version": "0.2.0",
+  "private": true,
   "type": "module",
-  "main": "worker.js",
-  "module": "worker.js",
-  "exports": {
-    ".": "./worker.js"
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "typecheck": "tsc --noEmit"
   },
-  "files": [
-    "worker.js"
-  ]
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20240314.0",
+    "typescript": "^5.4.5",
+    "wrangler": "^3.40.0"
+  }
 }

--- a/workers/api/tsconfig.json
+++ b/workers/api/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "types": ["@cloudflare/workers-types"],
+    "noEmit": true
+  },
+  "include": ["src/**/*", "worker-configuration.d.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/workers/api/worker-configuration.d.ts
+++ b/workers/api/worker-configuration.d.ts
@@ -1,0 +1,12 @@
+import type { D1Database, R2Bucket, DurableObjectNamespace } from '@cloudflare/workers-types';
+
+export {};
+
+declare global {
+  interface Env {
+    MAPS_DB: D1Database;
+    MAPS_BUCKET: R2Bucket;
+    SESSION_SECRET: string;
+    SESSION_HUB: DurableObjectNamespace;
+  }
+}

--- a/workers/api/wrangler.toml
+++ b/workers/api/wrangler.toml
@@ -1,0 +1,22 @@
+name = "dand-api"
+main = "src/index.ts"
+compatibility_date = "2024-04-24"
+usage_model = "standard"
+
+[vars]
+SESSION_SECRET = "replace-with-production-secret"
+
+[[d1_databases]]
+binding = "MAPS_DB"
+database_name = "maps-db"
+database_id = "YOUR_D1_DATABASE_ID"
+
+[[r2_buckets]]
+binding = "MAPS_BUCKET"
+bucket_name = "maps-bucket"
+preview_bucket_name = "maps-bucket-preview"
+
+[[durable_objects.bindings]]
+name = "SESSION_HUB"
+class_name = "SessionHub"
+script_name = "dand-session-do"

--- a/workers/session-do/.gitignore
+++ b/workers/session-do/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.wrangler/
+dist/
+*.log

--- a/workers/session-do/README.md
+++ b/workers/session-do/README.md
@@ -1,0 +1,36 @@
+# Session Hub Durable Object
+
+This directory contains the Session Hub Durable Object that coordinates WebSocket connections for live game sessions. The project is configured as a standalone [Cloudflare Worker Durable Object](https://developers.cloudflare.com/workers/learning/using-durable-objects/) so it can be deployed directly with Wrangler.
+
+## Project structure
+
+```
+workers/session-do/
+├── src/index.ts              # Durable Object implementation and stub handler
+├── worker-configuration.d.ts # Ambient type definitions for bindings
+├── wrangler.toml             # Wrangler configuration and migrations
+├── tsconfig.json             # TypeScript compiler options
+├── package.json              # Development scripts and dependencies
+└── .gitignore
+```
+
+## Getting started
+
+Install dependencies and run the Durable Object locally:
+
+```bash
+npm install
+npm run dev
+```
+
+`npm run dev` starts `wrangler dev` so you can exercise the Durable Object locally. If you need to override bindings for different environments, add additional sections such as `[env.production]` to `wrangler.toml`.
+
+## Deploying
+
+Deploy the worker with Wrangler once you have linked it to your Cloudflare account:
+
+```bash
+npm run deploy
+```
+
+The default configuration registers the `SessionHub` class under the `SESSION_HUB` binding and includes a migration (`v1`) that provisions the Durable Object namespace the first time you deploy.

--- a/workers/session-do/package.json
+++ b/workers/session-do/package.json
@@ -1,13 +1,16 @@
 {
   "name": "@dand/session-hub-do",
-  "version": "1.0.0",
+  "version": "0.2.0",
+  "private": true,
   "type": "module",
-  "main": "worker.js",
-  "module": "worker.js",
-  "exports": {
-    ".": "./worker.js"
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "typecheck": "tsc --noEmit"
   },
-  "files": [
-    "worker.js"
-  ]
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20240314.0",
+    "typescript": "^5.4.5",
+    "wrangler": "^3.40.0"
+  }
 }

--- a/workers/session-do/tsconfig.json
+++ b/workers/session-do/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "types": ["@cloudflare/workers-types"],
+    "noEmit": true
+  },
+  "include": ["src/**/*", "worker-configuration.d.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/workers/session-do/worker-configuration.d.ts
+++ b/workers/session-do/worker-configuration.d.ts
@@ -1,0 +1,7 @@
+export {};
+
+declare global {
+  interface Env {
+    // Add bindings for the durable object if needed.
+  }
+}

--- a/workers/session-do/wrangler.toml
+++ b/workers/session-do/wrangler.toml
@@ -1,0 +1,13 @@
+name = "dand-session-do"
+main = "src/index.ts"
+compatibility_date = "2024-04-24"
+usage_model = "standard"
+
+[durable_objects]
+bindings = [
+  { name = "SESSION_HUB", class_name = "SessionHub" }
+]
+
+[[migrations]]
+tag = "v1"
+new_classes = ["SessionHub"]


### PR DESCRIPTION
## Summary
- convert the API worker into a standalone Wrangler project with TypeScript sources, documentation, and deployment config
- convert the Session Hub durable object into its own Wrangler project with TypeScript implementation and migration config
- document the new layout in the workers README so both workers can be deployed directly from this repo

## Testing
- npm install (workers/api) *(fails: registry access returns 403 in container)*
- npm install (workers/session-do) *(fails: registry access returns 403 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc7f7966548323ba5a27fc845bdf5a