### PR TITLE
Reorder Smart Wand handler to avoid TDZ error

### DIFF
--- a/apps/pages/src/components/MapCreationWizard.tsx
+++ b/apps/pages/src/components/MapCreationWizard.tsx
@@ -868,30 +868,6 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({ campaign, onClose
     [vectorizePolygonWithWorker]
   );
 
-  const handleSmartWandSelection = useCallback(
-    (point: { x: number; y: number }) => {
-      const tool = smartWandToolRef.current;
-      const source = sourceImageRef.current;
-      if (!tool || !source) {
-        setIsOutliningRoom(false);
-        return;
-      }
-      drawingPointsRef.current = [];
-      setDraftRoomPoints([]);
-      setIsDrawingRoom(false);
-      const result = tool.select(point);
-      if (!result || result.polygon.length < 3) {
-        setIsOutliningRoom(false);
-        return;
-      }
-      const success = initializeSdfFromPolygon(result.polygon, { offsetPx: 5 });
-      if (!success) {
-        setIsOutliningRoom(false);
-      }
-    },
-    [initializeSdfFromPolygon]
-  );
-
   const updateDraftRoomFromSdf = useCallback((sdf: MaskSDF | null) => {
     if (!sdf) {
       setDraftRoomPoints([]);
@@ -944,6 +920,30 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({ campaign, onClose
       return true;
     },
     [brushSliderRange.max, imageDimensions, updateDraftRoomFromSdf]
+  );
+
+  const handleSmartWandSelection = useCallback(
+    (point: { x: number; y: number }) => {
+      const tool = smartWandToolRef.current;
+      const source = sourceImageRef.current;
+      if (!tool || !source) {
+        setIsOutliningRoom(false);
+        return;
+      }
+      drawingPointsRef.current = [];
+      setDraftRoomPoints([]);
+      setIsDrawingRoom(false);
+      const result = tool.select(point);
+      if (!result || result.polygon.length < 3) {
+        setIsOutliningRoom(false);
+        return;
+      }
+      const success = initializeSdfFromPolygon(result.polygon, { offsetPx: 5 });
+      if (!success) {
+        setIsOutliningRoom(false);
+      }
+    },
+    [initializeSdfFromPolygon]
   );
 
   const handleBrushRadiusChange = useCallback(


### PR DESCRIPTION
## Summary
- move the Smart Wand selection handler below the SDF initializer to prevent temporal dead zone access during runtime

## Testing
- npm run build
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d1ea0d2ac08323a9ce333b2d61e7ea