### PR TITLE
Add Define Rooms step to map creation wizard

### DIFF
--- a/apps/pages/src/App.tsx
+++ b/apps/pages/src/App.tsx
@@ -230,13 +230,13 @@ const App: React.FC = () => {
     setShowMapWizard(false);
   };
 
-  const handleMapWizardComplete = (map: MapRecord, createdMarkers: Marker[]) => {
+  const handleMapWizardComplete = (map: MapRecord, createdMarkers: Marker[], createdRegions: Region[]) => {
     setMaps((previous) => {
       const without = previous.filter((entry) => entry.id !== map.id);
       return [map, ...without];
     });
     setSelectedMap(map);
-    setRegions([]);
+    setRegions(createdRegions);
     setMarkers(createdMarkers);
     fetchMapsForSelectedCampaign();
     setStatusMessage('Map created successfully.');

--- a/apps/pages/src/components/MapCreationWizard.tsx
+++ b/apps/pages/src/components/MapCreationWizard.tsx
@@ -1,13 +1,13 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { apiClient } from '../api/client';
-import type { Campaign, MapRecord, Marker } from '../types';
+import type { Campaign, MapRecord, Marker, Region } from '../types';
 
-type WizardStep = 0 | 1 | 2;
+type WizardStep = 0 | 1 | 2 | 3;
 
 interface MapCreationWizardProps {
   campaign: Campaign;
   onClose: () => void;
-  onComplete: (map: MapRecord, markers: Marker[]) => void;
+  onComplete: (map: MapRecord, markers: Marker[], regions: Region[]) => void;
 }
 
 interface DraftMarker {
@@ -19,6 +19,114 @@ interface DraftMarker {
   y: number;
 }
 
+interface DraftRoom {
+  id: string;
+  name: string;
+  notes: string;
+  tagsInput: string;
+  polygon: Array<{ x: number; y: number }>;
+  isVisible: boolean;
+  tool: 'lasso' | 'smart';
+}
+
+const distanceBetweenPoints = (a: { x: number; y: number }, b: { x: number; y: number }) =>
+  Math.hypot(a.x - b.x, a.y - b.y);
+
+const pointInPolygon = (point: { x: number; y: number }, polygon: Array<{ x: number; y: number }>) => {
+  let inside = false;
+  for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
+    const xi = polygon[i].x;
+    const yi = polygon[i].y;
+    const xj = polygon[j].x;
+    const yj = polygon[j].y;
+    const intersect = yi > point.y !== yj > point.y && point.x < ((xj - xi) * (point.y - yi)) / (yj - yi + Number.EPSILON) + xi;
+    if (intersect) inside = !inside;
+  }
+  return inside;
+};
+
+const simplifyPolygon = (points: Array<{ x: number; y: number }>, tolerance = 0.004) => {
+  if (points.length <= 3) return points;
+
+  const perpendicularDistance = (
+    point: { x: number; y: number },
+    lineStart: { x: number; y: number },
+    lineEnd: { x: number; y: number }
+  ) => {
+    const area =
+      Math.abs(
+        0.5 *
+          (lineStart.x * lineEnd.y + lineEnd.x * point.y + point.x * lineStart.y - lineEnd.x * lineStart.y - point.x * lineEnd.y - lineStart.x * point.y)
+      );
+    const base = distanceBetweenPoints(lineStart, lineEnd) || Number.EPSILON;
+    return (area * 2) / base;
+  };
+
+  const rdp = (pts: Array<{ x: number; y: number }>, epsilon: number): Array<{ x: number; y: number }> => {
+    if (pts.length < 3) return pts;
+    let maxDistance = 0;
+    let index = 0;
+    const last = pts.length - 1;
+    for (let i = 1; i < last; i += 1) {
+      const distance = perpendicularDistance(pts[i], pts[0], pts[last]);
+      if (distance > maxDistance) {
+        index = i;
+        maxDistance = distance;
+      }
+    }
+    if (maxDistance > epsilon) {
+      const left = rdp(pts.slice(0, index + 1), epsilon);
+      const right = rdp(pts.slice(index), epsilon);
+      return [...left.slice(0, -1), ...right];
+    }
+    return [pts[0], pts[last]];
+  };
+
+  const simplified = rdp(points, tolerance);
+  return simplified.length >= 3 ? simplified : points;
+};
+
+const normalisePolygon = (points: Array<{ x: number; y: number }>) => {
+  const filtered = points.filter((point, index) => {
+    if (index === 0) return true;
+    return distanceBetweenPoints(point, points[index - 1]) > 0.0015;
+  });
+  return filtered;
+};
+
+const computeCentroid = (polygon: Array<{ x: number; y: number }>) => {
+  if (polygon.length === 0) {
+    return { x: 0.5, y: 0.5 };
+  }
+  let area = 0;
+  let x = 0;
+  let y = 0;
+  for (let i = 0; i < polygon.length; i += 1) {
+    const current = polygon[i];
+    const next = polygon[(i + 1) % polygon.length];
+    const cross = current.x * next.y - next.x * current.y;
+    area += cross;
+    x += (current.x + next.x) * cross;
+    y += (current.y + next.y) * cross;
+  }
+  area *= 0.5;
+  if (Math.abs(area) < Number.EPSILON) {
+    const sum = polygon.reduce(
+      (acc, point) => ({ x: acc.x + point.x, y: acc.y + point.y }),
+      { x: 0, y: 0 }
+    );
+    return { x: sum.x / polygon.length, y: sum.y / polygon.length };
+  }
+  const factor = 1 / (6 * area);
+  return { x: x * factor, y: y * factor };
+};
+
+const parseTagsInput = (input: string) =>
+  input
+    .split(',')
+    .map((tag) => tag.trim())
+    .filter((tag) => tag.length > 0);
+
 const steps: Array<{ title: string; description: string }> = [
   {
     title: 'Upload Map Image',
@@ -27,6 +135,10 @@ const steps: Array<{ title: string; description: string }> = [
   {
     title: 'Map Details',
     description: 'Name your map, assign it to a folder, and capture quick notes or tags.',
+  },
+  {
+    title: 'Define Rooms',
+    description: 'Outline rooms and hallways to control what your players can see.',
   },
   {
     title: 'Add Markers',
@@ -54,6 +166,123 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({ campaign, onClose
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const [markers, setMarkers] = useState<DraftMarker[]>([]);
+  const [rooms, setRooms] = useState<DraftRoom[]>([]);
+  const [activeRoomId, setActiveRoomId] = useState<string | null>(null);
+  const [selectedRoomTool, setSelectedRoomTool] = useState<'lasso' | 'smart'>('lasso');
+  const [isOutliningRoom, setIsOutliningRoom] = useState(false);
+  const [isDrawingRoom, setIsDrawingRoom] = useState(false);
+  const [draftRoomPoints, setDraftRoomPoints] = useState<Array<{ x: number; y: number }>>([]);
+
+  const roomsMapRef = useRef<HTMLDivElement>(null);
+  const drawingPointsRef = useRef<Array<{ x: number; y: number }>>([]);
+
+  const resolveRelativePoint = useCallback(
+    (event: { clientX: number; clientY: number }) => {
+      const container = roomsMapRef.current;
+      if (!container) return null;
+      const rect = container.getBoundingClientRect();
+      if (rect.width === 0 || rect.height === 0) return null;
+      const relativeX = clamp((event.clientX - rect.left) / rect.width, 0, 1);
+      const relativeY = clamp((event.clientY - rect.top) / rect.height, 0, 1);
+      return { x: relativeX, y: relativeY };
+    },
+    []
+  );
+
+  const finalizeRoomOutline = useCallback(
+    (points: Array<{ x: number; y: number }>) => {
+      let polygon = normalisePolygon(points);
+      if (polygon.length < 3) {
+        setIsOutliningRoom(false);
+        setDraftRoomPoints([]);
+        drawingPointsRef.current = [];
+        return;
+      }
+      if (selectedRoomTool === 'smart') {
+        polygon = simplifyPolygon(polygon, 0.0035);
+      }
+      const newRoomId = `room-${Date.now()}-${Math.round(Math.random() * 10000)}`;
+      setRooms((current) => {
+        const nextIndex = current.length + 1;
+        return [
+          ...current,
+          {
+            id: newRoomId,
+            name: `Room ${nextIndex}`,
+            notes: '',
+            tagsInput: '',
+            polygon,
+            isVisible: false,
+            tool: selectedRoomTool,
+          },
+        ];
+      });
+      setActiveRoomId(newRoomId);
+      setIsOutliningRoom(false);
+      setDraftRoomPoints([]);
+      drawingPointsRef.current = [];
+    },
+    [selectedRoomTool]
+  );
+
+  useEffect(() => {
+    if (!isDrawingRoom) return;
+
+    const handlePointerMove = (event: PointerEvent) => {
+      const point = resolveRelativePoint(event);
+      if (!point) return;
+      const last = drawingPointsRef.current[drawingPointsRef.current.length - 1];
+      if (!last || distanceBetweenPoints(last, point) > 0.001) {
+        drawingPointsRef.current = [...drawingPointsRef.current, point];
+        setDraftRoomPoints(drawingPointsRef.current);
+      }
+    };
+
+    const handlePointerUp = (event: PointerEvent) => {
+      event.preventDefault();
+      const completed = drawingPointsRef.current;
+      drawingPointsRef.current = [];
+      setDraftRoomPoints([]);
+      setIsDrawingRoom(false);
+      if (completed.length >= 3) {
+        finalizeRoomOutline(completed);
+      } else {
+        setIsOutliningRoom(false);
+      }
+    };
+
+    window.addEventListener('pointermove', handlePointerMove);
+    window.addEventListener('pointerup', handlePointerUp);
+    return () => {
+      window.removeEventListener('pointermove', handlePointerMove);
+      window.removeEventListener('pointerup', handlePointerUp);
+    };
+  }, [finalizeRoomOutline, isDrawingRoom, resolveRelativePoint]);
+
+  useEffect(() => {
+    if (!isOutliningRoom) return;
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setIsOutliningRoom(false);
+        setIsDrawingRoom(false);
+        drawingPointsRef.current = [];
+        setDraftRoomPoints([]);
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => {
+      window.removeEventListener('keydown', handleKey);
+    };
+  }, [isOutliningRoom]);
+
+  useEffect(() => {
+    if (activeRoomId && !rooms.some((room) => room.id === activeRoomId)) {
+      setActiveRoomId(null);
+    }
+  }, [activeRoomId, rooms]);
+
+  const activeRoom = useMemo(() => rooms.find((room) => room.id === activeRoomId) ?? null, [activeRoomId, rooms]);
+  const activeRoomCenter = useMemo(() => computeCentroid(activeRoom?.polygon ?? []), [activeRoom]);
 
   useEffect(() => {
     if (!file) {
@@ -150,6 +379,71 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({ campaign, onClose
     fileInputRef.current?.click();
   };
 
+  const handleStartRoomOutline = () => {
+    if (!previewUrl) return;
+    setActiveRoomId(null);
+    setIsOutliningRoom(true);
+    setIsDrawingRoom(false);
+    setDraftRoomPoints([]);
+    drawingPointsRef.current = [];
+  };
+
+  const handleCancelRoomOutline = () => {
+    setIsOutliningRoom(false);
+    setIsDrawingRoom(false);
+    setDraftRoomPoints([]);
+    drawingPointsRef.current = [];
+  };
+
+  const handleRoomPointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (!isOutliningRoom) return;
+    event.preventDefault();
+    const point = resolveRelativePoint(event.nativeEvent);
+    if (!point) return;
+    drawingPointsRef.current = [point];
+    setDraftRoomPoints([point]);
+    setIsDrawingRoom(true);
+  };
+
+  const handleRoomClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (isOutliningRoom || isDrawingRoom) return;
+    const point = resolveRelativePoint(event.nativeEvent);
+    if (!point) return;
+    let matched: DraftRoom | null = null;
+    for (let index = rooms.length - 1; index >= 0; index -= 1) {
+      const candidate = rooms[index];
+      if (pointInPolygon(point, candidate.polygon)) {
+        matched = candidate;
+        break;
+      }
+    }
+    setActiveRoomId(matched ? matched.id : null);
+  };
+
+  const handleRoomFieldChange = (roomId: string, field: 'name' | 'notes' | 'tagsInput', value: string) => {
+    setRooms((current) => current.map((room) => (room.id === roomId ? { ...room, [field]: value } : room)));
+  };
+
+  const handleRoomVisibilityToggle = (roomId: string, nextValue: boolean) => {
+    setRooms((current) => current.map((room) => (room.id === roomId ? { ...room, isVisible: nextValue } : room)));
+  };
+
+  const handleAutoSnapRoom = (roomId: string) => {
+    setRooms((current) =>
+      current.map((room) => {
+        if (room.id !== roomId) return room;
+        let polygon = normalisePolygon(room.polygon);
+        polygon = simplifyPolygon(polygon, 0.0035);
+        return { ...room, polygon };
+      })
+    );
+  };
+
+  const handleRemoveRoom = (roomId: string) => {
+    setRooms((current) => current.filter((room) => room.id !== roomId));
+    setActiveRoomId((current) => (current === roomId ? null : current));
+  };
+
   const handleMarkerChange = (markerId: string, field: keyof DraftMarker, value: string) => {
     setMarkers((current) =>
       current.map((marker) =>
@@ -220,6 +514,36 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({ campaign, onClose
       if (tags.length > 0) {
         metadata.tags = tags;
       }
+      if (rooms.length > 0) {
+        const roomEntries = rooms.map((room) => {
+          const trimmedName = room.name.trim();
+          const trimmedNotes = room.notes.trim();
+          const roomTags = parseTagsInput(room.tagsInput);
+          const entry: Record<string, unknown> = {
+            id: room.id,
+            polygon: room.polygon,
+            isVisible: room.isVisible,
+            tool: room.tool,
+          };
+          if (trimmedName) {
+            entry.name = trimmedName;
+          }
+          if (trimmedNotes) {
+            entry.notes = trimmedNotes;
+          }
+          if (roomTags.length > 0) {
+            entry.tags = roomTags;
+          }
+          return entry;
+        });
+        metadata.rooms = roomEntries;
+        const visibleRoomNames = rooms
+          .filter((room) => room.isVisible)
+          .map((room) => room.name.trim() || room.id);
+        if (visibleRoomNames.length > 0) {
+          metadata.visibleRooms = visibleRoomNames;
+        }
+      }
       const response = await apiClient.createMap({
         campaignId: campaign.id,
         name: name.trim(),
@@ -255,7 +579,26 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({ campaign, onClose
         createdMarkers.push(payload);
       }
 
-      onComplete(map, createdMarkers);
+      const createdRegions: Region[] = [];
+      for (const [index, room] of rooms.entries()) {
+        const roomTags = parseTagsInput(room.tagsInput);
+        const compiledNotes = [
+          room.notes.trim(),
+          roomTags.length > 0 ? `Tags: ${roomTags.join(', ')}` : '',
+          room.isVisible ? 'Visible to players at start.' : '',
+        ]
+          .filter(Boolean)
+          .join('\n');
+        const region = await apiClient.createRegion(map.id, {
+          name: room.name.trim() || `Room ${index + 1}`,
+          polygon: room.polygon,
+          notes: compiledNotes || undefined,
+          revealOrder: index + 1,
+        });
+        createdRegions.push(region);
+      }
+
+      onComplete(map, createdMarkers, createdRegions);
     } catch (err) {
       setError((err as Error).message);
     } finally {
@@ -446,6 +789,279 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({ campaign, onClose
         )}
         {step === 2 && (
           <div className="flex h-full flex-col">
+            <div className="mb-6 flex flex-wrap items-center justify-between gap-4">
+              <div>
+                <p className="text-xs uppercase tracking-[0.4em] text-slate-400">Fog of War</p>
+                <h3 className="text-lg font-semibold text-white">Define Rooms &amp; Hallways</h3>
+                <p className="text-xs text-slate-500">
+                  Outline rooms, corridors, and secret spaces to keep them hidden until you reveal them.
+                </p>
+              </div>
+              <div className="flex flex-wrap items-center gap-3">
+                <div className="flex items-center gap-1 rounded-full border border-slate-800/70 bg-slate-950/70 p-1 text-[10px] uppercase tracking-[0.3em] text-slate-400">
+                  <button
+                    type="button"
+                    onClick={() => setSelectedRoomTool('lasso')}
+                    className={`rounded-full px-3 py-2 transition ${
+                      selectedRoomTool === 'lasso'
+                        ? 'border border-teal-400/70 bg-teal-500/80 text-slate-900'
+                        : 'border border-transparent text-slate-400 hover:text-teal-200'
+                    }`}
+                  >
+                    Lasso
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setSelectedRoomTool('smart')}
+                    className={`rounded-full px-3 py-2 transition ${
+                      selectedRoomTool === 'smart'
+                        ? 'border border-teal-400/70 bg-teal-500/80 text-slate-900'
+                        : 'border border-transparent text-slate-400 hover:text-teal-200'
+                    }`}
+                  >
+                    Smart Select
+                  </button>
+                </div>
+                <button
+                  type="button"
+                  onClick={handleStartRoomOutline}
+                  disabled={!previewUrl || isOutliningRoom}
+                  className={`rounded-full border px-4 py-2 text-[10px] font-semibold uppercase tracking-[0.3em] transition ${
+                    previewUrl && !isOutliningRoom
+                      ? 'border-teal-400/60 bg-teal-500/80 text-slate-900 hover:bg-teal-400/90'
+                      : 'cursor-not-allowed border-slate-800/70 bg-slate-900/70 text-slate-500'
+                  }`}
+                >
+                  + Add Room
+                </button>
+              </div>
+            </div>
+            <div className="grid flex-1 gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">
+              <div
+                ref={roomsMapRef}
+                className="relative flex min-h-[420px] items-center justify-center overflow-hidden rounded-3xl border border-slate-800/70 bg-slate-900/70"
+                onPointerDown={handleRoomPointerDown}
+                onClick={handleRoomClick}
+              >
+                {previewUrl ? (
+                  <>
+                    <img
+                      src={previewUrl}
+                      alt="Room outlining map preview"
+                      className="h-full w-full select-none object-contain"
+                      draggable={false}
+                    />
+                    <svg className="pointer-events-none absolute inset-0 h-full w-full" viewBox="0 0 1000 1000" preserveAspectRatio="none">
+                      {rooms.map((room) => {
+                        const isActive = room.id === activeRoomId;
+                        const polygonPoints = room.polygon.map((point) => `${point.x * 1000},${point.y * 1000}`).join(' ');
+                        const center = computeCentroid(room.polygon);
+                        return (
+                          <g key={room.id}>
+                            <polygon
+                              points={polygonPoints}
+                              fill={isActive ? 'rgba(45, 212, 191, 0.28)' : 'rgba(59, 130, 246, 0.22)'}
+                              stroke={isActive ? 'rgba(45, 212, 191, 0.9)' : 'rgba(148, 163, 184, 0.9)'}
+                              strokeWidth={isActive ? 6 : 4}
+                            />
+                            <text
+                              x={center.x * 1000}
+                              y={center.y * 1000}
+                              textAnchor="middle"
+                              dominantBaseline="middle"
+                              className="fill-white text-[26px] font-semibold"
+                              opacity={0.9}
+                            >
+                              {room.name || 'Room'}
+                            </text>
+                          </g>
+                        );
+                      })}
+                      {draftRoomPoints.length > 1 && (
+                        <polyline
+                          points={[...draftRoomPoints, draftRoomPoints[0]].map((point) => `${point.x * 1000},${point.y * 1000}`).join(' ')}
+                          fill="rgba(45, 212, 191, 0.18)"
+                          stroke="rgba(45, 212, 191, 0.8)"
+                          strokeWidth={5}
+                          strokeLinejoin="round"
+                          strokeLinecap="round"
+                        />
+                      )}
+                      {draftRoomPoints.length === 1 && (
+                        <circle cx={draftRoomPoints[0].x * 1000} cy={draftRoomPoints[0].y * 1000} r={12} fill="rgba(45, 212, 191, 0.8)" />
+                      )}
+                    </svg>
+                    {isOutliningRoom && (
+                      <button
+                        type="button"
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          handleCancelRoomOutline();
+                        }}
+                        className="absolute left-4 top-4 rounded-full border border-rose-400/60 bg-rose-500/20 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.3em] text-rose-200 transition hover:bg-rose-500/30"
+                      >
+                        Cancel Outline
+                      </button>
+                    )}
+                    {isOutliningRoom && !isDrawingRoom && (
+                      <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+                        <div className="rounded-xl border border-teal-400/50 bg-slate-950/80 px-5 py-4 text-center text-[10px] uppercase tracking-[0.35em] text-teal-100">
+                          Click and drag to outline the room with the {selectedRoomTool === 'smart' ? 'smart select' : 'lasso'} tool
+                        </div>
+                      </div>
+                    )}
+                    {activeRoom && (
+                      <div
+                        className="pointer-events-auto absolute z-20 w-80 max-w-[90%] -translate-x-1/2 -translate-y-full rounded-2xl border border-teal-400/40 bg-slate-950/95 p-4 shadow-2xl"
+                        style={{
+                          left: `${clamp(activeRoomCenter.x, 0.12, 0.88) * 100}%`,
+                          top: `${clamp(activeRoomCenter.y, 0.18, 0.85) * 100}%`,
+                        }}
+                        onPointerDown={(event) => event.stopPropagation()}
+                        onClick={(event) => event.stopPropagation()}
+                      >
+                        <div className="flex items-start justify-between gap-3">
+                          <div>
+                            <p className="text-[10px] uppercase tracking-[0.35em] text-teal-300">Room Details</p>
+                            <h4 className="mt-1 text-sm font-semibold text-white">{activeRoom.name || 'Unnamed Area'}</h4>
+                          </div>
+                          <button
+                            type="button"
+                            onClick={() => handleAutoSnapRoom(activeRoom.id)}
+                            className="rounded-full border border-teal-400/60 px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.3em] text-teal-100 transition hover:bg-teal-400/20"
+                          >
+                            Auto Snap
+                          </button>
+                        </div>
+                        <label className="mt-3 block text-[10px] uppercase tracking-[0.35em] text-slate-400">
+                          Area Name
+                          <input
+                            type="text"
+                            value={activeRoom.name}
+                            onChange={(event) => handleRoomFieldChange(activeRoom.id, 'name', event.target.value)}
+                            className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-3 py-2 text-xs text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                            placeholder="Hallway A"
+                          />
+                        </label>
+                        <label className="mt-3 block text-[10px] uppercase tracking-[0.35em] text-slate-400">
+                          Tags
+                          <input
+                            type="text"
+                            value={activeRoom.tagsInput}
+                            onChange={(event) => handleRoomFieldChange(activeRoom.id, 'tagsInput', event.target.value)}
+                            className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-3 py-2 text-xs text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                            placeholder="hallway, treasure, trap"
+                          />
+                        </label>
+                        <label className="mt-3 block text-[10px] uppercase tracking-[0.35em] text-slate-400">
+                          Notes
+                          <textarea
+                            value={activeRoom.notes}
+                            onChange={(event) => handleRoomFieldChange(activeRoom.id, 'notes', event.target.value)}
+                            rows={3}
+                            className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-3 py-2 text-xs text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                            placeholder="Hidden lever opens the passage."
+                          />
+                        </label>
+                        <label className="mt-4 flex items-center gap-2 text-[10px] uppercase tracking-[0.35em] text-slate-400">
+                          <input
+                            type="checkbox"
+                            checked={activeRoom.isVisible}
+                            onChange={(event) => handleRoomVisibilityToggle(activeRoom.id, event.target.checked)}
+                            className="h-4 w-4 rounded border-slate-700 bg-slate-900 text-teal-400 focus:ring-teal-400"
+                          />
+                          Visible to players at start
+                        </label>
+                        <div className="mt-4 flex justify-end">
+                          <button
+                            type="button"
+                            onClick={() => setActiveRoomId(null)}
+                            className="rounded-full border border-slate-700/70 px-4 py-2 text-[10px] font-semibold uppercase tracking-[0.3em] text-slate-300 transition hover:border-teal-400/60 hover:text-teal-100"
+                          >
+                            Done
+                          </button>
+                        </div>
+                      </div>
+                    )}
+                  </>
+                ) : (
+                  <div className="flex h-full w-full items-center justify-center text-sm text-slate-400">
+                    Upload a map image to outline rooms.
+                  </div>
+                )}
+              </div>
+              <div className="flex flex-col rounded-3xl border border-slate-800/70 bg-slate-900/70">
+                <div className="border-b border-slate-800/70 p-5">
+                  <p className="text-xs uppercase tracking-[0.4em] text-slate-400">Rooms &amp; Hallways</p>
+                  <h3 className="text-lg font-semibold text-white">Manage hidden areas</h3>
+                  <p className="mt-2 text-xs text-slate-500">
+                    Select a region on the map to edit its details, tags, or visibility.
+                  </p>
+                </div>
+                <div className="flex-1 space-y-3 overflow-auto p-5">
+                  {rooms.map((room) => {
+                    const roomTags = parseTagsInput(room.tagsInput);
+                    const isActive = room.id === activeRoomId;
+                    return (
+                      <div
+                        key={room.id}
+                        className={`flex items-start justify-between gap-3 rounded-2xl border px-4 py-3 text-sm transition ${
+                          isActive
+                            ? 'border-teal-400/70 bg-teal-500/10 text-teal-100'
+                            : 'border-slate-800/70 bg-slate-950/70 text-slate-300'
+                        }`}
+                      >
+                        <div>
+                          <button
+                            type="button"
+                            className="text-left text-sm font-semibold text-white hover:underline"
+                            onClick={() => setActiveRoomId(room.id)}
+                          >
+                            {room.name || 'Unnamed Area'}
+                          </button>
+                          {roomTags.length > 0 && (
+                            <p className="mt-1 text-[11px] uppercase tracking-[0.35em] text-slate-400">
+                              Tags: {roomTags.join(', ')}
+                            </p>
+                          )}
+                          {room.notes && <p className="mt-1 text-xs text-slate-400">{room.notes}</p>}
+                          {room.isVisible && (
+                            <span className="mt-2 inline-flex rounded-full border border-amber-400/60 bg-amber-500/20 px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.3em] text-amber-200">
+                              Visible to players
+                            </span>
+                          )}
+                        </div>
+                        <div className="flex flex-col gap-2 text-[10px] uppercase tracking-[0.3em]">
+                          <button
+                            type="button"
+                            onClick={() => setActiveRoomId(room.id)}
+                            className="rounded-full border border-teal-400/60 px-3 py-1 text-teal-100 transition hover:bg-teal-400/20"
+                          >
+                            Edit
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => handleRemoveRoom(room.id)}
+                            className="rounded-full border border-rose-400/60 px-3 py-1 text-rose-200 transition hover:bg-rose-500/20"
+                          >
+                            Remove
+                          </button>
+                        </div>
+                      </div>
+                    );
+                  })}
+                  {rooms.length === 0 && (
+                    <div className="rounded-2xl border border-dashed border-slate-700/70 px-4 py-10 text-center text-xs text-slate-500">
+                      Add rooms to control what players can see on the map.
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+        {step === 3 && (
+          <div className="flex h-full flex-col">
             <div className="mb-6 grid flex-1 gap-6 lg:grid-cols-[minmax(0,1fr)_360px]">
               <div
                 ref={mapAreaRef}
@@ -485,7 +1101,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({ campaign, onClose
                   <div className="flex items-center justify-between">
                     <div>
                       <p className="text-xs uppercase tracking-[0.4em] text-slate-400">Markers</p>
-                      <h3 className="text-lg font-semibold text-white">Drag & Drop Points</h3>
+                      <h3 className="text-lg font-semibold text-white">Drag &amp; Drop Points</h3>
                     </div>
                     <button
                       type="button"


### PR DESCRIPTION
## Summary
- add a Define Rooms step to the map creation wizard with room outlining tools, editing overlays, and visibility controls
- store outlined room details in map metadata and create matching regions when the map is saved
- return the created regions to the app so the new map immediately reflects its defined areas

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cdab2e0ba88323a4be323b3dd94b3b