### PR TITLE
Add define rooms step to map wizard

### DIFF
--- a/apps/pages/src/components/MapCreationWizard.tsx
+++ b/apps/pages/src/components/MapCreationWizard.tsx
@@ -1,0 +1,1169 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { apiClient } from '../api/client';
+import type { Campaign, MapRecord, Marker } from '../types';
+
+type WizardStep = 0 | 1 | 2 | 3;
+
+type SelectionMode = 'lasso' | 'smart';
+
+interface MapCreationWizardProps {
+  campaign: Campaign;
+  onClose: () => void;
+  onComplete: (map: MapRecord, markers: Marker[]) => void;
+}
+
+interface DraftMarker {
+  id: string;
+  label: string;
+  color: string;
+  notes: string;
+  x: number;
+  y: number;
+}
+
+interface DraftRoom {
+  id: string;
+  name: string;
+  tags: string;
+  notes: string;
+  visibleFromStart: boolean;
+  selectionMode: SelectionMode;
+  points: Array<{ x: number; y: number }>;
+  autoSnapped: boolean;
+}
+
+const steps: Array<{ title: string; description: string }> = [
+  {
+    title: 'Upload Map Image',
+    description: 'Drop in the battle map image you want to use for this campaign.',
+  },
+  {
+    title: 'Map Details',
+    description: 'Name your map, assign it to a folder, and capture quick notes or tags.',
+  },
+  {
+    title: 'Define Rooms',
+    description: 'Outline rooms and halls to keep hidden until you choose to reveal them.',
+  },
+  {
+    title: 'Add Markers',
+    description: 'Drag markers onto the map to highlight points of interest for your players.',
+  },
+];
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+const pointInPolygon = (point: { x: number; y: number }, polygon: Array<{ x: number; y: number }>) => {
+  if (polygon.length < 3) return false;
+  let inside = false;
+  for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
+    const xi = polygon[i].x;
+    const yi = polygon[i].y;
+    const xj = polygon[j].x;
+    const yj = polygon[j].y;
+    const intersect = yi > point.y !== yj > point.y && point.x < ((xj - xi) * (point.y - yi)) / (yj - yi + 0.0000001) + xi;
+    if (intersect) {
+      inside = !inside;
+    }
+  }
+  return inside;
+};
+
+const calculateCentroid = (points: Array<{ x: number; y: number }>): { x: number; y: number } => {
+  if (points.length === 0) {
+    return { x: 0.5, y: 0.5 };
+  }
+  const sum = points.reduce(
+    (acc, point) => ({
+      x: acc.x + point.x,
+      y: acc.y + point.y,
+    }),
+    { x: 0, y: 0 }
+  );
+  return {
+    x: sum.x / points.length,
+    y: sum.y / points.length,
+  };
+};
+
+const boundingBoxFromPoints = (points: Array<{ x: number; y: number }>) => {
+  if (points.length === 0) {
+    return [
+      { x: 0.4, y: 0.4 },
+      { x: 0.6, y: 0.4 },
+      { x: 0.6, y: 0.6 },
+      { x: 0.4, y: 0.6 },
+    ];
+  }
+  let minX = points[0].x;
+  let maxX = points[0].x;
+  let minY = points[0].y;
+  let maxY = points[0].y;
+  for (const point of points) {
+    minX = Math.min(minX, point.x);
+    maxX = Math.max(maxX, point.x);
+    minY = Math.min(minY, point.y);
+    maxY = Math.max(maxY, point.y);
+  }
+  const width = Math.max(maxX - minX, 0.01);
+  const height = Math.max(maxY - minY, 0.01);
+  return [
+    { x: clamp(minX, 0, 1), y: clamp(minY, 0, 1) },
+    { x: clamp(minX + width, 0, 1), y: clamp(minY, 0, 1) },
+    { x: clamp(minX + width, 0, 1), y: clamp(minY + height, 0, 1) },
+    { x: clamp(minX, 0, 1), y: clamp(minY + height, 0, 1) },
+  ];
+};
+
+const MapCreationWizard: React.FC<MapCreationWizardProps> = ({ campaign, onClose, onComplete }) => {
+  const [step, setStep] = useState<WizardStep>(0);
+  const [file, setFile] = useState<File | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [imageDimensions, setImageDimensions] = useState<{ width: number; height: number } | null>(null);
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [grouping, setGrouping] = useState('');
+  const [notes, setNotes] = useState('');
+  const [tagsInput, setTagsInput] = useState('');
+  const [creating, setCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [draggingId, setDraggingId] = useState<string | null>(null);
+
+  const markersAreaRef = useRef<HTMLDivElement>(null);
+  const roomsAreaRef = useRef<HTMLDivElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const drawingPointerIdRef = useRef<number | null>(null);
+
+  const [markers, setMarkers] = useState<DraftMarker[]>([]);
+  const [rooms, setRooms] = useState<DraftRoom[]>([]);
+  const [activeRoomId, setActiveRoomId] = useState<string | null>(null);
+  const [drawingRoom, setDrawingRoom] = useState<{
+    id: string;
+    mode: SelectionMode;
+    points: Array<{ x: number; y: number }>;
+  } | null>(null);
+  const [selectionMode, setSelectionMode] = useState<SelectionMode>('lasso');
+
+  useEffect(() => {
+    if (!drawingRoom) {
+      drawingPointerIdRef.current = null;
+    }
+  }, [drawingRoom]);
+
+  useEffect(() => {
+    if (!file) {
+      setPreviewUrl((previous) => {
+        if (previous) {
+          URL.revokeObjectURL(previous);
+        }
+        return null;
+      });
+      setImageDimensions(null);
+      setRooms([]);
+      setActiveRoomId(null);
+      setDrawingRoom(null);
+      return;
+    }
+    const objectUrl = URL.createObjectURL(file);
+    setPreviewUrl((previous) => {
+      if (previous) {
+        URL.revokeObjectURL(previous);
+      }
+      return objectUrl;
+    });
+    const image = new Image();
+    image.onload = () => {
+      setImageDimensions({ width: image.naturalWidth, height: image.naturalHeight });
+    };
+    image.src = objectUrl;
+    return () => {
+      image.onload = null;
+    };
+  }, [file]);
+
+  useEffect(() => {
+    return () => {
+      if (previewUrl) {
+        URL.revokeObjectURL(previewUrl);
+      }
+    };
+  }, [previewUrl]);
+
+  useEffect(() => {
+    if (!draggingId) return;
+
+    const handlePointerMove = (event: PointerEvent) => {
+      const container = markersAreaRef.current;
+      if (!container) return;
+      const rect = container.getBoundingClientRect();
+      if (rect.width === 0 || rect.height === 0) return;
+      const relativeX = clamp((event.clientX - rect.left) / rect.width, 0, 1);
+      const relativeY = clamp((event.clientY - rect.top) / rect.height, 0, 1);
+      setMarkers((current) =>
+        current.map((marker) => (marker.id === draggingId ? { ...marker, x: relativeX, y: relativeY } : marker))
+      );
+    };
+
+    const handlePointerUp = () => {
+      setDraggingId(null);
+    };
+
+    window.addEventListener('pointermove', handlePointerMove);
+    window.addEventListener('pointerup', handlePointerUp);
+    return () => {
+      window.removeEventListener('pointermove', handlePointerMove);
+      window.removeEventListener('pointerup', handlePointerUp);
+    };
+  }, [draggingId]);
+
+  const allowNext = useMemo(() => {
+    if (step === 0) {
+      return !!file;
+    }
+    if (step === 1) {
+      return name.trim().length > 0;
+    }
+    return true;
+  }, [file, name, step]);
+
+  const tags = useMemo(
+    () =>
+      tagsInput
+        .split(',')
+        .map((tag) => tag.trim())
+        .filter((tag) => tag.length > 0),
+    [tagsInput]
+  );
+
+  const activeRoom = useMemo(() => rooms.find((room) => room.id === activeRoomId) ?? null, [rooms, activeRoomId]);
+
+  const activeRoomCentroid = useMemo(
+    () => calculateCentroid(activeRoom?.points ?? []),
+    [activeRoom]
+  );
+
+  const handleDrop = (event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    setError(null);
+    const droppedFile = event.dataTransfer.files?.[0];
+    if (droppedFile) {
+      setFile(droppedFile);
+    }
+  };
+
+  const handleBrowse = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleMarkerChange = (markerId: string, field: keyof DraftMarker, value: string) => {
+    setMarkers((current) =>
+      current.map((marker) =>
+        marker.id === markerId
+          ? {
+              ...marker,
+              [field]: field === 'x' || field === 'y' ? Number(value) : value,
+            }
+          : marker
+      )
+    );
+  };
+
+  const handleRemoveMarker = (markerId: string) => {
+    setMarkers((current) => current.filter((marker) => marker.id !== markerId));
+  };
+
+  const handleAddMarker = () => {
+    const nextIndex = markers.length + 1;
+    const newMarker: DraftMarker = {
+      id: `draft-${Date.now()}-${nextIndex}`,
+      label: `Marker ${nextIndex}`,
+      color: '#facc15',
+      notes: '',
+      x: 0.5,
+      y: 0.5,
+    };
+    setMarkers((current) => [...current, newMarker]);
+  };
+
+  const handleStartRoomDrawing = () => {
+    if (!previewUrl) {
+      setError('Upload an image before defining rooms.');
+      return;
+    }
+    if (drawingRoom) {
+      return;
+    }
+    setError(null);
+    setActiveRoomId(null);
+    const id = `room-${Date.now()}`;
+    setDrawingRoom({
+      id,
+      mode: selectionMode,
+      points: [],
+    });
+  };
+
+  const handleRoomAreaPointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (!previewUrl) {
+      return;
+    }
+    if (event.button !== 0) {
+      return;
+    }
+    const container = roomsAreaRef.current;
+    if (!container) return;
+    const rect = container.getBoundingClientRect();
+    if (rect.width === 0 || rect.height === 0) return;
+    const relativeX = clamp((event.clientX - rect.left) / rect.width, 0, 1);
+    const relativeY = clamp((event.clientY - rect.top) / rect.height, 0, 1);
+
+    if (drawingRoom) {
+      event.preventDefault();
+      drawingPointerIdRef.current = event.pointerId;
+      event.currentTarget.setPointerCapture(event.pointerId);
+      setDrawingRoom((current) =>
+        current
+          ? {
+              ...current,
+              points: [...current.points, { x: relativeX, y: relativeY }],
+            }
+          : current
+      );
+      return;
+    }
+
+    const targetPoint = { x: relativeX, y: relativeY };
+    let clickedRoom: DraftRoom | undefined;
+    for (let index = rooms.length - 1; index >= 0; index -= 1) {
+      const room = rooms[index];
+      if (pointInPolygon(targetPoint, room.points)) {
+        clickedRoom = room;
+        break;
+      }
+    }
+    setActiveRoomId(clickedRoom?.id ?? null);
+  };
+
+  const handleRoomAreaPointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (!drawingRoom) {
+      return;
+    }
+    if (drawingPointerIdRef.current !== event.pointerId) {
+      return;
+    }
+    const container = roomsAreaRef.current;
+    if (!container) return;
+    const rect = container.getBoundingClientRect();
+    if (rect.width === 0 || rect.height === 0) return;
+    const relativeX = clamp((event.clientX - rect.left) / rect.width, 0, 1);
+    const relativeY = clamp((event.clientY - rect.top) / rect.height, 0, 1);
+    setDrawingRoom((current) => {
+      if (!current) return current;
+      const lastPoint = current.points[current.points.length - 1];
+      if (!lastPoint) {
+        return { ...current, points: [{ x: relativeX, y: relativeY }] };
+      }
+      const distance = Math.hypot(relativeX - lastPoint.x, relativeY - lastPoint.y);
+      if (distance < 0.005) {
+        return current;
+      }
+      return {
+        ...current,
+        points: [...current.points, { x: relativeX, y: relativeY }],
+      };
+    });
+  };
+
+  const handleRoomAreaPointerUp = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (!drawingRoom) {
+      return;
+    }
+    if (drawingPointerIdRef.current !== event.pointerId) {
+      return;
+    }
+    event.preventDefault();
+    try {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    } catch (err) {
+      // Ignore if the pointer was not captured.
+    }
+    drawingPointerIdRef.current = null;
+    const rawPoints = drawingRoom.points;
+    const usablePoints =
+      drawingRoom.mode === 'smart'
+        ? boundingBoxFromPoints(rawPoints)
+        : rawPoints.length >= 3
+        ? rawPoints
+        : boundingBoxFromPoints(rawPoints);
+    const sanitizedPoints = usablePoints.map((point) => ({
+      x: clamp(point.x, 0, 1),
+      y: clamp(point.y, 0, 1),
+    }));
+    if (sanitizedPoints.length < 3) {
+      setError('Draw a larger outline to create a room.');
+      setDrawingRoom(null);
+      return;
+    }
+    const newRoom: DraftRoom = {
+      id: drawingRoom.id,
+      name: '',
+      tags: '',
+      notes: '',
+      visibleFromStart: false,
+      selectionMode: drawingRoom.mode,
+      points: sanitizedPoints,
+      autoSnapped: drawingRoom.mode === 'smart',
+    };
+    setRooms((current) => [...current, newRoom]);
+    setActiveRoomId(newRoom.id);
+    setDrawingRoom(null);
+    setError(null);
+  };
+
+  const handleRoomFieldChange = (roomId: string, field: 'name' | 'tags' | 'notes', value: string) => {
+    setRooms((current) =>
+      current.map((room) =>
+        room.id === roomId
+          ? {
+              ...room,
+              [field]: value,
+            }
+          : room
+      )
+    );
+  };
+
+  const handleRoomVisibilityToggle = (roomId: string, value: boolean) => {
+    setRooms((current) =>
+      current.map((room) =>
+        room.id === roomId
+          ? {
+              ...room,
+              visibleFromStart: value,
+            }
+          : room
+      )
+    );
+  };
+
+  const handleRoomAutoSnap = (roomId: string) => {
+    setRooms((current) =>
+      current.map((room) =>
+        room.id === roomId
+          ? {
+              ...room,
+              points: boundingBoxFromPoints(room.points),
+              autoSnapped: true,
+            }
+          : room
+      )
+    );
+  };
+
+  const handleRemoveRoom = (roomId: string) => {
+    setRooms((current) => current.filter((room) => room.id !== roomId));
+    setActiveRoomId((current) => (current === roomId ? null : current));
+  };
+
+  const handleContinue = () => {
+    if (step < steps.length - 1) {
+      setStep((current) => (current + 1) as WizardStep);
+    }
+  };
+
+  const handleBack = () => {
+    if (step === 0) {
+      onClose();
+      return;
+    }
+    setStep((current) => (current - 1) as WizardStep);
+  };
+
+  const handleComplete = async () => {
+    if (!file) {
+      setError('Upload an image before creating your map.');
+      return;
+    }
+    if (!imageDimensions) {
+      setError('Image dimensions could not be determined. Try uploading the file again.');
+      return;
+    }
+    try {
+      setCreating(true);
+      setError(null);
+      const extension = file.name.split('.').pop()?.toLowerCase() || 'png';
+      const metadata: Record<string, unknown> = {};
+      if (description.trim()) {
+        metadata.description = description.trim();
+      }
+      if (grouping.trim()) {
+        metadata.grouping = grouping.trim();
+      }
+      if (notes.trim()) {
+        metadata.notes = notes.trim();
+      }
+      if (tags.length > 0) {
+        metadata.tags = tags;
+      }
+      if (rooms.length > 0) {
+        metadata.rooms = rooms.map((room) => {
+          const trimmedName = room.name.trim();
+          const trimmedNotes = room.notes.trim();
+          const tagList = room.tags
+            .split(',')
+            .map((tag) => tag.trim())
+            .filter((tag) => tag.length > 0);
+          const entry: Record<string, unknown> = {
+            id: room.id,
+            points: room.points,
+            selectionMode: room.selectionMode,
+            autoSnapped: room.autoSnapped,
+            visibleFromStart: room.visibleFromStart,
+          };
+          if (trimmedName) {
+            entry.name = trimmedName;
+          }
+          if (trimmedNotes) {
+            entry.notes = trimmedNotes;
+          }
+          if (tagList.length > 0) {
+            entry.tags = tagList;
+          }
+          return entry;
+        });
+      }
+      const response = await apiClient.createMap({
+        campaignId: campaign.id,
+        name: name.trim(),
+        originalExtension: extension,
+        width: imageDimensions.width,
+        height: imageDimensions.height,
+        metadata,
+      });
+      const { map, uploads } = response;
+
+      const uploadFile = async (url: string) => {
+        await fetch(url, {
+          method: 'PUT',
+          headers: {
+            'Content-Type': file.type || 'application/octet-stream',
+          },
+          body: file,
+        });
+      };
+
+      await uploadFile(uploads.original);
+      await uploadFile(uploads.display);
+
+      const createdMarkers: Marker[] = [];
+      for (const marker of markers) {
+        const payload = await apiClient.createMarker(map.id, {
+          label: marker.label.trim() || 'Marker',
+          notes: marker.notes.trim() || undefined,
+          color: marker.color.trim() || undefined,
+          x: marker.x,
+          y: marker.y,
+        });
+        createdMarkers.push(payload);
+      }
+
+      onComplete(map, createdMarkers);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex flex-col bg-slate-950/95 backdrop-blur-sm">
+      <header className="border-b border-slate-800/70 px-6 py-5">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <p className="text-xs uppercase tracking-[0.4em] text-teal-300">New Map Wizard</p>
+            <h2 className="text-2xl font-bold text-white">{steps[step].title}</h2>
+            <p className="text-sm text-slate-400">{steps[step].description}</p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-full border border-slate-700/70 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-300 transition hover:border-rose-400/60 hover:text-rose-200"
+          >
+            Exit Wizard
+          </button>
+        </div>
+        <div className="mt-4 flex flex-wrap gap-2">
+          {steps.map((item, index) => {
+            const isActive = index === step;
+            const isComplete = index < step;
+            return (
+              <div
+                key={item.title}
+                className={`flex items-center gap-3 rounded-full border px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] transition ${
+                  isActive
+                    ? 'border-teal-400/70 bg-teal-500/20 text-teal-100'
+                    : isComplete
+                    ? 'border-slate-700/70 bg-slate-800/80 text-slate-200'
+                    : 'border-slate-800/70 bg-slate-900/80 text-slate-500'
+                }`}
+              >
+                <span className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-current">
+                  {index + 1}
+                </span>
+                {item.title}
+              </div>
+            );
+          })}
+        </div>
+      </header>
+      <main className="flex-1 overflow-auto px-6 py-8">
+        {step === 0 && (
+          <div className="mx-auto max-w-4xl rounded-3xl border border-slate-800/70 bg-slate-900/70 p-10 text-center">
+            <div
+              onDragEnter={(event) => event.preventDefault()}
+              onDragOver={(event) => event.preventDefault()}
+              onDrop={handleDrop}
+              className="group relative flex min-h-[240px] flex-col items-center justify-center rounded-2xl border-2 border-dashed border-slate-700/70 bg-slate-950/70 px-6 py-10 transition hover:border-teal-400/60"
+            >
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/*"
+                className="hidden"
+                onChange={(event) => {
+                  const selected = event.target.files?.[0];
+                  if (selected) {
+                    setFile(selected);
+                  }
+                }}
+              />
+              <p className="text-sm uppercase tracking-[0.4em] text-slate-500">Drag & Drop</p>
+              <h3 className="mt-3 text-2xl font-semibold text-white">Drop your map image here</h3>
+              <p className="mt-2 max-w-xl text-sm text-slate-400">
+                We accept PNG, JPG, WEBP, and other common image formats. Drop the file or browse your computer to get started.
+              </p>
+              <button
+                type="button"
+                onClick={handleBrowse}
+                className="mt-6 rounded-full border border-teal-400/60 bg-teal-500/80 px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-teal-400/90"
+              >
+                Browse Files
+              </button>
+            </div>
+            {previewUrl && (
+              <div className="mt-8">
+                <p className="text-xs uppercase tracking-[0.4em] text-teal-300">Preview</p>
+                <div className="mt-3 overflow-hidden rounded-2xl border border-slate-800/70">
+                  <img src={previewUrl} alt="Uploaded map preview" className="max-h-[360px] w-full object-contain" />
+                </div>
+                {imageDimensions && (
+                  <p className="mt-2 text-xs uppercase tracking-[0.4em] text-slate-500">
+                    {imageDimensions.width} × {imageDimensions.height} pixels
+                  </p>
+                )}
+              </div>
+            )}
+          </div>
+        )}
+        {step === 1 && (
+          <div className="mx-auto max-w-4xl rounded-3xl border border-slate-800/70 bg-slate-900/70 p-10">
+            <div className="grid gap-8 md:grid-cols-[minmax(0,1fr)_280px]">
+              <div className="space-y-6">
+                <div>
+                  <label className="block text-xs uppercase tracking-[0.4em] text-slate-400">Map Name</label>
+                  <input
+                    type="text"
+                    value={name}
+                    onChange={(event) => setName(event.target.value)}
+                    className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                    placeholder="Ancient Ruins"
+                  />
+                </div>
+                <div>
+                  <label className="block text-xs uppercase tracking-[0.4em] text-slate-400">Description</label>
+                  <textarea
+                    value={description}
+                    onChange={(event) => setDescription(event.target.value)}
+                    rows={3}
+                    className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                    placeholder="Give a brief overview of the map."
+                  />
+                </div>
+                <div>
+                  <label className="block text-xs uppercase tracking-[0.4em] text-slate-400">Grouping</label>
+                  <input
+                    type="text"
+                    value={grouping}
+                    onChange={(event) => setGrouping(event.target.value)}
+                    className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                    placeholder="Dungeon Delves"
+                  />
+                </div>
+                <div>
+                  <label className="block text-xs uppercase tracking-[0.4em] text-slate-400">Notes</label>
+                  <textarea
+                    value={notes}
+                    onChange={(event) => setNotes(event.target.value)}
+                    rows={3}
+                    className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                    placeholder="DM-only reminders or encounter tips"
+                  />
+                </div>
+                <div>
+                  <label className="block text-xs uppercase tracking-[0.4em] text-slate-400">Tags</label>
+                  <input
+                    type="text"
+                    value={tagsInput}
+                    onChange={(event) => setTagsInput(event.target.value)}
+                    className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                    placeholder="forest, ruins, night"
+                  />
+                  <p className="mt-2 text-xs text-slate-500">Separate tags with commas to help search and filtering.</p>
+                </div>
+              </div>
+              <div className="space-y-4">
+                <div className="overflow-hidden rounded-2xl border border-slate-800/70 bg-slate-950/70">
+                  {previewUrl ? (
+                    <img src={previewUrl} alt="Map preview" className="h-full w-full object-cover" />
+                  ) : (
+                    <div className="flex h-full items-center justify-center p-6 text-sm text-slate-500">
+                      Upload a map image to see the preview.
+                    </div>
+                  )}
+                </div>
+                <div className="rounded-2xl border border-slate-800/70 bg-slate-950/70 p-4 text-xs text-slate-400">
+                  <p className="uppercase tracking-[0.4em] text-slate-500">Campaign</p>
+                  <p className="mt-2 text-sm text-white">{campaign.name}</p>
+                  {imageDimensions && (
+                    <p className="mt-3 text-xs uppercase tracking-[0.4em] text-slate-500">
+                      {imageDimensions.width} × {imageDimensions.height} pixels
+                    </p>
+                  )}
+                  {tags.length > 0 && (
+                    <div className="mt-3 flex flex-wrap gap-2">
+                      {tags.map((tag) => (
+                        <span
+                          key={tag}
+                          className="inline-flex items-center rounded-full border border-slate-700/70 bg-slate-900/70 px-2 py-1 text-[10px] uppercase tracking-[0.3em] text-slate-300"
+                        >
+                          {tag}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+        {step === 2 && (
+          <div className="flex h-full flex-col">
+            <div className="mb-6 grid flex-1 gap-6 lg:grid-cols-[minmax(0,1fr)_360px]">
+              <div className="flex flex-col rounded-3xl border border-slate-800/70 bg-slate-900/70">
+                <div className="flex flex-wrap items-center justify-between gap-4 border-b border-slate-800/70 p-5">
+                  <div>
+                    <p className="text-xs uppercase tracking-[0.4em] text-slate-400">Rooms &amp; Fog</p>
+                    <h3 className="text-lg font-semibold text-white">Outline Hidden Areas</h3>
+                    <p className="mt-1 max-w-xl text-xs text-slate-500">
+                      Trace rooms and hallways to control what your players see. Choose lasso for freehand outlines or smart select for quick bounding shapes.
+                    </p>
+                  </div>
+                  <div className="flex flex-col items-end gap-3 sm:flex-row sm:items-center">
+                    <div className="flex overflow-hidden rounded-full border border-slate-800/70">
+                      <button
+                        type="button"
+                        onClick={() => setSelectionMode('lasso')}
+                        className={`px-4 py-2 text-[10px] font-semibold uppercase tracking-[0.3em] transition ${
+                          selectionMode === 'lasso'
+                            ? 'bg-teal-500/80 text-slate-900'
+                            : 'bg-slate-900/80 text-slate-400 hover:text-slate-200'
+                        }`}
+                      >
+                        Lasso
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setSelectionMode('smart')}
+                        className={`px-4 py-2 text-[10px] font-semibold uppercase tracking-[0.3em] transition ${
+                          selectionMode === 'smart'
+                            ? 'bg-teal-500/80 text-slate-900'
+                            : 'bg-slate-900/80 text-slate-400 hover:text-slate-200'
+                        }`}
+                      >
+                        Smart Select
+                      </button>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={handleStartRoomDrawing}
+                      disabled={!previewUrl}
+                      className={`rounded-full border px-5 py-2 text-[10px] font-semibold uppercase tracking-[0.3em] transition ${
+                        previewUrl
+                          ? 'border-teal-400/60 bg-teal-500/80 text-slate-900 hover:bg-teal-400/90'
+                          : 'cursor-not-allowed border-slate-800/70 bg-slate-900/70 text-slate-500'
+                      }`}
+                    >
+                      + Add Room
+                    </button>
+                  </div>
+                </div>
+                <div className="relative flex-1 overflow-hidden">
+                  <div
+                    ref={roomsAreaRef}
+                    className={`relative flex h-full min-h-[420px] w-full items-center justify-center overflow-hidden bg-slate-950/60 ${
+                      drawingRoom ? 'cursor-crosshair' : 'cursor-pointer'
+                    }`}
+                    onPointerDown={handleRoomAreaPointerDown}
+                    onPointerMove={handleRoomAreaPointerMove}
+                    onPointerUp={handleRoomAreaPointerUp}
+                  >
+                    {previewUrl ? (
+                      <>
+                        <img
+                          src={previewUrl}
+                          alt="Room outlining preview"
+                          className="h-full w-full select-none object-contain pointer-events-none"
+                          draggable={false}
+                        />
+                        <svg className="pointer-events-none absolute inset-0 h-full w-full" viewBox="0 0 100 100" preserveAspectRatio="none">
+                          {rooms.map((room) => (
+                            <polygon
+                              key={room.id}
+                              points={room.points.map((point) => `${point.x * 100},${point.y * 100}`).join(' ')}
+                              className={`${
+                                activeRoomId === room.id
+                                  ? 'fill-teal-500/30 stroke-teal-300/90'
+                                  : 'fill-slate-500/20 stroke-slate-300/60'
+                              }`}
+                              strokeWidth={0.4}
+                            />
+                          ))}
+                          {drawingRoom && drawingRoom.points.length > 0 && (
+                            <polyline
+                              points={drawingRoom.points.map((point) => `${point.x * 100},${point.y * 100}`).join(' ')}
+                              className="fill-teal-500/10 stroke-teal-300/80"
+                              strokeWidth={0.6}
+                            />
+                          )}
+                        </svg>
+                        {drawingRoom && (
+                          <div className="pointer-events-none absolute inset-0 flex items-start justify-center p-6">
+                            <div className="rounded-full border border-teal-400/60 bg-teal-500/20 px-4 py-2 text-[10px] font-semibold uppercase tracking-[0.3em] text-teal-100 shadow-lg">
+                              Trace the area to define the room boundary
+                            </div>
+                          </div>
+                        )}
+                        {activeRoom && activeRoom.points.length > 0 && (
+                          <div
+                            className="absolute z-20 w-72 max-w-[85vw] -translate-x-1/2 -translate-y-full rounded-2xl border border-slate-800/80 bg-slate-950/95 p-4 text-xs text-slate-200 shadow-2xl"
+                            style={{ left: `${activeRoomCentroid.x * 100}%`, top: `${activeRoomCentroid.y * 100}%` }}
+                            onPointerDown={(event) => event.stopPropagation()}
+                          >
+                            <div className="flex items-start justify-between gap-3">
+                              <p className="text-[10px] uppercase tracking-[0.4em] text-slate-400">Room Details</p>
+                              <button
+                                type="button"
+                                onClick={() => handleRoomAutoSnap(activeRoom.id)}
+                                className="rounded-full border border-teal-400/60 px-3 py-1 text-[9px] font-semibold uppercase tracking-[0.3em] text-teal-100 transition hover:bg-teal-400/20"
+                              >
+                                Auto Snap
+                              </button>
+                            </div>
+                            <label className="mt-3 block text-[10px] uppercase tracking-[0.4em] text-slate-400">
+                              Area Name
+                              <input
+                                type="text"
+                                value={activeRoom.name}
+                                onChange={(event) => handleRoomFieldChange(activeRoom.id, 'name', event.target.value)}
+                                className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-3 py-2 text-xs text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                                placeholder="Starting Chamber"
+                              />
+                            </label>
+                            <label className="mt-3 block text-[10px] uppercase tracking-[0.4em] text-slate-400">
+                              Tags
+                              <input
+                                type="text"
+                                value={activeRoom.tags}
+                                onChange={(event) => handleRoomFieldChange(activeRoom.id, 'tags', event.target.value)}
+                                className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-3 py-2 text-xs text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                                placeholder="hallway, secret"
+                              />
+                            </label>
+                            <label className="mt-3 block text-[10px] uppercase tracking-[0.4em] text-slate-400">
+                              Notes
+                              <textarea
+                                value={activeRoom.notes}
+                                onChange={(event) => handleRoomFieldChange(activeRoom.id, 'notes', event.target.value)}
+                                rows={2}
+                                className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-3 py-2 text-xs text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                                placeholder="Reveal treasure chest after puzzle is solved"
+                              />
+                            </label>
+                            <label className="mt-3 flex items-center gap-2 text-[10px] uppercase tracking-[0.4em] text-slate-400">
+                              <input
+                                type="checkbox"
+                                checked={activeRoom.visibleFromStart}
+                                onChange={(event) => handleRoomVisibilityToggle(activeRoom.id, event.target.checked)}
+                                className="h-4 w-4 rounded border border-slate-700 bg-slate-900 text-teal-400 focus:ring-teal-500"
+                              />
+                              Visible to players on start
+                            </label>
+                          </div>
+                        )}
+                      </>
+                    ) : (
+                      <div className="flex h-full w-full items-center justify-center text-sm text-slate-400">
+                        Upload a map image to outline rooms.
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </div>
+              <aside className="flex flex-col rounded-3xl border border-slate-800/70 bg-slate-900/70">
+                <div className="border-b border-slate-800/70 p-5">
+                  <p className="text-xs uppercase tracking-[0.4em] text-slate-400">Defined Areas</p>
+                  <h3 className="mt-1 text-lg font-semibold text-white">Manage Room Visibility</h3>
+                  <p className="mt-2 text-xs text-slate-500">
+                    Click a room in the list or on the map to edit details. Rooms marked visible will be revealed to players immediately.
+                  </p>
+                </div>
+                <div className="flex-1 space-y-4 overflow-auto p-5">
+                  {rooms.map((room, index) => {
+                    const tagList = room.tags
+                      .split(',')
+                      .map((tag) => tag.trim())
+                      .filter((tag) => tag.length > 0);
+                    return (
+                      <div
+                        key={room.id}
+                        className={`rounded-2xl border p-4 transition ${
+                          activeRoomId === room.id
+                            ? 'border-teal-400/60 bg-teal-500/10'
+                            : 'border-slate-800/70 bg-slate-950/70'
+                        }`}
+                      >
+                        <div className="flex items-start justify-between gap-3">
+                          <div>
+                            <p className="text-[10px] uppercase tracking-[0.4em] text-slate-500">Room {index + 1}</p>
+                            <h4 className="mt-1 text-sm font-semibold text-white">{room.name.trim() || 'Unnamed Area'}</h4>
+                          </div>
+                          <div className="flex items-center gap-2">
+                            <span
+                              className={`rounded-full px-2 py-1 text-[9px] font-semibold uppercase tracking-[0.3em] ${
+                                room.selectionMode === 'smart'
+                                  ? 'bg-indigo-500/20 text-indigo-200'
+                                  : 'bg-slate-700/50 text-slate-200'
+                              }`}
+                            >
+                              {room.selectionMode === 'smart' ? 'Smart' : 'Lasso'}
+                            </span>
+                            {room.autoSnapped && (
+                              <span className="rounded-full bg-teal-500/20 px-2 py-1 text-[9px] font-semibold uppercase tracking-[0.3em] text-teal-200">
+                                Snapped
+                              </span>
+                            )}
+                            <button
+                              type="button"
+                              onClick={() => handleRemoveRoom(room.id)}
+                              className="rounded-full border border-rose-400/60 px-2 py-1 text-[9px] font-semibold uppercase tracking-[0.3em] text-rose-200 transition hover:bg-rose-400/20"
+                            >
+                              Remove
+                            </button>
+                          </div>
+                        </div>
+                        <button
+                          type="button"
+                          onClick={() => setActiveRoomId(room.id)}
+                          className="mt-3 w-full rounded-xl border border-dashed border-teal-400/40 px-3 py-2 text-[10px] font-semibold uppercase tracking-[0.3em] text-teal-200 transition hover:border-teal-400/80 hover:text-teal-100"
+                        >
+                          Edit Area
+                        </button>
+                        {tagList.length > 0 && (
+                          <div className="mt-3 flex flex-wrap gap-2">
+                            {tagList.map((tag) => (
+                              <span
+                                key={tag}
+                                className="inline-flex items-center rounded-full border border-slate-700/70 bg-slate-900/70 px-2 py-1 text-[9px] uppercase tracking-[0.3em] text-slate-300"
+                              >
+                                {tag}
+                              </span>
+                            ))}
+                          </div>
+                        )}
+                        {room.visibleFromStart && (
+                          <p className="mt-3 text-[10px] uppercase tracking-[0.4em] text-teal-200">Visible at Start</p>
+                        )}
+                      </div>
+                    );
+                  })}
+                  {rooms.length === 0 && (
+                    <div className="rounded-2xl border border-dashed border-slate-700/70 px-4 py-10 text-center text-xs text-slate-500">
+                      No rooms yet. Use + Add Room to start outlining fog-of-war areas.
+                    </div>
+                  )}
+                </div>
+              </aside>
+            </div>
+          </div>
+        )}
+        {step === 3 && (
+          <div className="flex h-full flex-col">
+            <div className="mb-6 grid flex-1 gap-6 lg:grid-cols-[minmax(0,1fr)_360px]">
+              <div
+                ref={markersAreaRef}
+                className="relative flex min-h-[420px] items-center justify-center overflow-hidden rounded-3xl border border-slate-800/70 bg-slate-900/70"
+              >
+                {previewUrl ? (
+                  <>
+                    <img src={previewUrl} alt="Interactive map preview" className="h-full w-full object-contain" />
+                    {markers.map((marker) => (
+                      <button
+                        key={marker.id}
+                        type="button"
+                        onPointerDown={(event) => {
+                          event.preventDefault();
+                          setDraggingId(marker.id);
+                        }}
+                        style={{ left: `${marker.x * 100}%`, top: `${marker.y * 100}%` }}
+                        className="group absolute -translate-x-1/2 -translate-y-1/2 rounded-full border border-white/40 bg-slate-950/80 px-3 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-white shadow-lg transition hover:border-teal-300/80 hover:text-teal-100"
+                      >
+                        {marker.label || 'Marker'}
+                      </button>
+                    ))}
+                    {markers.length === 0 && (
+                      <div className="absolute inset-0 flex items-center justify-center text-sm text-slate-400">
+                        Add markers from the panel to start placing points of interest.
+                      </div>
+                    )}
+                  </>
+                ) : (
+                  <div className="flex h-full w-full items-center justify-center text-sm text-slate-400">
+                    Upload a map image to place markers.
+                  </div>
+                )}
+              </div>
+              <div className="flex flex-col rounded-3xl border border-slate-800/70 bg-slate-900/70">
+                <div className="border-b border-slate-800/70 p-5">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <p className="text-xs uppercase tracking-[0.4em] text-slate-400">Markers</p>
+                      <h3 className="text-lg font-semibold text-white">Drag &amp; Drop Points</h3>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={handleAddMarker}
+                      className="rounded-full border border-teal-400/60 bg-teal-500/80 px-4 py-2 text-[10px] font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-teal-400/90"
+                    >
+                      Add Marker
+                    </button>
+                  </div>
+                  <p className="mt-2 text-xs text-slate-500">
+                    Create markers and drag them directly onto the map. Use notes to capture quick reminders.
+                  </p>
+                </div>
+                <div className="flex-1 space-y-4 overflow-auto p-5">
+                  {markers.map((marker) => (
+                    <div key={marker.id} className="rounded-2xl border border-slate-800/70 bg-slate-950/70 p-4">
+                      <div className="flex items-center justify-between gap-3">
+                        <label className="flex-1 text-[10px] uppercase tracking-[0.4em] text-slate-500">
+                          Label
+                          <input
+                            type="text"
+                            value={marker.label}
+                            onChange={(event) => handleMarkerChange(marker.id, 'label', event.target.value)}
+                            className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-3 py-2 text-xs text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                            placeholder="Secret Door"
+                          />
+                        </label>
+                        <label className="text-[10px] uppercase tracking-[0.4em] text-slate-500">
+                          Color
+                          <input
+                            type="text"
+                            value={marker.color}
+                            onChange={(event) => handleMarkerChange(marker.id, 'color', event.target.value)}
+                            className="mt-2 w-28 rounded-xl border border-slate-800/60 bg-slate-950/70 px-3 py-2 text-xs text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                            placeholder="#facc15"
+                          />
+                        </label>
+                      </div>
+                      <label className="mt-3 block text-[10px] uppercase tracking-[0.4em] text-slate-500">
+                        Notes
+                        <textarea
+                          value={marker.notes}
+                          onChange={(event) => handleMarkerChange(marker.id, 'notes', event.target.value)}
+                          rows={2}
+                          className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-3 py-2 text-xs text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                          placeholder="Trap trigger, treasure cache, etc."
+                        />
+                      </label>
+                      <div className="mt-3 flex items-center justify-between text-[10px] uppercase tracking-[0.4em] text-slate-500">
+                        <span>
+                          Position: {Math.round(marker.x * 100)}% × {Math.round(marker.y * 100)}%
+                        </span>
+                        <button
+                          type="button"
+                          onClick={() => handleRemoveMarker(marker.id)}
+                          className="rounded-full border border-rose-400/60 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.3em] text-rose-200 transition hover:bg-rose-400/20"
+                        >
+                          Remove
+                        </button>
+                      </div>
+                    </div>
+                  ))}
+                  {markers.length === 0 && (
+                    <div className="rounded-2xl border border-dashed border-slate-700/70 px-4 py-10 text-center text-xs text-slate-500">
+                      No markers yet. Add a marker to start placing points of interest.
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+      </main>
+      <footer className="border-t border-slate-800/70 px-6 py-5">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <button
+            type="button"
+            onClick={handleBack}
+            className="rounded-full border border-slate-700/70 px-5 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-300 transition hover:border-teal-400/60 hover:text-teal-200"
+          >
+            {step === 0 ? 'Cancel' : 'Back'}
+          </button>
+          <div className="flex flex-wrap items-center gap-4">
+            {error && <p className="text-xs font-semibold text-rose-300">{error}</p>}
+            {step < steps.length - 1 ? (
+              <button
+                type="button"
+                disabled={!allowNext}
+                onClick={handleContinue}
+                className={`rounded-full border px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] transition ${
+                  allowNext
+                    ? 'border-teal-400/60 bg-teal-500/80 text-slate-900 hover:bg-teal-400/90'
+                    : 'cursor-not-allowed border-slate-800/70 bg-slate-900/70 text-slate-500'
+                }`}
+              >
+                Next
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={handleComplete}
+                disabled={creating}
+                className={`rounded-full border px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] transition ${
+                  creating
+                    ? 'cursor-wait border-slate-800/70 bg-slate-900/70 text-slate-500'
+                    : 'border-teal-400/60 bg-teal-500/80 text-slate-900 hover:bg-teal-400/90'
+                }`}
+              >
+                {creating ? 'Creating…' : 'Create Map'}
+              </button>
+            )}
+          </div>
+        </div>
+      </footer>
+    </div>
+  );
+};
+
+export default MapCreationWizard;

--- a/apps/pages/src/components/MapFolderList.tsx
+++ b/apps/pages/src/components/MapFolderList.tsx
@@ -1,0 +1,174 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { apiClient } from '../api/client';
+import type { MapRecord } from '../types';
+
+interface MapFolderListProps {
+  maps: MapRecord[];
+  selectedMapId: string | null;
+  onSelect: (map: MapRecord) => void;
+  onCreateMap: () => void;
+}
+
+interface GroupedMaps {
+  name: string;
+  maps: MapRecord[];
+}
+
+const getMetadataString = (metadata: MapRecord['metadata'], key: string) => {
+  const value = metadata?.[key];
+  return typeof value === 'string' ? value : undefined;
+};
+
+const getMetadataStringArray = (metadata: MapRecord['metadata'], key: string) => {
+  const value = metadata?.[key];
+  if (Array.isArray(value)) {
+    return value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0);
+  }
+  if (typeof value === 'string') {
+    return value
+      .split(',')
+      .map((item) => item.trim())
+      .filter((item) => item.length > 0);
+  }
+  return [];
+};
+
+const MapFolderList: React.FC<MapFolderListProps> = ({ maps, selectedMapId, onSelect, onCreateMap }) => {
+  const grouped = useMemo<GroupedMaps[]>(() => {
+    const byGroup = new Map<string, MapRecord[]>();
+    maps.forEach((map) => {
+      const metadataGroup = getMetadataString(map.metadata, 'grouping') ?? getMetadataString(map.metadata, 'group');
+      const groupName = metadataGroup?.trim().length ? metadataGroup : 'Ungrouped Maps';
+      if (!byGroup.has(groupName)) {
+        byGroup.set(groupName, []);
+      }
+      byGroup.get(groupName)!.push(map);
+    });
+    return Array.from(byGroup.entries())
+      .map(([name, groupMaps]) => ({ name, maps: groupMaps }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }, [maps]);
+
+  const [expandedGroups, setExpandedGroups] = useState<Record<string, boolean>>({});
+
+  useEffect(() => {
+    setExpandedGroups((previous) => {
+      const next: Record<string, boolean> = { ...previous };
+      grouped.forEach((group) => {
+        if (typeof next[group.name] === 'undefined') {
+          next[group.name] = true;
+        }
+      });
+      return next;
+    });
+  }, [grouped]);
+
+  const toggleGroup = (groupName: string) => {
+    setExpandedGroups((previous) => ({ ...previous, [groupName]: !previous[groupName] }));
+  };
+
+  return (
+    <div className="rounded-2xl border border-slate-800/70 bg-slate-900/70 p-5">
+      <div className="mb-6 flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <p className="text-xs uppercase tracking-[0.4em] text-slate-400">Maps</p>
+          <h3 className="text-2xl font-bold text-white">Campaign Atlas</h3>
+          <p className="text-sm text-slate-400">Organize maps into folders to keep your encounters tidy.</p>
+        </div>
+        <button
+          type="button"
+          onClick={onCreateMap}
+          className="rounded-xl border border-teal-400/60 bg-teal-500/80 px-5 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-teal-400/90"
+        >
+          New Map
+        </button>
+      </div>
+      {grouped.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-slate-700/70 px-6 py-12 text-center text-sm text-slate-400">
+          No maps yet. Create a map to start building your world.
+        </div>
+      ) : (
+        <div className="grid gap-4">
+          {grouped.map((group) => {
+            const expanded = expandedGroups[group.name];
+            return (
+              <div key={group.name} className="rounded-2xl border border-slate-800/70 bg-slate-950/70 shadow-lg">
+                <button
+                  type="button"
+                  onClick={() => toggleGroup(group.name)}
+                  className="flex w-full items-center justify-between gap-4 px-5 py-4 text-left"
+                >
+                  <div>
+                    <p className="text-lg font-semibold text-white">{group.name}</p>
+                    <p className="text-[10px] uppercase tracking-[0.4em] text-slate-500">{group.maps.length} Maps</p>
+                  </div>
+                  <span
+                    className={`inline-flex h-8 w-8 items-center justify-center rounded-full border border-slate-700/70 text-xs font-bold text-slate-300 transition ${
+                      expanded ? 'bg-teal-500/10 text-teal-200' : 'bg-slate-900'
+                    }`}
+                    aria-hidden="true"
+                  >
+                    {expanded ? '−' : '+'}
+                  </span>
+                </button>
+                {expanded && (
+                  <div className="grid gap-4 border-t border-slate-800/60 px-5 py-5 sm:grid-cols-2 xl:grid-cols-3">
+                    {group.maps.map((map) => {
+                      const description = getMetadataString(map.metadata, 'description');
+                      const notes = getMetadataString(map.metadata, 'notes');
+                      const tags = getMetadataStringArray(map.metadata, 'tags');
+                      return (
+                        <button
+                          key={map.id}
+                          type="button"
+                          onClick={() => onSelect(map)}
+                          className={`group relative overflow-hidden rounded-2xl border px-5 py-6 text-left transition ${
+                            selectedMapId === map.id
+                              ? 'border-teal-400 bg-teal-500/10 shadow-[0_0_0_1px_rgba(45,212,191,0.4)]'
+                              : 'border-slate-800/60 bg-slate-950/60 hover:border-teal-400/60 hover:shadow-[0_0_0_1px_rgba(45,212,191,0.3)]'
+                          }`}
+                        >
+                          <div className="mb-4 flex items-center justify-between text-xs uppercase tracking-[0.4em] text-slate-500">
+                            <span>Map</span>
+                            <span>
+                              {map.width ?? '—'} × {map.height ?? '—'}
+                            </span>
+                          </div>
+                          <h4 className="text-lg font-semibold text-white">{map.name}</h4>
+                          {description && <p className="mt-2 text-sm text-slate-300">{description}</p>}
+                          {notes && !description && <p className="mt-2 text-sm text-slate-400">{notes}</p>}
+                          {tags.length > 0 && (
+                            <div className="mt-4 flex flex-wrap gap-2">
+                              {tags.map((tag) => (
+                                <span
+                                  key={tag}
+                                  className="inline-flex items-center rounded-full border border-slate-700/70 bg-slate-900/70 px-2 py-1 text-[10px] uppercase tracking-[0.3em] text-slate-300"
+                                >
+                                  {tag}
+                                </span>
+                              ))}
+                            </div>
+                          )}
+                          <div className="pointer-events-none absolute inset-0 rounded-2xl border border-white/5 transition group-hover:border-white/10" />
+                          <div className="pointer-events-none absolute inset-0 opacity-0 transition group-hover:opacity-100">
+                            <div
+                              className="absolute inset-0 bg-cover bg-center opacity-20"
+                              style={{ backgroundImage: `url(${apiClient.buildMapDisplayUrl(map.id)})` }}
+                            />
+                            <div className="absolute inset-0 bg-gradient-to-t from-slate-950 via-transparent to-transparent" />
+                          </div>
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default MapFolderList;


### PR DESCRIPTION
## Summary
- add a dedicated "Define Rooms" step with lasso and smart selection tooling and inline room detail editing
- render a management panel for outlined rooms plus an overlay editor so DMs can tweak visibility, tags, and snapping
- extend wizard state and metadata serialization so newly created maps retain their defined rooms alongside markers

## Testing
- npm install *(fails: registry returned 403 for @types/react)*
- npm run build *(fails: vite not found because dependencies could not be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68cd90a265108323baad1e33238ecdaa