### PR TITLE
feat: add landing page experience for unauthenticated users

### DIFF
--- a/apps/pages/src/App.tsx
+++ b/apps/pages/src/App.tsx
@@ -1,10 +1,10 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import AuthPanel from './components/AuthPanel';
 import SessionViewer from './components/SessionViewer';
 import MapMaskCanvas from './components/MapMaskCanvas';
 import { apiClient } from './api/client';
 import MapCreationWizard from './components/MapCreationWizard';
 import MapFolderList from './components/MapFolderList';
+import LandingPage from './components/LandingPage';
 import type {
   AuthResponse,
   Campaign,
@@ -405,22 +405,7 @@ const App: React.FC = () => {
     }`;
 
   if (!token || !user) {
-    return (
-      <div className="min-h-screen bg-gradient-to-br from-slate-100 via-white to-slate-200 dark:from-slate-900 dark:via-slate-950 dark:to-slate-900">
-        <header className="px-6 py-4">
-          <div className="mx-auto flex max-w-4xl items-center justify-between">
-            <h1 className="text-2xl font-bold text-primary">TITLE</h1>
-            <button
-              className="rounded-full border border-slate-300 px-3 py-1 text-xs text-slate-600 hover:bg-slate-200 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800"
-              onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
-            >
-              {themeLabel}
-            </button>
-          </div>
-        </header>
-        <AuthPanel onAuthenticate={handleAuthenticated} />
-      </div>
-    );
+    return <LandingPage theme={theme} setTheme={setTheme} onAuthenticate={handleAuthenticated} />;
   }
 
   if (activeSession) {

--- a/apps/pages/src/components/AuthPanel.tsx
+++ b/apps/pages/src/components/AuthPanel.tsx
@@ -1,11 +1,18 @@
-import React, { useState } from 'react';
+import React, { useId, useState } from 'react';
 import type { AuthResponse } from '../types';
+
+type AuthPanelVariant = 'default' | 'wide';
 
 interface AuthPanelProps {
   onAuthenticate: (response: AuthResponse) => Promise<void> | void;
+  className?: string;
+  variant?: AuthPanelVariant;
 }
 
-const AuthPanel: React.FC<AuthPanelProps> = ({ onAuthenticate }) => {
+const classNames = (...classes: Array<string | false | null | undefined>) =>
+  classes.filter(Boolean).join(' ');
+
+const AuthPanel: React.FC<AuthPanelProps> = ({ onAuthenticate, className, variant = 'default' }) => {
   const [mode, setMode] = useState<'login' | 'signup'>('login');
   const [email, setEmail] = useState('demo@dandmaps.example');
   const [password, setPassword] = useState('demo-password');
@@ -13,15 +20,19 @@ const AuthPanel: React.FC<AuthPanelProps> = ({ onAuthenticate }) => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  const formId = useId();
+  const emailId = `${formId}-email`;
+  const passwordId = `${formId}-password`;
+  const displayNameId = `${formId}-display-name`;
+  const errorId = `${formId}-error`;
+
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
     setLoading(true);
     setError(null);
     try {
       const response = await (mode === 'login'
-        ? import('../api/client').then(({ apiClient }) =>
-            apiClient.login({ email, password })
-          )
+        ? import('../api/client').then(({ apiClient }) => apiClient.login({ email, password }))
         : import('../api/client').then(({ apiClient }) =>
             apiClient.signup({ email, password, displayName })
           ));
@@ -33,62 +44,120 @@ const AuthPanel: React.FC<AuthPanelProps> = ({ onAuthenticate }) => {
     }
   };
 
+  const containerClasses = classNames(
+    'relative w-full overflow-hidden rounded-3xl border border-slate-200/80 bg-white/80 p-8 shadow-xl shadow-slate-200/60 backdrop-blur-sm transition-colors dark:border-slate-800/60 dark:bg-slate-900/80 dark:shadow-black/40 sm:p-10',
+    variant === 'default' ? 'mx-auto max-w-md' : '',
+    className
+  );
+
+  const badgeText = mode === 'login' ? 'Return to the table' : 'Create a DM profile';
+  const headingText = mode === 'login' ? 'Sign in to D&D Map Reveal' : 'Join the D&D Map Reveal beta';
+  const submitLabel = loading ? 'Please wait…' : mode === 'login' ? 'Log in' : 'Sign up';
+  const toggleLabel = mode === 'login' ? 'Need an account?' : 'Already have an account?';
+  const toggleHelper = mode === 'login' ? 'Create one instead' : 'Use your existing login';
+
   return (
-    <div className="mx-auto mt-16 max-w-md rounded-lg border border-slate-300 bg-white p-6 shadow-lg dark:border-slate-700 dark:bg-slate-800">
-      <div className="mb-6 flex items-center justify-between">
-        <h1 className="text-xl font-semibold text-slate-900 dark:text-white">
-          {mode === 'login' ? 'Log in' : 'Create account'}
-        </h1>
-        <button
-          type="button"
-          onClick={() => setMode(mode === 'login' ? 'signup' : 'login')}
-          className="text-sm text-primary hover:underline"
-        >
-          {mode === 'login' ? 'Need an account?' : 'Already have an account?'}
-        </button>
-      </div>
-      <form onSubmit={handleSubmit} className="space-y-4">
-        <div>
-          <label className="mb-1 block text-sm font-medium">Email</label>
-          <input
-            type="email"
-            value={email}
-            onChange={(event) => setEmail(event.target.value)}
-            className="w-full rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:outline-none dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100"
-            required
-          />
-        </div>
-        {mode === 'signup' && (
-          <div>
-            <label className="mb-1 block text-sm font-medium">Display name</label>
-            <input
-              value={displayName}
-              onChange={(event) => setDisplayName(event.target.value)}
-              className="w-full rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:outline-none dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100"
-              required
-            />
+    <section className={containerClasses} aria-labelledby={`${formId}-title`}>
+      <span
+        aria-hidden
+        className="pointer-events-none absolute -top-28 left-1/2 h-72 w-72 -translate-x-1/2 rounded-full bg-teal-400/20 blur-3xl dark:bg-teal-500/10"
+      />
+      <div className="relative space-y-8">
+        <header className="space-y-3">
+          <span className="inline-flex items-center rounded-full border border-teal-500/40 bg-teal-100/60 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.3em] text-teal-700 shadow-sm dark:border-teal-400/50 dark:bg-teal-500/10 dark:text-teal-200">
+            {badgeText}
+          </span>
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <div className="space-y-2">
+              <h2 id={`${formId}-title`} className="text-2xl font-semibold text-slate-900 dark:text-white">
+                {headingText}
+              </h2>
+              <p className="text-sm text-slate-600 dark:text-slate-300">
+                Use the pre-filled demo credentials or sign up with your own details to explore the DM console.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => setMode((current) => (current === 'login' ? 'signup' : 'login'))}
+              className="inline-flex items-center rounded-full border border-slate-300/70 bg-white/40 px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-slate-500 transition hover:border-teal-400/60 hover:text-teal-600 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-300 dark:hover:border-teal-400/50 dark:hover:text-teal-200"
+              aria-pressed={mode === 'signup'}
+            >
+              {toggleLabel}
+            </button>
           </div>
-        )}
-        <div>
-          <label className="mb-1 block text-sm font-medium">Password</label>
-          <input
-            type="password"
-            value={password}
-            onChange={(event) => setPassword(event.target.value)}
-            className="w-full rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary focus:outline-none dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100"
-            required
-          />
-        </div>
-        {error && <p className="text-sm text-rose-500">{error}</p>}
-        <button
-          type="submit"
-          disabled={loading}
-          className="flex w-full items-center justify-center rounded bg-primary px-4 py-2 text-sm font-medium text-white shadow hover:bg-primary-dark disabled:cursor-wait disabled:opacity-70"
+          <p className="text-xs uppercase tracking-[0.35em] text-slate-400 dark:text-slate-500">{toggleHelper}</p>
+        </header>
+        <form
+          id={formId}
+          onSubmit={handleSubmit}
+          aria-describedby={error ? errorId : undefined}
+          aria-busy={loading}
+          className="space-y-5"
+          noValidate
         >
-          {loading ? 'Please wait…' : mode === 'login' ? 'Log in' : 'Sign up'}
-        </button>
-      </form>
-    </div>
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <label htmlFor={emailId} className="text-sm font-medium text-slate-700 dark:text-slate-200">
+                Email
+              </label>
+              <input
+                id={emailId}
+                type="email"
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+                autoComplete="email"
+                className="w-full rounded-2xl border border-slate-300/80 bg-white px-4 py-3 text-sm font-medium text-slate-900 shadow-sm transition focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-400/60 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:focus:border-teal-400"
+                required
+              />
+            </div>
+            {mode === 'signup' && (
+              <div className="space-y-2">
+                <label htmlFor={displayNameId} className="text-sm font-medium text-slate-700 dark:text-slate-200">
+                  Display name
+                </label>
+                <input
+                  id={displayNameId}
+                  value={displayName}
+                  onChange={(event) => setDisplayName(event.target.value)}
+                  autoComplete="name"
+                  className="w-full rounded-2xl border border-slate-300/80 bg-white px-4 py-3 text-sm font-medium text-slate-900 shadow-sm transition focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-400/60 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:focus:border-teal-400"
+                  required
+                />
+              </div>
+            )}
+            <div className="space-y-2">
+              <label htmlFor={passwordId} className="text-sm font-medium text-slate-700 dark:text-slate-200">
+                Password
+              </label>
+              <input
+                id={passwordId}
+                type="password"
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+                autoComplete={mode === 'login' ? 'current-password' : 'new-password'}
+                className="w-full rounded-2xl border border-slate-300/80 bg-white px-4 py-3 text-sm font-medium text-slate-900 shadow-sm transition focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-400/60 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:focus:border-teal-400"
+                required
+              />
+            </div>
+          </div>
+          {error && (
+            <p id={errorId} role="alert" className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-2 text-sm text-rose-600 dark:border-rose-500/50 dark:bg-rose-500/10 dark:text-rose-200">
+              {error}
+            </p>
+          )}
+          <button
+            type="submit"
+            disabled={loading}
+            className="flex w-full items-center justify-center gap-2 rounded-2xl bg-gradient-to-r from-teal-500 via-sky-500 to-blue-500 px-5 py-3 text-sm font-semibold uppercase tracking-[0.4em] text-white shadow-lg shadow-teal-500/30 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-white/80 focus-visible:ring-offset-2 focus-visible:ring-offset-teal-500 disabled:cursor-wait disabled:opacity-80"
+          >
+            {submitLabel}
+          </button>
+        </form>
+        <p className="text-xs text-slate-500 dark:text-slate-400">
+          We respect your table: credentials are only used to authenticate with the demo API and never stored by this client.
+        </p>
+      </div>
+    </section>
   );
 };
 

--- a/apps/pages/src/components/LandingPage.tsx
+++ b/apps/pages/src/components/LandingPage.tsx
@@ -1,0 +1,138 @@
+import React from 'react';
+import type { AuthResponse } from '../types';
+import AuthPanel from './AuthPanel';
+
+interface LandingPageProps {
+  theme: 'light' | 'dark';
+  setTheme: React.Dispatch<React.SetStateAction<'light' | 'dark'>>;
+  onAuthenticate: (response: AuthResponse) => Promise<void> | void;
+}
+
+const features = [
+  {
+    title: 'Reveal maps live',
+    description: 'Fade in fog-of-war with precision tools built for dramatic reveals and on-the-fly adjustments.',
+    icon: '🗺️',
+  },
+  {
+    title: 'Campaign control',
+    description: 'Organise every battlemap, note and marker by campaign so your prep is ready when players arrive.',
+    icon: '🎯',
+  },
+  {
+    title: 'Share instantly',
+    description: 'Invite players with short join codes and let them explore revealed regions from any device.',
+    icon: '⚡',
+  },
+  {
+    title: 'Save your progress',
+    description: 'Archive live sessions and pick up where you left off without losing the dramatic tension.',
+    icon: '🛡️',
+  },
+];
+
+const LandingPage: React.FC<LandingPageProps> = ({ theme, setTheme, onAuthenticate }) => {
+  const themeLabel = theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode';
+
+  const handleThemeToggle = () => {
+    setTheme(theme === 'dark' ? 'light' : 'dark');
+  };
+
+  return (
+    <div className="bg-landing relative min-h-screen overflow-hidden text-slate-900 transition-colors dark:text-slate-100">
+      <div aria-hidden className="absolute inset-0 bg-grid-mask opacity-60 mix-blend-soft-light dark:opacity-40" />
+      <div aria-hidden className="pointer-events-none absolute -top-32 right-12 h-72 w-72 rounded-full bg-sky-400/30 blur-3xl dark:bg-sky-500/20 animate-float-slow" />
+      <div aria-hidden className="pointer-events-none absolute bottom-[-10rem] left-[-6rem] h-96 w-96 rounded-full bg-teal-400/20 blur-[120px] dark:bg-teal-500/20 animate-float-slow" />
+      <div className="relative isolate">
+        <header className="mx-auto flex max-w-7xl flex-wrap items-center justify-between gap-4 px-6 py-8 sm:py-10">
+          <div className="flex items-center gap-4">
+            <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-slate-900/90 text-2xl font-black text-teal-300 shadow-2xl shadow-teal-500/20 ring-4 ring-white/50 backdrop-blur dark:bg-white/10 dark:text-teal-200 dark:ring-teal-500/30">
+              DM
+            </div>
+            <div>
+              <p className="text-xs uppercase tracking-[0.45em] text-teal-600 dark:text-teal-300">D&D Map Reveal</p>
+              <p className="text-lg font-semibold text-slate-900 dark:text-slate-100">Fog-of-war built for dramatic storytelling</p>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={handleThemeToggle}
+            aria-pressed={theme === 'dark'}
+            className="inline-flex items-center gap-2 rounded-full border border-slate-300/70 bg-white/40 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-600 shadow-sm transition hover:border-teal-400/70 hover:text-teal-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-teal-400 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-200 dark:hover:border-teal-400/60 dark:hover:text-teal-200"
+          >
+            <span className="text-base" aria-hidden>
+              {theme === 'dark' ? '🌙' : '🌞'}
+            </span>
+            {themeLabel}
+          </button>
+        </header>
+        <main className="mx-auto grid max-w-7xl gap-16 px-6 pb-24 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,0.9fr)] lg:items-center">
+          <section className="space-y-10">
+            <div className="space-y-6">
+              <span className="inline-flex items-center rounded-full border border-teal-400/50 bg-teal-100/60 px-4 py-1 text-[11px] font-semibold uppercase tracking-[0.35em] text-teal-700 shadow-sm dark:border-teal-500/40 dark:bg-teal-500/10 dark:text-teal-200">
+                Your new DM co-pilot
+              </span>
+              <h1 className="text-4xl font-black tracking-tight text-slate-900 sm:text-5xl dark:text-white">
+                Guide your party through unforgettable encounters with cinematic map reveals.
+              </h1>
+              <p className="max-w-xl text-lg text-slate-600 dark:text-slate-300">
+                D&D Map Reveal keeps your battlemap prep organised and ready. Cue dramatic lighting, reveal regions in real time, and manage campaigns without breaking the table’s immersion.
+              </p>
+              <div className="flex flex-wrap items-center gap-4">
+                <a
+                  href="#auth-panel"
+                  className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-teal-500 via-sky-500 to-blue-500 px-6 py-3 text-xs font-semibold uppercase tracking-[0.45em] text-white shadow-lg shadow-teal-500/30 transition hover:scale-[1.02] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-teal-400"
+                >
+                  Launch the demo
+                </a>
+                <a
+                  href="#features"
+                  className="inline-flex items-center justify-center gap-2 rounded-full border border-slate-300/70 bg-white/60 px-6 py-3 text-xs font-semibold uppercase tracking-[0.35em] text-slate-600 transition hover:border-teal-400/60 hover:text-teal-600 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-200 dark:hover:border-teal-400/60 dark:hover:text-teal-200"
+                >
+                  Explore features
+                  <span aria-hidden>→</span>
+                </a>
+              </div>
+            </div>
+            <section id="features" className="grid gap-6 sm:grid-cols-2">
+              {features.map((feature) => (
+                <article
+                  key={feature.title}
+                  className="group relative overflow-hidden rounded-3xl border border-white/60 bg-white/80 p-6 shadow-lg shadow-slate-200/40 transition hover:-translate-y-1 hover:shadow-2xl dark:border-slate-800/70 dark:bg-slate-900/70 dark:shadow-black/40"
+                >
+                  <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-teal-500/20 to-sky-500/10 text-2xl">
+                    <span aria-hidden>{feature.icon}</span>
+                    <span className="sr-only">{feature.title} icon</span>
+                  </div>
+                  <h3 className="mt-4 text-lg font-semibold text-slate-900 dark:text-white">{feature.title}</h3>
+                  <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">{feature.description}</p>
+                  <div
+                    aria-hidden
+                    className="pointer-events-none absolute inset-0 translate-y-full bg-gradient-to-t from-teal-500/10 to-transparent transition duration-500 group-hover:translate-y-0"
+                  />
+                </article>
+              ))}
+            </section>
+          </section>
+          <aside className="relative">
+            <div aria-hidden className="absolute inset-0 -translate-y-6 rounded-[2.75rem] bg-white/50 blur-3xl dark:bg-slate-900/50" />
+            <div className="relative rounded-[2.5rem] border border-white/40 bg-white/60 p-1 shadow-2xl shadow-teal-500/10 backdrop-blur-xl dark:border-slate-800/60 dark:bg-slate-950/60">
+              <div className="absolute -top-16 right-10 h-24 w-24 rounded-full bg-gradient-to-br from-teal-400/40 to-sky-500/20 blur-3xl dark:from-teal-500/30 dark:to-sky-500/20 animate-gradient" aria-hidden />
+              <div className="absolute bottom-10 left-10 h-20 w-20 rounded-full bg-teal-400/20 blur-2xl dark:bg-teal-500/20 animate-float-slow" aria-hidden />
+              <AuthPanel
+                variant="wide"
+                className="border-transparent bg-white/80 shadow-none ring-1 ring-white/60 dark:bg-slate-950/70 dark:ring-teal-500/20"
+                onAuthenticate={onAuthenticate}
+              />
+            </div>
+            <p id="auth-panel" className="mt-6 text-center text-xs text-slate-500 dark:text-slate-400">
+              No spam, no credit card – just a guided tour of the DM mission control.
+            </p>
+          </aside>
+        </main>
+      </div>
+    </div>
+  );
+};
+
+export default LandingPage;

--- a/apps/pages/src/index.css
+++ b/apps/pages/src/index.css
@@ -17,3 +17,64 @@ button {
 body.dark {
   @apply bg-slate-900 text-slate-100;
 }
+
+@layer utilities {
+  .bg-landing {
+    background-image:
+      radial-gradient(circle at 10% -10%, rgba(56, 189, 248, 0.35), transparent 45%),
+      radial-gradient(circle at 80% 10%, rgba(20, 184, 166, 0.25), transparent 40%),
+      radial-gradient(circle at 0% 80%, rgba(14, 165, 233, 0.2), transparent 45%),
+      linear-gradient(135deg, #f8fafc 0%, #f1f5f9 50%, #e2e8f0 100%);
+  }
+
+  .dark .bg-landing {
+    background-image:
+      radial-gradient(circle at 15% -10%, rgba(56, 189, 248, 0.2), transparent 45%),
+      radial-gradient(circle at 85% 15%, rgba(37, 99, 235, 0.18), transparent 45%),
+      radial-gradient(circle at 10% 85%, rgba(45, 212, 191, 0.18), transparent 45%),
+      linear-gradient(135deg, #020617 0%, #0f172a 55%, #020617 100%);
+  }
+
+  .bg-grid-mask {
+    --grid-color: rgba(15, 23, 42, 0.08);
+    background-image:
+      linear-gradient(var(--grid-color) 1px, transparent 1px),
+      linear-gradient(90deg, var(--grid-color) 1px, transparent 1px);
+    background-size: 48px 48px;
+  }
+
+  .dark .bg-grid-mask {
+    --grid-color: rgba(148, 163, 184, 0.1);
+  }
+
+  .animate-gradient {
+    background-size: 220% 220%;
+    animation: gradientShift 18s ease infinite;
+  }
+
+  .animate-float-slow {
+    animation: floatSlow 14s ease-in-out infinite;
+  }
+}
+
+@keyframes gradientShift {
+  0% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
+  }
+}
+
+@keyframes floatSlow {
+  0%,
+  100% {
+    transform: translateY(0px) scale(1);
+  }
+  50% {
+    transform: translateY(-14px) scale(1.02);
+  }
+}


### PR DESCRIPTION
## Summary
- create a branded landing page hero with feature highlights and embedded authentication panel
- refactor the unauthenticated app branch to render the new landing page and pass through theme/auth handlers
- refresh the auth panel component API/styles and add utility gradients to support the new layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1b1d2d1ec8323b20349db1251f2aa