### PR TITLE
Support paintbrush add/erase mode in MapCreationWizard

### DIFF
--- a/apps/pages/src/utils/roomToolUtils.test.ts
+++ b/apps/pages/src/utils/roomToolUtils.test.ts
@@ -25,6 +25,21 @@ describe('roomToolUtils', () => {
     });
   });
 
+  it('supports erasing pixels from an existing mask', () => {
+    const width = 12;
+    const height = 12;
+    const mask = new Uint8Array(width * height);
+    applyBrushToMask(mask, width, height, 6, 6, 3, 'add');
+    let filled = 0;
+    mask.forEach((value) => {
+      if (value) filled += 1;
+    });
+    expect(filled).toBeGreaterThan(0);
+    applyBrushToMask(mask, width, height, 6, 6, 2, 'erase');
+    const remaining = mask.reduce((count, value) => count + value, 0);
+    expect(remaining).toBeLessThan(filled);
+  });
+
   it('extracts the dominant region when multiple polygons exist', () => {
     const width = 8;
     const height = 8;

--- a/apps/pages/src/utils/roomToolUtils.ts
+++ b/apps/pages/src/utils/roomToolUtils.ts
@@ -8,25 +8,29 @@ export interface RasterImageData {
   data: Uint8ClampedArray;
 }
 
+export type BrushMode = 'add' | 'erase';
+
 export const applyBrushToMask = (
   mask: Uint8Array,
   width: number,
   height: number,
   centerX: number,
   centerY: number,
-  radius: number
+  radius: number,
+  mode: BrushMode = 'add'
 ) => {
   if (!mask || width <= 0 || height <= 0 || radius <= 0) return;
   const minY = Math.max(0, Math.floor(centerY - radius));
   const maxY = Math.min(height - 1, Math.ceil(centerY + radius));
   const radiusSquared = radius * radius;
+  const value = mode === 'add' ? 1 : 0;
   for (let y = minY; y <= maxY; y += 1) {
     const dy = y - centerY;
     const dxLimit = Math.sqrt(Math.max(radiusSquared - dy * dy, 0));
     const minX = Math.max(0, Math.floor(centerX - dxLimit));
     const maxX = Math.min(width - 1, Math.ceil(centerX + dxLimit));
     for (let x = minX; x <= maxX; x += 1) {
-      mask[y * width + x] = 1;
+      mask[y * width + x] = value;
     }
   }
 };


### PR DESCRIPTION
## Summary
- detect pointer button presses to set paintbrush add vs. erase strokes, reuse the existing mask, and update the draft outline from the evolving mask
- add a brush mode parameter to applyBrushToMask and cover erasing behavior with unit tests

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d19d7b3aa483239d4f3494b73da695