### PR TITLE
Add dropdown room tools with paintbrush and wand modes

### DIFF
--- a/apps/pages/src/components/roomToolOptions.test.ts
+++ b/apps/pages/src/components/roomToolOptions.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_ROOM_TOOL,
+  ROOM_TOOL_INSTRUCTIONS,
+  ROOM_TOOL_OPTIONS,
+  type RoomToolOption,
+} from './roomToolOptions';
+
+describe('roomToolOptions', () => {
+  it('defines the expected tool identifiers', () => {
+    const ids = ROOM_TOOL_OPTIONS.map((option) => option.id);
+    expect(ids).toEqual(['lasso', 'smartSnap', 'paintbrush', 'smartWand']);
+  });
+
+  it('provides instructions for every tool option', () => {
+    ROOM_TOOL_OPTIONS.forEach((option: RoomToolOption) => {
+      expect(ROOM_TOOL_INSTRUCTIONS[option.id]).toBeTruthy();
+    });
+  });
+
+  it('defaults to the lasso tool', () => {
+    expect(DEFAULT_ROOM_TOOL).toBe('lasso');
+  });
+});

--- a/apps/pages/src/components/roomToolOptions.ts
+++ b/apps/pages/src/components/roomToolOptions.ts
@@ -1,0 +1,47 @@
+export type RoomTool = 'lasso' | 'smartSnap' | 'paintbrush' | 'smartWand';
+
+export interface RoomToolOption {
+  id: RoomTool;
+  label: string;
+  description: string;
+  tooltip: string;
+}
+
+export const ROOM_TOOL_OPTIONS: RoomToolOption[] = [
+  {
+    id: 'lasso',
+    label: 'Lasso Outline',
+    description: 'Draw freehand boundaries for irregular rooms and corridors.',
+    tooltip: 'Sketch the perimeter manually with a freehand lasso.',
+  },
+  {
+    id: 'smartSnap',
+    label: 'Smart Snap',
+    description: 'Rough in the outline and let edges snap to nearby walls.',
+    tooltip: 'Trace the area and we will pull the boundary to strong edges.',
+  },
+  {
+    id: 'paintbrush',
+    label: 'Paintbrush Fill',
+    description: 'Paint over the area to generate a smooth outline automatically.',
+    tooltip: 'Brush over the space; we will convert the stroke to a room.',
+  },
+  {
+    id: 'smartWand',
+    label: 'Smart Wand',
+    description: 'Click inside a space to grow a selection that hugs the walls.',
+    tooltip: 'Click once and the wand will try to detect the room for you.',
+  },
+];
+
+export const DEFAULT_ROOM_TOOL: RoomTool = 'lasso';
+
+export const ROOM_TOOL_INSTRUCTIONS: Record<RoomTool, string> = {
+  lasso: 'Click and drag to trace the room with the lasso tool.',
+  smartSnap: 'Sketch the rough outline—the smart snap tool will cling to walls.',
+  paintbrush: 'Paint over the area to capture it; lift your cursor to finish.',
+  smartWand: 'Click inside a room to let the smart wand outline it automatically.',
+};
+
+export const getRoomToolOption = (tool: RoomTool) =>
+  ROOM_TOOL_OPTIONS.find((option) => option.id === tool) ?? ROOM_TOOL_OPTIONS[0];

--- a/apps/pages/src/utils/roomToolUtils.test.ts
+++ b/apps/pages/src/utils/roomToolUtils.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import type { EdgeMap } from './imageProcessing';
+import {
+  applyBrushToMask,
+  dilateMask,
+  extractLargestPolygonFromMask,
+  floodFillRoomMask,
+  type RasterImageData,
+} from './roomToolUtils';
+
+describe('roomToolUtils', () => {
+  it('converts a brushed mask into a polygon', () => {
+    const width = 16;
+    const height = 16;
+    const mask = new Uint8Array(width * height);
+    applyBrushToMask(mask, width, height, 8, 8, 3);
+    const dilated = dilateMask(mask, width, height, 2);
+    const polygon = extractLargestPolygonFromMask(dilated, width, height);
+    expect(polygon.length).toBeGreaterThanOrEqual(4);
+    polygon.forEach((point) => {
+      expect(point.x).toBeGreaterThanOrEqual(0);
+      expect(point.x).toBeLessThanOrEqual(1);
+      expect(point.y).toBeGreaterThanOrEqual(0);
+      expect(point.y).toBeLessThanOrEqual(1);
+    });
+  });
+
+  it('extracts the dominant region when multiple polygons exist', () => {
+    const width = 8;
+    const height = 8;
+    const mask = new Uint8Array(width * height);
+    // Fill two regions, one larger than the other.
+    for (let y = 1; y <= 5; y += 1) {
+      for (let x = 1; x <= 4; x += 1) {
+        mask[y * width + x] = 1;
+      }
+    }
+    for (let y = 6; y < height; y += 1) {
+      for (let x = 6; x < width; x += 1) {
+        mask[y * width + x] = 1;
+      }
+    }
+    const polygon = extractLargestPolygonFromMask(mask, width, height);
+    expect(polygon.length).toBeGreaterThan(0);
+    const area = polygon.reduce((acc, point, index) => {
+      const next = polygon[(index + 1) % polygon.length];
+      return acc + point.x * next.y - next.x * point.y;
+    }, 0);
+    expect(Math.abs(area)).toBeGreaterThan(0.01);
+  });
+
+  it('performs a flood fill that respects edge map gradients', () => {
+    const width = 4;
+    const height = 4;
+    const data = new Uint8ClampedArray(width * height * 4);
+    for (let y = 0; y < height; y += 1) {
+      for (let x = 0; x < width; x += 1) {
+        const offset = (y * width + x) * 4;
+        const value = x < 2 ? 40 : 180;
+        data[offset] = value;
+        data[offset + 1] = value;
+        data[offset + 2] = value;
+        data[offset + 3] = 255;
+      }
+    }
+    const raster: RasterImageData = { width, height, data };
+    const magnitudes = new Float32Array(width * height);
+    for (let y = 0; y < height; y += 1) {
+      const wallIndex = y * width + 2;
+      magnitudes[wallIndex] = 1;
+    }
+    const edgeMap: EdgeMap = {
+      width,
+      height,
+      magnitudes,
+      gradientX: new Float32Array(width * height),
+      gradientY: new Float32Array(width * height),
+      maxMagnitude: 1,
+    };
+    const result = floodFillRoomMask(raster, edgeMap, 0, 0, {
+      colorTolerance: 30,
+      gradientThreshold: 0.5,
+    });
+    expect(result).not.toBeNull();
+    expect(result!.count).toBe(8);
+    const polygon = extractLargestPolygonFromMask(result!.mask, width, height);
+    expect(polygon.length).toBeGreaterThanOrEqual(4);
+  });
+});

--- a/apps/pages/src/utils/roomToolUtils.ts
+++ b/apps/pages/src/utils/roomToolUtils.ts
@@ -1,0 +1,305 @@
+import type { EdgeMap } from './imageProcessing';
+
+export interface RasterImageData {
+  width: number;
+  height: number;
+  data: Uint8ClampedArray;
+}
+
+export const applyBrushToMask = (
+  mask: Uint8Array,
+  width: number,
+  height: number,
+  centerX: number,
+  centerY: number,
+  radius: number
+) => {
+  if (!mask || width <= 0 || height <= 0 || radius <= 0) return;
+  const minY = Math.max(0, Math.floor(centerY - radius));
+  const maxY = Math.min(height - 1, Math.ceil(centerY + radius));
+  const radiusSquared = radius * radius;
+  for (let y = minY; y <= maxY; y += 1) {
+    const dy = y - centerY;
+    const dxLimit = Math.sqrt(Math.max(radiusSquared - dy * dy, 0));
+    const minX = Math.max(0, Math.floor(centerX - dxLimit));
+    const maxX = Math.min(width - 1, Math.ceil(centerX + dxLimit));
+    for (let x = minX; x <= maxX; x += 1) {
+      mask[y * width + x] = 1;
+    }
+  }
+};
+
+export const dilateMask = (mask: Uint8Array, width: number, height: number, radius: number) => {
+  if (!mask || width <= 0 || height <= 0 || radius <= 0) {
+    return mask;
+  }
+  const result = new Uint8Array(mask); // copy existing mask
+  const radiusCeil = Math.max(1, Math.ceil(radius));
+  const radiusSquared = radius * radius;
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      if (!mask[y * width + x]) continue;
+      const minY = Math.max(0, y - radiusCeil);
+      const maxY = Math.min(height - 1, y + radiusCeil);
+      for (let ny = minY; ny <= maxY; ny += 1) {
+        const dy = ny - y;
+        const dxLimit = Math.sqrt(Math.max(radiusSquared - dy * dy, 0));
+        const minX = Math.max(0, Math.floor(x - dxLimit));
+        const maxX = Math.min(width - 1, Math.ceil(x + dxLimit));
+        for (let nx = minX; nx <= maxX; nx += 1) {
+          result[ny * width + nx] = 1;
+        }
+      }
+    }
+  }
+  return result;
+};
+
+interface Point {
+  x: number;
+  y: number;
+}
+
+const pointKey = (point: Point) => `${point.x},${point.y}`;
+
+const computePolygonArea = (points: Point[]) => {
+  if (points.length < 3) return 0;
+  let area = 0;
+  for (let i = 0; i < points.length; i += 1) {
+    const current = points[i];
+    const next = points[(i + 1) % points.length];
+    area += current.x * next.y - next.x * current.y;
+  }
+  return area / 2;
+};
+
+export const extractLargestPolygonFromMask = (
+  mask: Uint8Array,
+  width: number,
+  height: number
+): Array<{ x: number; y: number }> => {
+  if (!mask || width <= 0 || height <= 0) return [];
+
+  const inside = (x: number, y: number) => {
+    if (x < 0 || x >= width || y < 0 || y >= height) return 0;
+    return mask[y * width + x];
+  };
+
+  interface Edge {
+    start: Point;
+    end: Point;
+  }
+
+  const edges: Edge[] = [];
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      if (!inside(x, y)) continue;
+      if (!inside(x, y - 1)) {
+        edges.push({ start: { x, y }, end: { x: x + 1, y } });
+      }
+      if (!inside(x + 1, y)) {
+        edges.push({ start: { x: x + 1, y }, end: { x: x + 1, y: y + 1 } });
+      }
+      if (!inside(x, y + 1)) {
+        edges.push({ start: { x: x + 1, y: y + 1 }, end: { x, y: y + 1 } });
+      }
+      if (!inside(x - 1, y)) {
+        edges.push({ start: { x, y: y + 1 }, end: { x, y } });
+      }
+    }
+  }
+
+  if (edges.length === 0) {
+    return [];
+  }
+
+  const adjacency = new Map<string, Array<{ edgeIndex: number; end: Point }>>();
+  edges.forEach((edge, index) => {
+    const key = pointKey(edge.start);
+    const bucket = adjacency.get(key);
+    if (bucket) {
+      bucket.push({ edgeIndex: index, end: edge.end });
+    } else {
+      adjacency.set(key, [{ edgeIndex: index, end: edge.end }]);
+    }
+  });
+
+  const used = new Array<boolean>(edges.length).fill(false);
+  const loops: Point[][] = [];
+
+  for (let startIndex = 0; startIndex < edges.length; startIndex += 1) {
+    if (used[startIndex]) continue;
+    const loop: Point[] = [];
+    let currentEdgeIndex = startIndex;
+    const startEdge = edges[startIndex];
+    const startKey = pointKey(startEdge.start);
+    let safeguard = edges.length * 4;
+
+    while (safeguard > 0) {
+      safeguard -= 1;
+      const edge = edges[currentEdgeIndex];
+      if (used[currentEdgeIndex]) break;
+      used[currentEdgeIndex] = true;
+      loop.push(edge.start);
+      const nextKey = pointKey(edge.end);
+      if (nextKey === startKey) {
+        loop.push(edge.end);
+        break;
+      }
+      const candidates = adjacency.get(nextKey);
+      if (!candidates) break;
+      let nextEdge: { edgeIndex: number; end: Point } | null = null;
+      for (const candidate of candidates) {
+        if (!used[candidate.edgeIndex]) {
+          nextEdge = candidate;
+          break;
+        }
+      }
+      if (!nextEdge) break;
+      currentEdgeIndex = nextEdge.edgeIndex;
+    }
+
+    if (loop.length >= 3) {
+      // Remove duplicate trailing point if it matches the first entry.
+      if (loop.length > 1) {
+        const first = loop[0];
+        const last = loop[loop.length - 1];
+        if (first.x === last.x && first.y === last.y) {
+          loop.pop();
+        }
+      }
+      // Remove immediate duplicates.
+      const filtered: Point[] = [];
+      for (const point of loop) {
+        const prev = filtered[filtered.length - 1];
+        if (!prev || prev.x !== point.x || prev.y !== point.y) {
+          filtered.push(point);
+        }
+      }
+      if (filtered.length >= 3) {
+        loops.push(filtered);
+      }
+    }
+  }
+
+  if (loops.length === 0) {
+    return [];
+  }
+
+  loops.sort((a, b) => Math.abs(computePolygonArea(b)) - Math.abs(computePolygonArea(a)));
+  const best = loops[0];
+  const area = computePolygonArea(best);
+  const oriented = area < 0 ? [...best].reverse() : best;
+
+  return oriented.map((point) => ({
+    x: point.x / width,
+    y: point.y / height,
+  }));
+};
+
+export interface FloodFillOptions {
+  colorTolerance?: number;
+  gradientThreshold?: number;
+  maxPixels?: number;
+}
+
+export interface FloodFillResult {
+  mask: Uint8Array;
+  count: number;
+}
+
+const computeColorDistance = (
+  data: Uint8ClampedArray,
+  index: number,
+  base: [number, number, number]
+) => {
+  const offset = index * 4;
+  const dr = data[offset] - base[0];
+  const dg = data[offset + 1] - base[1];
+  const db = data[offset + 2] - base[2];
+  return Math.sqrt(dr * dr + dg * dg + db * db);
+};
+
+export const floodFillRoomMask = (
+  raster: RasterImageData,
+  edgeMap: EdgeMap | null,
+  startX: number,
+  startY: number,
+  options: FloodFillOptions = {}
+): FloodFillResult | null => {
+  const { width, height, data } = raster;
+  if (width <= 0 || height <= 0) return null;
+  if (startX < 0 || startX >= width || startY < 0 || startY >= height) return null;
+
+  const startIndex = startY * width + startX;
+  const totalPixels = width * height;
+  const visited = new Uint8Array(totalPixels);
+  const mask = new Uint8Array(totalPixels);
+  const baseColor: [number, number, number] = [
+    data[startIndex * 4],
+    data[startIndex * 4 + 1],
+    data[startIndex * 4 + 2],
+  ];
+
+  const colorTolerance = options.colorTolerance ?? 42;
+  const gradientThreshold = options.gradientThreshold ?? (edgeMap ? edgeMap.maxMagnitude * 0.32 : Infinity);
+  const maxPixels = options.maxPixels ?? Math.max(512, Math.floor(totalPixels * 0.55));
+
+  const queue = new Uint32Array(totalPixels);
+  let head = 0;
+  let tail = 0;
+  queue[tail] = startIndex;
+  tail += 1;
+  let filled = 0;
+
+  const push = (index: number) => {
+    if (visited[index]) return;
+    queue[tail] = index;
+    tail += 1;
+  };
+
+  while (head < tail) {
+    const index = queue[head];
+    head += 1;
+    if (visited[index]) continue;
+    visited[index] = 1;
+
+    const gradient = edgeMap ? edgeMap.magnitudes[index] : 0;
+    if (gradient > gradientThreshold) {
+      continue;
+    }
+
+    const colorDistance = computeColorDistance(data, index, baseColor);
+    if (colorDistance > colorTolerance) {
+      continue;
+    }
+
+    mask[index] = 1;
+    filled += 1;
+    if (filled >= maxPixels) {
+      break;
+    }
+
+    const x = index % width;
+    const y = Math.floor(index / width);
+    const neighbors: Array<[number, number]> = [
+      [x + 1, y],
+      [x - 1, y],
+      [x, y + 1],
+      [x, y - 1],
+    ];
+    for (const [nx, ny] of neighbors) {
+      if (nx < 0 || nx >= width || ny < 0 || ny >= height) continue;
+      const neighborIndex = ny * width + nx;
+      if (visited[neighborIndex]) continue;
+      if (edgeMap && edgeMap.magnitudes[neighborIndex] > gradientThreshold) continue;
+      push(neighborIndex);
+    }
+  }
+
+  if (filled < 4) {
+    return null;
+  }
+
+  return { mask, count: filled };
+};


### PR DESCRIPTION
## Summary
- expand the map creation wizard to track lasso, smart snap, paintbrush, and smart wand tools, storing source image data and handling new outlining behaviours
- replace the inline tool pills with an Add Room dropdown, refreshed instructions, and shared tool metadata
- add raster mask utilities plus Vitest coverage for the tool catalogue and mask-to-polygon and flood fill helpers

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68cdfd1d24848323a2315e2ca70c681f