### PR TITLE
feat: add define rooms placeholder

### DIFF
--- a/apps/pages/src/__tests__/MapCreationWizard.defineRooms.placeholder.spec.tsx
+++ b/apps/pages/src/__tests__/MapCreationWizard.defineRooms.placeholder.spec.tsx
@@ -1,0 +1,69 @@
+/* @vitest-environment node */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import * as React from 'react';
+import type { Campaign } from '../types';
+
+const baseCampaign: Campaign = {
+  id: 'campaign-1',
+  name: 'Test Campaign',
+  isPublic: false,
+};
+
+const noop = () => {};
+
+const renderStepTwoMarkup = async (useNewDefineRooms: boolean) => {
+  vi.resetModules();
+  vi.doMock('../components/mapCreationWizardConfig', () => ({
+    USE_NEW_DEFINE_ROOMS: useNewDefineRooms,
+  }));
+
+  vi.doMock('react', async () => {
+    const actual = await vi.importActual<typeof import('react')>('react');
+    const originalUseState = actual.useState;
+    let callIndex = 0;
+    const customUseState: typeof actual.useState = ((initial: unknown) => {
+      if (callIndex === 0) {
+        callIndex += 1;
+        return [2, vi.fn()] as unknown as ReturnType<typeof originalUseState>;
+      }
+      callIndex += 1;
+      return originalUseState(initial);
+    }) as typeof actual.useState;
+    return {
+      ...actual,
+      default: { ...actual, useState: customUseState },
+      useState: customUseState,
+    };
+  });
+
+  const { default: MapCreationWizard } = await import('../components/MapCreationWizard');
+  const markup = renderToStaticMarkup(
+    React.createElement(MapCreationWizard, {
+      campaign: baseCampaign,
+      onClose: noop,
+      onComplete: noop,
+    })
+  );
+  vi.doUnmock('react');
+  return markup;
+};
+
+afterEach(() => {
+  vi.resetModules();
+  vi.doUnmock('react');
+});
+
+describe('MapCreationWizard define rooms step', () => {
+  it('renders placeholder when new define rooms feature flag is enabled', async () => {
+    const markup = await renderStepTwoMarkup(true);
+    expect(markup).toContain('data-testid="define-rooms-placeholder"');
+    expect(markup).toContain('Define Rooms (new editor coming soon)');
+  });
+
+  it('renders legacy UI when new define rooms feature flag is disabled', async () => {
+    const markup = await renderStepTwoMarkup(false);
+    expect(markup).toContain('Rooms &amp; Hallways');
+  });
+});

--- a/apps/pages/src/components/MapCreationWizard.tsx
+++ b/apps/pages/src/components/MapCreationWizard.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { USE_NEW_DEFINE_ROOMS } from './mapCreationWizardConfig';
 import { apiClient } from '../api/client';
 import {
   buildEdgeMap,
@@ -1941,7 +1942,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({ campaign, onClose
 
   return (
     <div className="fixed inset-0 z-50 flex flex-col bg-slate-950/95 backdrop-blur-sm">
-      {step === 2 && (
+      {step === 2 && !USE_NEW_DEFINE_ROOMS && (
         <WizardSidebar
           isOutlining={isOutliningRoom}
           canOutline={Boolean(previewUrl)}
@@ -2146,16 +2147,21 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({ campaign, onClose
             </div>
           )}
         {step === 2 && (
-          <div className="grid h-full min-h-0 grid-rows-[auto,1fr] gap-6 overflow-hidden">
-            <div className="rounded-3xl border border-slate-800/70 bg-slate-900/70 p-5">
-              <p className="text-xs uppercase tracking-[0.4em] text-slate-400">Fog of War</p>
-              <h3 className="mt-1 text-lg font-semibold text-white">Define Rooms &amp; Hallways</h3>
-              <p className="mt-2 text-xs text-slate-500">
-                Outline rooms, corridors, and secret spaces with the lasso, smart snap, paintbrush, or smart wand tools to keep
-                them hidden until you are ready to reveal them.
-              </p>
+          USE_NEW_DEFINE_ROOMS ? (
+            <div className="flex flex-1 items-center justify-center">
+              <div data-testid="define-rooms-placeholder">Define Rooms (new editor coming soon)</div>
             </div>
-            <div className="grid min-h-0 gap-6 lg:grid-cols-[minmax(0,1fr)_300px]">
+          ) : (
+            <div className="grid h-full min-h-0 grid-rows-[auto,1fr] gap-6 overflow-hidden">
+              <div className="rounded-3xl border border-slate-800/70 bg-slate-900/70 p-5">
+                <p className="text-xs uppercase tracking-[0.4em] text-slate-400">Fog of War</p>
+                <h3 className="mt-1 text-lg font-semibold text-white">Define Rooms &amp; Hallways</h3>
+                <p className="mt-2 text-xs text-slate-500">
+                  Outline rooms, corridors, and secret spaces with the lasso, smart snap, paintbrush, or smart wand tools to keep
+                  them hidden until you are ready to reveal them.
+                </p>
+              </div>
+              <div className="grid min-h-0 gap-6 lg:grid-cols-[minmax(0,1fr)_300px]">
               <div
                 ref={roomsMapRef}
                 className="relative flex h-full min-h-0 max-h-full items-center justify-center overflow-hidden rounded-3xl border border-slate-800/70 bg-slate-900/70"
@@ -2421,6 +2427,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({ campaign, onClose
               </div>
             </div>
           </div>
+        )
         )}
         {step === 3 && (
           <div className="grid h-full min-h-0 gap-6 lg:grid-cols-[minmax(0,1fr)_340px]">

--- a/apps/pages/src/components/mapCreationWizardConfig.ts
+++ b/apps/pages/src/components/mapCreationWizardConfig.ts
@@ -1,0 +1,1 @@
+export const USE_NEW_DEFINE_ROOMS: boolean = true;


### PR DESCRIPTION
## Summary
- add a feature flag for the Define Rooms step and render a placeholder by default
- retain the legacy Define Rooms UI behind the flag for rollback usage
- cover the new placeholder and legacy fallback behaviour with a server-rendered test

## Testing
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d1ed2629048323938379d2c0e5e6e3