### PR TITLE
Add define rooms store, segmentation worker, and tools

### DIFF
--- a/apps/pages/src/state/defineRoomsStore.ts
+++ b/apps/pages/src/state/defineRoomsStore.ts
@@ -1,0 +1,621 @@
+export type Point = { x: number; y: number };
+
+export interface GapMarker {
+  id: string;
+  position: Point;
+  radius: number;
+  severity: 'info' | 'warning' | 'error';
+  description: string;
+}
+
+export interface SignedDistanceField {
+  width: number;
+  height: number;
+  bounds: { minX: number; minY: number; maxX: number; maxY: number };
+  values: Float32Array;
+}
+
+export interface RoundTripResult {
+  sdf: SignedDistanceField;
+  polygon: Point[];
+  error: number;
+}
+
+export interface SdfOptions {
+  resolution?: number;
+  padding?: number;
+}
+
+export interface RoundTripOptions extends SdfOptions {
+  threshold?: number;
+}
+
+export interface DefineRoomsState {
+  mode: 'idle' | 'editing';
+  polygon: Point[];
+  preview: Point[] | null;
+  samples: Point[];
+  brushRadius: number;
+  snapStrength: number;
+  busyMessage: string | null;
+  gapMarkers: GapMarker[];
+  signedDistanceField: SignedDistanceField | null;
+  vectorDraft: Point[] | null;
+  lastRoundTrip: RoundTripResult | null;
+  lastUpdated: number;
+}
+
+export type DefineRoomsListener = (state: DefineRoomsState) => void;
+
+export interface DefineRoomsStore {
+  getState(): DefineRoomsState;
+  subscribe(listener: DefineRoomsListener): () => void;
+  setMode(mode: DefineRoomsState['mode']): void;
+  setBusy(message: string | null): void;
+  setBrushRadius(radius: number): void;
+  setSnapStrength(strength: number): void;
+  setPolygon(polygon: Point[]): void;
+  previewPolygon(polygon: Point[] | null): void;
+  commitPolygon(polygon: Point[]): void;
+  setSamples(samples: Point[]): void;
+  applyBrushSample(point: Point, mode: 'add' | 'erase'): void;
+  clear(): void;
+  setGapMarkers(markers: GapMarker[]): void;
+  refreshGapMarkers(): void;
+  setSignedDistanceField(field: SignedDistanceField | null): void;
+  setVectorDraft(polygon: Point[] | null): void;
+  roundTrip(polygon: Point[], options?: RoundTripOptions): RoundTripResult;
+  vectorToSdf(polygon: Point[], options?: SdfOptions): SignedDistanceField;
+  sdfToVector(field: SignedDistanceField, threshold?: number): Point[];
+  snapPoint(point: Point): Point;
+}
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+const distance = (a: Point, b: Point) => Math.hypot(a.x - b.x, a.y - b.y);
+
+const nearlyEqual = (a: number, b: number, epsilon = 1e-6) => Math.abs(a - b) <= epsilon;
+
+const pointKey = (point: Point) => `${point.x.toFixed(6)}:${point.y.toFixed(6)}`;
+
+const dedupePoints = (points: Point[]) => {
+  const seen = new Set<string>();
+  return points.filter((point) => {
+    const key = pointKey(point);
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+};
+
+const simplifyDouglasPeucker = (points: Point[], tolerance: number) => {
+  if (points.length <= 2) {
+    return points.slice();
+  }
+
+  const sqTolerance = tolerance * tolerance;
+
+  const sqDistanceToSegment = (p: Point, a: Point, b: Point) => {
+    let x = a.x;
+    let y = a.y;
+    let dx = b.x - x;
+    let dy = b.y - y;
+
+    if (dx !== 0 || dy !== 0) {
+      const t = ((p.x - x) * dx + (p.y - y) * dy) / (dx * dx + dy * dy);
+      if (t > 1) {
+        x = b.x;
+        y = b.y;
+      } else if (t > 0) {
+        x += dx * t;
+        y += dy * t;
+      }
+    }
+
+    dx = p.x - x;
+    dy = p.y - y;
+    return dx * dx + dy * dy;
+  };
+
+  const simplifyDPStep = (pointsToSimplify: Point[], first: number, last: number, simplified: Point[]) => {
+    let maxSqDist = sqTolerance;
+    let index = -1;
+
+    for (let i = first + 1; i < last; i += 1) {
+      const sqDist = sqDistanceToSegment(pointsToSimplify[i], pointsToSimplify[first], pointsToSimplify[last]);
+      if (sqDist > maxSqDist) {
+        index = i;
+        maxSqDist = sqDist;
+      }
+    }
+
+    if (index !== -1) {
+      if (index - first > 1) {
+        simplifyDPStep(pointsToSimplify, first, index, simplified);
+      }
+      simplified.push(pointsToSimplify[index]);
+      if (last - index > 1) {
+        simplifyDPStep(pointsToSimplify, index, last, simplified);
+      }
+    }
+  };
+
+  const last = points.length - 1;
+  const result = [points[0]];
+  simplifyDPStep(points, 0, last, result);
+  result.push(points[last]);
+  return result;
+};
+
+const pointInPolygon = (point: Point, polygon: Point[]) => {
+  let inside = false;
+  for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i += 1) {
+    const xi = polygon[i].x;
+    const yi = polygon[i].y;
+    const xj = polygon[j].x;
+    const yj = polygon[j].y;
+    const intersect = yi > point.y !== yj > point.y && point.x < ((xj - xi) * (point.y - yi)) / (yj - yi) + xi;
+    if (intersect) inside = !inside;
+  }
+  return inside;
+};
+
+const distanceToSegment = (point: Point, a: Point, b: Point) => {
+  const vx = b.x - a.x;
+  const vy = b.y - a.y;
+  const wx = point.x - a.x;
+  const wy = point.y - a.y;
+  const c1 = vx * wx + vy * wy;
+  if (c1 <= 0) {
+    return Math.hypot(point.x - a.x, point.y - a.y);
+  }
+  const c2 = vx * vx + vy * vy;
+  if (c2 <= c1) {
+    return Math.hypot(point.x - b.x, point.y - b.y);
+  }
+  const t = c1 / c2;
+  const px = a.x + vx * t;
+  const py = a.y + vy * t;
+  return Math.hypot(point.x - px, point.y - py);
+};
+
+const ensureBounds = (polygon: Point[]) => {
+  if (polygon.length === 0) {
+    return { minX: 0, minY: 0, maxX: 1, maxY: 1 };
+  }
+  let minX = polygon[0].x;
+  let minY = polygon[0].y;
+  let maxX = polygon[0].x;
+  let maxY = polygon[0].y;
+  for (const point of polygon) {
+    if (point.x < minX) minX = point.x;
+    if (point.y < minY) minY = point.y;
+    if (point.x > maxX) maxX = point.x;
+    if (point.y > maxY) maxY = point.y;
+  }
+  const width = maxX - minX || 1;
+  const height = maxY - minY || 1;
+  const padding = Math.max(width, height) * 0.05;
+  return {
+    minX: minX - padding,
+    minY: minY - padding,
+    maxX: maxX + padding,
+    maxY: maxY + padding,
+  };
+};
+
+const defaultState: DefineRoomsState = {
+  mode: 'idle',
+  polygon: [],
+  preview: null,
+  samples: [],
+  brushRadius: 0.08,
+  snapStrength: 0.65,
+  busyMessage: null,
+  gapMarkers: [],
+  signedDistanceField: null,
+  vectorDraft: null,
+  lastRoundTrip: null,
+  lastUpdated: Date.now(),
+};
+
+let state: DefineRoomsState = { ...defaultState };
+
+const listeners = new Set<DefineRoomsListener>();
+
+const notify = () => {
+  listeners.forEach((listener) => listener(state));
+};
+
+const commitState = (updater: (current: DefineRoomsState) => DefineRoomsState) => {
+  state = { ...updater(state), lastUpdated: Date.now() };
+  notify();
+};
+
+const generateBrushSamples = (center: Point, radius: number, segments = 16) => {
+  const samples: Point[] = [];
+  samples.push(center);
+  for (let i = 0; i < segments; i += 1) {
+    const angle = (i / segments) * Math.PI * 2;
+    samples.push({
+      x: center.x + Math.cos(angle) * radius,
+      y: center.y + Math.sin(angle) * radius,
+    });
+  }
+  return samples;
+};
+
+const computeGapMarkers = (polygon: Point[]) => {
+  if (polygon.length < 2) {
+    return [] as GapMarker[];
+  }
+  const markers: GapMarker[] = [];
+  const threshold = 0.075;
+  for (let i = 0; i < polygon.length; i += 1) {
+    const current = polygon[i];
+    const next = polygon[(i + 1) % polygon.length];
+    const gap = distance(current, next);
+    if (gap <= threshold) {
+      continue;
+    }
+    const radius = gap / 2;
+    const severity = gap > threshold * 1.6 ? 'error' : gap > threshold * 1.2 ? 'warning' : 'info';
+    markers.push({
+      id: `gap-${i}`,
+      position: { x: (current.x + next.x) / 2, y: (current.y + next.y) / 2 },
+      radius,
+      severity,
+      description: `Gap of ${(gap * 100).toFixed(1)}% between segments`,
+    });
+  }
+  return markers;
+};
+
+const rasterizePolygon = (polygon: Point[], width: number, height: number, bounds: SignedDistanceField['bounds']) => {
+  const mask = new Uint8Array(width * height);
+  if (polygon.length === 0) {
+    return mask;
+  }
+  const scaleX = bounds.maxX - bounds.minX || 1;
+  const scaleY = bounds.maxY - bounds.minY || 1;
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      const worldPoint = {
+        x: bounds.minX + ((x + 0.5) / width) * scaleX,
+        y: bounds.minY + ((y + 0.5) / height) * scaleY,
+      };
+      if (pointInPolygon(worldPoint, polygon)) {
+        mask[y * width + x] = 1;
+      }
+    }
+  }
+  return mask;
+};
+
+const marchingSquares = (mask: Uint8Array, width: number, height: number) => {
+  const segments: Array<{ start: Point; end: Point }> = [];
+
+  const edgePoint = (x: number, y: number, edge: 'top' | 'bottom' | 'left' | 'right'): Point => {
+    switch (edge) {
+      case 'top':
+        return { x: x + 0.5, y };
+      case 'bottom':
+        return { x: x + 0.5, y: y + 1 };
+      case 'left':
+        return { x, y: y + 0.5 };
+      case 'right':
+        return { x: x + 1, y: y + 0.5 };
+    }
+  };
+
+  const cases: Record<number, Array<[Point, Point]>> = {
+    0: [],
+    1: [[edgePoint(0, 0, 'left'), edgePoint(0, 0, 'top')]],
+    2: [[edgePoint(0, 0, 'top'), edgePoint(0, 0, 'right')]],
+    3: [[edgePoint(0, 0, 'left'), edgePoint(0, 0, 'right')]],
+    4: [[edgePoint(0, 0, 'right'), edgePoint(0, 0, 'bottom')]],
+    5: [
+      [edgePoint(0, 0, 'left'), edgePoint(0, 0, 'bottom')],
+      [edgePoint(0, 0, 'top'), edgePoint(0, 0, 'right')],
+    ],
+    6: [[edgePoint(0, 0, 'top'), edgePoint(0, 0, 'bottom')]],
+    7: [[edgePoint(0, 0, 'left'), edgePoint(0, 0, 'bottom')]],
+    8: [[edgePoint(0, 0, 'bottom'), edgePoint(0, 0, 'left')]],
+    9: [[edgePoint(0, 0, 'top'), edgePoint(0, 0, 'bottom')]],
+    10: [
+      [edgePoint(0, 0, 'top'), edgePoint(0, 0, 'right')],
+      [edgePoint(0, 0, 'bottom'), edgePoint(0, 0, 'left')],
+    ],
+    11: [[edgePoint(0, 0, 'right'), edgePoint(0, 0, 'bottom')]],
+    12: [[edgePoint(0, 0, 'right'), edgePoint(0, 0, 'left')]],
+    13: [[edgePoint(0, 0, 'top'), edgePoint(0, 0, 'right')]],
+    14: [[edgePoint(0, 0, 'left'), edgePoint(0, 0, 'top')]],
+    15: [],
+  };
+
+  for (let y = 0; y < height - 1; y += 1) {
+    for (let x = 0; x < width - 1; x += 1) {
+      const topLeft = mask[y * width + x] > 0;
+      const topRight = mask[y * width + x + 1] > 0;
+      const bottomRight = mask[(y + 1) * width + x + 1] > 0;
+      const bottomLeft = mask[(y + 1) * width + x] > 0;
+      let key = 0;
+      if (topLeft) key |= 1;
+      if (topRight) key |= 2;
+      if (bottomRight) key |= 4;
+      if (bottomLeft) key |= 8;
+      if (key === 0 || key === 15) {
+        continue;
+      }
+      const template = cases[key];
+      for (const [start, end] of template) {
+        segments.push({
+          start: { x: start.x + x, y: start.y + y },
+          end: { x: end.x + x, y: end.y + y },
+        });
+      }
+    }
+  }
+
+  if (segments.length === 0) {
+    return [] as Point[];
+  }
+
+  const polygon: Point[] = [];
+  const used = new Array(segments.length).fill(false);
+  polygon.push(segments[0].start);
+  polygon.push(segments[0].end);
+  used[0] = true;
+
+  const equals = (a: Point, b: Point) => nearlyEqual(a.x, b.x, 1e-4) && nearlyEqual(a.y, b.y, 1e-4);
+
+  while (polygon.length < 5000) {
+    const current = polygon[polygon.length - 1];
+    let advanced = false;
+    for (let i = 0; i < segments.length; i += 1) {
+      if (used[i]) continue;
+      const segment = segments[i];
+      if (equals(segment.start, current)) {
+        polygon.push(segment.end);
+        used[i] = true;
+        advanced = true;
+        break;
+      }
+      if (equals(segment.end, current)) {
+        polygon.push(segment.start);
+        used[i] = true;
+        advanced = true;
+        break;
+      }
+    }
+    if (!advanced) {
+      break;
+    }
+    if (equals(polygon[polygon.length - 1], polygon[0])) {
+      polygon.pop();
+      break;
+    }
+  }
+
+  return polygon;
+};
+
+const convertMaskToPolygon = (mask: Uint8Array, width: number, height: number, bounds: SignedDistanceField['bounds']) => {
+  const rawPolygon = marchingSquares(mask, width, height);
+  if (rawPolygon.length === 0) {
+    return [];
+  }
+  const scaleX = bounds.maxX - bounds.minX || 1;
+  const scaleY = bounds.maxY - bounds.minY || 1;
+  const widthDenominator = width - 1 || 1;
+  const heightDenominator = height - 1 || 1;
+  const polygon = rawPolygon.map((point) => ({
+    x: bounds.minX + (point.x / widthDenominator) * scaleX,
+    y: bounds.minY + (point.y / heightDenominator) * scaleY,
+  }));
+  return simplifyDouglasPeucker(dedupePoints(polygon), 0.001);
+};
+
+const averageDistanceBetweenPolygons = (a: Point[], b: Point[]) => {
+  if (a.length === 0 || b.length === 0) {
+    return 1;
+  }
+  const sampleCount = Math.min(a.length, 256);
+  let total = 0;
+  for (let i = 0; i < sampleCount; i += 1) {
+    const index = Math.floor((i / sampleCount) * a.length);
+    const point = a[index];
+    let closest = Infinity;
+    for (const other of b) {
+      const d = distance(point, other);
+      if (d < closest) {
+        closest = d;
+      }
+    }
+    total += closest;
+  }
+  return total / sampleCount;
+};
+
+const vectorToSdf = (polygon: Point[], options?: SdfOptions): SignedDistanceField => {
+  const bounds = ensureBounds(polygon);
+  const resolution = clamp(options?.resolution ?? 128, 16, 1024);
+  const padding = options?.padding ?? 0;
+  const width = Math.max(8, Math.round((bounds.maxX - bounds.minX + padding) * resolution));
+  const height = Math.max(8, Math.round((bounds.maxY - bounds.minY + padding) * resolution));
+  const adjustedBounds = {
+    minX: bounds.minX - padding / 2,
+    minY: bounds.minY - padding / 2,
+    maxX: bounds.maxX + padding / 2,
+    maxY: bounds.maxY + padding / 2,
+  };
+  const values = new Float32Array(width * height);
+  const mask = rasterizePolygon(polygon, width, height, adjustedBounds);
+
+  const scaleX = adjustedBounds.maxX - adjustedBounds.minX || 1;
+  const scaleY = adjustedBounds.maxY - adjustedBounds.minY || 1;
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      const worldPoint = {
+        x: adjustedBounds.minX + ((x + 0.5) / width) * scaleX,
+        y: adjustedBounds.minY + ((y + 0.5) / height) * scaleY,
+      };
+      let minDist = Infinity;
+      for (let i = 0; i < polygon.length; i += 1) {
+        const a = polygon[i];
+        const b = polygon[(i + 1) % polygon.length];
+        const dist = distanceToSegment(worldPoint, a, b);
+        if (dist < minDist) {
+          minDist = dist;
+        }
+      }
+      const inside = mask[y * width + x] > 0;
+      values[y * width + x] = inside ? -minDist : minDist;
+    }
+  }
+
+  return {
+    width,
+    height,
+    bounds: adjustedBounds,
+    values,
+  };
+};
+
+const sdfToVector = (field: SignedDistanceField, threshold = 0) => {
+  const mask = new Uint8Array(field.width * field.height);
+  for (let i = 0; i < field.values.length; i += 1) {
+    mask[i] = field.values[i] <= threshold ? 1 : 0;
+  }
+  return convertMaskToPolygon(mask, field.width, field.height, field.bounds);
+};
+
+const roundTripPolygon = (polygon: Point[], options?: RoundTripOptions): RoundTripResult => {
+  const sdf = vectorToSdf(polygon, options);
+  const reconstructed = sdfToVector(sdf, options?.threshold ?? 0);
+  const error = averageDistanceBetweenPolygons(polygon, reconstructed);
+  return { sdf, polygon: reconstructed, error };
+};
+
+export const defineRoomsStore: DefineRoomsStore = {
+  getState: () => state,
+  subscribe(listener) {
+    listeners.add(listener);
+    listener(state);
+    return () => {
+      listeners.delete(listener);
+    };
+  },
+  setMode(mode) {
+    commitState((current) => ({ ...current, mode }));
+  },
+  setBusy(message) {
+    commitState((current) => ({ ...current, busyMessage: message }));
+  },
+  setBrushRadius(radius) {
+    const next = clamp(radius, 0.01, 0.5);
+    commitState((current) => ({ ...current, brushRadius: next }));
+  },
+  setSnapStrength(strength) {
+    commitState((current) => ({ ...current, snapStrength: clamp(strength, 0, 1) }));
+  },
+  setPolygon(polygon) {
+    const deduped = dedupePoints(polygon);
+    const simplified = simplifyDouglasPeucker(deduped, 0.0005);
+    commitState((current) => ({
+      ...current,
+      polygon: simplified,
+      samples: simplified.slice(),
+      preview: null,
+      gapMarkers: computeGapMarkers(simplified),
+      lastRoundTrip: null,
+    }));
+  },
+  previewPolygon(polygon) {
+    commitState((current) => ({ ...current, preview: polygon ? polygon.slice() : null }));
+  },
+  commitPolygon(polygon) {
+    const deduped = dedupePoints(polygon);
+    const simplified = simplifyDouglasPeucker(deduped, 0.0005);
+    commitState((current) => ({
+      ...current,
+      mode: 'editing',
+      polygon: simplified,
+      samples: simplified.slice(),
+      preview: null,
+      gapMarkers: computeGapMarkers(simplified),
+      lastRoundTrip: null,
+    }));
+  },
+  setSamples(samples) {
+    const deduped = dedupePoints(samples);
+    commitState((current) => ({
+      ...current,
+      samples: deduped,
+      polygon: deduped.slice(),
+      preview: null,
+      gapMarkers: computeGapMarkers(deduped),
+      lastRoundTrip: null,
+    }));
+  },
+  applyBrushSample(point, mode) {
+    commitState((current) => {
+      const snapped = defineRoomsStore.snapPoint(point);
+      const radius = current.brushRadius;
+      const samples = [...current.samples];
+      if (mode === 'add') {
+        const additions = generateBrushSamples(snapped, radius);
+        for (const sample of additions) {
+          samples.push(sample);
+        }
+      } else {
+        const filtered = samples.filter((sample) => distance(sample, snapped) > radius * 0.6);
+        samples.length = 0;
+        samples.push(...filtered);
+      }
+      const deduped = dedupePoints(samples);
+      const simplified = simplifyDouglasPeucker(deduped, 0.0005);
+      return {
+        ...current,
+        samples: deduped,
+        polygon: simplified,
+        preview: null,
+        gapMarkers: computeGapMarkers(simplified),
+        lastRoundTrip: null,
+      };
+    });
+  },
+  clear() {
+    commitState(() => ({ ...defaultState, lastUpdated: Date.now() }));
+  },
+  setGapMarkers(markers) {
+    commitState((current) => ({ ...current, gapMarkers: markers.slice() }));
+  },
+  refreshGapMarkers() {
+    commitState((current) => ({ ...current, gapMarkers: computeGapMarkers(current.polygon) }));
+  },
+  setSignedDistanceField(field) {
+    commitState((current) => ({ ...current, signedDistanceField: field }));
+  },
+  setVectorDraft(polygon) {
+    commitState((current) => ({ ...current, vectorDraft: polygon ? polygon.slice() : null }));
+  },
+  roundTrip(polygon, options) {
+    const result = roundTripPolygon(polygon, options);
+    commitState((current) => ({ ...current, signedDistanceField: result.sdf, vectorDraft: result.polygon, lastRoundTrip: result }));
+    return result;
+  },
+  vectorToSdf,
+  sdfToVector,
+  snapPoint(point) {
+    const strength = clamp(state.snapStrength, 0, 1);
+    const resolution = clamp(Math.round(12 + strength * 20), 6, 64);
+    return {
+      x: clamp(Math.round(point.x * resolution) / resolution, 0, 1),
+      y: clamp(Math.round(point.y * resolution) / resolution, 0, 1),
+    };
+  },
+};
+

--- a/apps/pages/src/tools/defineRooms/AutoWandTool.ts
+++ b/apps/pages/src/tools/defineRooms/AutoWandTool.ts
@@ -1,0 +1,73 @@
+import type { Point } from '../../state/defineRoomsStore';
+import type { DefineRoomsTool, PointerState, ToolContext } from './ToolContext';
+
+const clamp01 = (value: number) => Math.min(Math.max(value, 0), 1);
+
+const clampPoint = (point: Point): Point => ({ x: clamp01(point.x), y: clamp01(point.y) });
+
+const buildCirclePolygon = (center: Point, radius: number, steps = 24): Point[] => {
+  const points: Point[] = [];
+  for (let i = 0; i < steps; i += 1) {
+    const angle = (i / steps) * Math.PI * 2;
+    points.push({
+      x: clamp01(center.x + Math.cos(angle) * radius),
+      y: clamp01(center.y + Math.sin(angle) * radius),
+    });
+  }
+  return points;
+};
+
+export class AutoWandTool implements DefineRoomsTool {
+  readonly id = 'autoWand';
+
+  private requestId = 0;
+
+  onPointerDown(ctx: ToolContext, pointer: PointerState) {
+    if (pointer.button !== undefined && pointer.button !== 0) {
+      return;
+    }
+    const seed = clampPoint(ctx.snap(ctx.clamp(pointer.point)));
+    const request = ++this.requestId;
+
+    if (!ctx.segmentation) {
+      const radius = Math.max(0.02, ctx.store.getState().brushRadius * 0.75);
+      ctx.store.commitPolygon(buildCirclePolygon(seed, radius));
+      return;
+    }
+
+    const snapStrength = ctx.store.getState().snapStrength;
+    const tolerance = Math.round(24 + snapStrength * 48);
+    ctx.store.setBusy('Detecting region…');
+    ctx.segmentation
+      .smartWand(seed, { tolerance, connectivity: 8, softenEdges: true })
+      .then((result) => {
+        if (this.requestId !== request) {
+          return;
+        }
+        ctx.store.setBusy(null);
+        if (result.polygon.length >= 3) {
+          ctx.store.commitPolygon(result.polygon);
+        } else {
+          const radius = Math.max(0.02, ctx.store.getState().brushRadius * 0.75);
+          ctx.store.commitPolygon(buildCirclePolygon(seed, radius));
+        }
+      })
+      .catch(() => {
+        if (this.requestId === request) {
+          ctx.store.setBusy(null);
+        }
+      });
+  }
+
+  onPointerMove() {}
+
+  onPointerUp() {}
+
+  onCancel(ctx: ToolContext) {
+    this.requestId += 1;
+    ctx.store.setBusy(null);
+  }
+}
+
+export const createAutoWandTool = () => new AutoWandTool();
+

--- a/apps/pages/src/tools/defineRooms/LassoTool.ts
+++ b/apps/pages/src/tools/defineRooms/LassoTool.ts
@@ -1,0 +1,74 @@
+import type { Point } from '../../state/defineRoomsStore';
+import type { DefineRoomsTool, PointerState, ToolContext } from './ToolContext';
+
+const distance = (a: Point, b: Point) => Math.hypot(a.x - b.x, a.y - b.y);
+
+const clamp01 = (value: number) => Math.min(Math.max(value, 0), 1);
+
+const clampPoint = (point: Point): Point => ({ x: clamp01(point.x), y: clamp01(point.y) });
+
+export class LassoTool implements DefineRoomsTool {
+  readonly id = 'lasso';
+
+  private active = false;
+
+  private points: Point[] = [];
+
+  onPointerDown(ctx: ToolContext, pointer: PointerState) {
+    if (pointer.button !== undefined && pointer.button !== 0) {
+      return;
+    }
+    const start = clampPoint(ctx.snap(ctx.clamp(pointer.point)));
+    this.active = true;
+    this.points = [start];
+    ctx.store.previewPolygon(this.points.slice());
+  }
+
+  onPointerMove(ctx: ToolContext, pointer: PointerState) {
+    if (!this.active) {
+      return;
+    }
+    const current = clampPoint(ctx.snap(ctx.clamp(pointer.point)));
+    const last = this.points[this.points.length - 1];
+    if (!last || distance(last, current) > 0.003) {
+      this.points.push(current);
+      ctx.store.previewPolygon(this.points.slice());
+    } else if (this.points.length) {
+      this.points[this.points.length - 1] = current;
+      ctx.store.previewPolygon(this.points.slice());
+    }
+  }
+
+  onPointerUp(ctx: ToolContext, pointer: PointerState) {
+    if (!this.active) {
+      return;
+    }
+    const endPoint = clampPoint(ctx.snap(ctx.clamp(pointer.point)));
+    if (this.points.length === 0 || distance(this.points[this.points.length - 1], endPoint) > 0.003) {
+      this.points.push(endPoint);
+    } else {
+      this.points[this.points.length - 1] = endPoint;
+    }
+    this.finish(ctx);
+  }
+
+  onCancel(ctx: ToolContext) {
+    this.active = false;
+    this.points = [];
+    ctx.store.previewPolygon(null);
+  }
+
+  private finish(ctx: ToolContext) {
+    this.active = false;
+    const polygon = this.points.slice();
+    this.points = [];
+    if (polygon.length >= 3) {
+      ctx.store.commitPolygon(polygon);
+    } else {
+      ctx.store.previewPolygon(null);
+    }
+  }
+}
+
+export const createLassoTool = () => new LassoTool();
+

--- a/apps/pages/src/tools/defineRooms/PaintbrushTool.ts
+++ b/apps/pages/src/tools/defineRooms/PaintbrushTool.ts
@@ -1,0 +1,79 @@
+import type { Point } from '../../state/defineRoomsStore';
+import type { DefineRoomsTool, PointerState, ToolContext } from './ToolContext';
+
+const distance = (a: Point, b: Point) => Math.hypot(a.x - b.x, a.y - b.y);
+
+const interpolate = (a: Point, b: Point, t: number): Point => ({
+  x: a.x + (b.x - a.x) * t,
+  y: a.y + (b.y - a.y) * t,
+});
+
+const clamp01 = (value: number) => Math.min(Math.max(value, 0), 1);
+
+const clampPoint = (point: Point): Point => ({ x: clamp01(point.x), y: clamp01(point.y) });
+
+export class PaintbrushTool implements DefineRoomsTool {
+  readonly id = 'paintbrush';
+
+  private active = false;
+
+  private mode: 'add' | 'erase' = 'add';
+
+  private lastPoint: Point | null = null;
+
+  onPointerDown(ctx: ToolContext, pointer: PointerState) {
+    const initial = clampPoint(ctx.snap(ctx.clamp(pointer.point)));
+    this.mode = pointer.button === 2 || pointer.buttons === 2 || pointer.altKey || pointer.ctrlKey ? 'erase' : 'add';
+    this.active = true;
+    this.lastPoint = initial;
+    ctx.store.applyBrushSample(initial, this.mode);
+  }
+
+  onPointerMove(ctx: ToolContext, pointer: PointerState) {
+    if (!this.active || !this.lastPoint) {
+      return;
+    }
+    const point = clampPoint(ctx.snap(ctx.clamp(pointer.point)));
+    this.strokeSegment(ctx, this.lastPoint, point);
+    this.lastPoint = point;
+  }
+
+  onPointerUp(ctx: ToolContext, pointer: PointerState) {
+    if (!this.active) {
+      return;
+    }
+    const point = clampPoint(ctx.snap(ctx.clamp(pointer.point)));
+    if (this.lastPoint) {
+      this.strokeSegment(ctx, this.lastPoint, point);
+    } else {
+      ctx.store.applyBrushSample(point, this.mode);
+    }
+    this.active = false;
+    this.lastPoint = null;
+  }
+
+  onCancel(ctx: ToolContext) {
+    this.active = false;
+    this.lastPoint = null;
+    ctx.store.previewPolygon(null);
+  }
+
+  private strokeSegment(ctx: ToolContext, from: Point, to: Point) {
+    const radius = Math.max(0.0025, ctx.store.getState().brushRadius);
+    const dist = distance(from, to);
+    if (dist === 0) {
+      ctx.store.applyBrushSample(to, this.mode);
+      return;
+    }
+    const step = Math.max(radius * 0.5, 0.003);
+    const steps = Math.max(1, Math.ceil(dist / step));
+    for (let i = 1; i <= steps; i += 1) {
+      const t = i / steps;
+      const point = clampPoint(ctx.snap(ctx.clamp(interpolate(from, to, t))));
+      ctx.store.applyBrushSample(point, this.mode);
+    }
+  }
+}
+
+export const createPaintbrushTool = () => new PaintbrushTool();
+

--- a/apps/pages/src/tools/defineRooms/SmartLassoTool.ts
+++ b/apps/pages/src/tools/defineRooms/SmartLassoTool.ts
@@ -1,0 +1,167 @@
+import type { Point } from '../../state/defineRoomsStore';
+import type { DefineRoomsTool, PointerState, ToolContext } from './ToolContext';
+
+const distance = (a: Point, b: Point) => Math.hypot(a.x - b.x, a.y - b.y);
+
+const clamp01 = (value: number) => Math.min(Math.max(value, 0), 1);
+
+const clampPoint = (point: Point): Point => ({ x: clamp01(point.x), y: clamp01(point.y) });
+
+export class SmartLassoTool implements DefineRoomsTool {
+  readonly id = 'smartLasso';
+
+  private active = false;
+
+  private rawPoints: Point[] = [];
+
+  private requestId = 0;
+
+  onPointerDown(ctx: ToolContext, pointer: PointerState) {
+    if (pointer.button !== undefined && pointer.button !== 0) {
+      return;
+    }
+    const start = clampPoint(ctx.snap(ctx.clamp(pointer.point)));
+    this.active = true;
+    this.rawPoints = [start];
+    this.requestId += 1;
+    ctx.store.previewPolygon([start]);
+  }
+
+  onPointerMove(ctx: ToolContext, pointer: PointerState) {
+    if (!this.active) {
+      return;
+    }
+    const point = clampPoint(ctx.snap(ctx.clamp(pointer.point)));
+    if (this.rawPoints.length === 0) {
+      this.rawPoints.push(point);
+    } else {
+      const last = this.rawPoints[this.rawPoints.length - 1];
+      if (distance(last, point) > 0.002) {
+        this.rawPoints.push(point);
+      } else {
+        this.rawPoints[this.rawPoints.length - 1] = point;
+      }
+    }
+    this.updatePreview(ctx);
+  }
+
+  onPointerUp(ctx: ToolContext, pointer: PointerState) {
+    if (!this.active) {
+      return;
+    }
+    const end = clampPoint(ctx.snap(ctx.clamp(pointer.point)));
+    if (this.rawPoints.length === 0 || distance(this.rawPoints[this.rawPoints.length - 1], end) > 0.002) {
+      this.rawPoints.push(end);
+    } else {
+      this.rawPoints[this.rawPoints.length - 1] = end;
+    }
+    this.active = false;
+    const request = ++this.requestId;
+    const finalize = (path: Point[]) => {
+      if (this.requestId !== request) {
+        return;
+      }
+      if (path.length >= 3) {
+        ctx.store.commitPolygon(path);
+      } else {
+        ctx.store.previewPolygon(null);
+      }
+      ctx.store.setBusy(null);
+      this.rawPoints = [];
+    };
+
+    if (ctx.segmentation && this.rawPoints.length >= 2) {
+      const samples = this.samplePoints(ctx);
+      ctx.store.setBusy('Tracing live-wire…');
+      this.computeLiveWire(ctx, samples)
+        .then((path) => finalize(path))
+        .catch(() => finalize(samples));
+    } else {
+      finalize(this.rawPoints.slice());
+    }
+  }
+
+  onCancel(ctx: ToolContext) {
+    this.requestId += 1;
+    this.active = false;
+    this.rawPoints = [];
+    ctx.store.setBusy(null);
+    ctx.store.previewPolygon(null);
+  }
+
+  private updatePreview(ctx: ToolContext) {
+    ctx.store.previewPolygon(this.rawPoints.slice());
+    if (!ctx.segmentation || this.rawPoints.length < 2) {
+      return;
+    }
+    const samples = this.samplePoints(ctx);
+    const request = ++this.requestId;
+    ctx.store.setBusy('Tracing live-wire…');
+    this.computeLiveWire(ctx, samples)
+      .then((path) => {
+        if (this.requestId !== request) {
+          return;
+        }
+        ctx.store.previewPolygon(path);
+        ctx.store.setBusy(null);
+      })
+      .catch(() => {
+        if (this.requestId === request) {
+          ctx.store.setBusy(null);
+        }
+      });
+  }
+
+  private samplePoints(ctx: ToolContext) {
+    const spacing = Math.max(0.01, ctx.store.getState().brushRadius * 0.75);
+    const samples: Point[] = [];
+    for (const point of this.rawPoints) {
+      if (!samples.length) {
+        samples.push(point);
+        continue;
+      }
+      const last = samples[samples.length - 1];
+      if (distance(last, point) >= spacing) {
+        samples.push(point);
+      }
+    }
+    const lastPoint = this.rawPoints[this.rawPoints.length - 1];
+    if (samples.length === 0) {
+      samples.push(lastPoint);
+    } else if (distance(samples[samples.length - 1], lastPoint) > 0) {
+      samples.push(lastPoint);
+    }
+    return samples;
+  }
+
+  private async computeLiveWire(ctx: ToolContext, samples: Point[]): Promise<Point[]> {
+    if (!ctx.segmentation) {
+      return samples;
+    }
+    const result: Point[] = [];
+    for (let i = 0; i < samples.length; i += 1) {
+      const point = samples[i];
+      if (i === 0) {
+        result.push(point);
+        continue;
+      }
+      try {
+        const segment = await ctx.segmentation.liveWire(samples[i - 1], point);
+        if (segment.length === 0) {
+          result.push(point);
+        } else {
+          if (result.length) {
+            result.pop();
+          }
+          result.push(...segment);
+        }
+      } catch (_error) {
+        result.push(point);
+      }
+    }
+    return result;
+  }
+}
+
+export const createSmartLassoTool = () => new SmartLassoTool();
+

--- a/apps/pages/src/tools/defineRooms/ToolContext.ts
+++ b/apps/pages/src/tools/defineRooms/ToolContext.ts
@@ -1,0 +1,29 @@
+import type { DefineRoomsStore, Point } from '../../state/defineRoomsStore';
+import type { SegmentationWorker } from '../../workers/seg';
+
+export interface PointerState {
+  point: Point;
+  button?: number;
+  buttons?: number;
+  pressure?: number;
+  altKey?: boolean;
+  ctrlKey?: boolean;
+  metaKey?: boolean;
+  shiftKey?: boolean;
+}
+
+export interface ToolContext {
+  store: DefineRoomsStore;
+  segmentation: SegmentationWorker | null;
+  snap(point: Point): Point;
+  clamp(point: Point): Point;
+}
+
+export interface DefineRoomsTool {
+  readonly id: string;
+  onPointerDown(ctx: ToolContext, pointer: PointerState): void;
+  onPointerMove(ctx: ToolContext, pointer: PointerState): void;
+  onPointerUp(ctx: ToolContext, pointer: PointerState): void;
+  onCancel?(ctx: ToolContext): void;
+}
+

--- a/apps/pages/src/workers/seg.ts
+++ b/apps/pages/src/workers/seg.ts
@@ -1,0 +1,772 @@
+import type { Point, SignedDistanceField } from '../state/defineRoomsStore';
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+const nearlyEqual = (a: number, b: number, epsilon = 1e-5) => Math.abs(a - b) <= epsilon;
+
+const pointKey = (point: Point) => `${point.x.toFixed(5)}:${point.y.toFixed(5)}`;
+
+export interface CostLevel {
+  width: number;
+  height: number;
+  data: Float32Array;
+  scale: number;
+}
+
+export interface CostPyramid {
+  width: number;
+  height: number;
+  levels: CostLevel[];
+}
+
+export interface CostPyramidOptions {
+  levels?: number;
+  smoothIterations?: number;
+}
+
+export interface LiveWireOptions {
+  smoothing?: number;
+  allowDiagonals?: boolean;
+}
+
+export interface SmartWandOptions {
+  tolerance?: number;
+  connectivity?: 4 | 8;
+  minArea?: number;
+  softenEdges?: boolean;
+}
+
+export interface SmartWandResult {
+  mask: Uint8Array;
+  width: number;
+  height: number;
+  polygon: Point[];
+  bounds: { minX: number; minY: number; maxX: number; maxY: number };
+  seed: Point;
+  area: number;
+}
+
+export interface VectorFitOptions {
+  simplifyTolerance?: number;
+}
+
+const toGrayscale = (source: Uint8ClampedArray | Uint8Array | number[], width: number, height: number) => {
+  const grayscale = new Float32Array(width * height);
+  const hasAlpha = source.length === width * height * 4;
+  for (let i = 0; i < width * height; i += 1) {
+    if (hasAlpha) {
+      const index = i * 4;
+      const r = source[index];
+      const g = source[index + 1];
+      const b = source[index + 2];
+      grayscale[i] = 0.2989 * r + 0.587 * g + 0.114 * b;
+    } else {
+      grayscale[i] = source[i];
+    }
+  }
+  return grayscale;
+};
+
+const blurField = (data: Float32Array, width: number, height: number, iterations: number) => {
+  if (iterations <= 0) {
+    return data;
+  }
+  const temp = new Float32Array(data.length);
+  for (let iter = 0; iter < iterations; iter += 1) {
+    for (let y = 0; y < height; y += 1) {
+      for (let x = 0; x < width; x += 1) {
+        let total = 0;
+        let count = 0;
+        for (let dy = -1; dy <= 1; dy += 1) {
+          for (let dx = -1; dx <= 1; dx += 1) {
+            const nx = x + dx;
+            const ny = y + dy;
+            if (nx < 0 || nx >= width || ny < 0 || ny >= height) {
+              continue;
+            }
+            total += data[ny * width + nx];
+            count += 1;
+          }
+        }
+        temp[y * width + x] = total / count;
+      }
+    }
+    data.set(temp);
+  }
+  return data;
+};
+
+export const buildCostPyramid = (
+  image: Uint8ClampedArray | Uint8Array | number[],
+  width: number,
+  height: number,
+  options?: CostPyramidOptions
+): CostPyramid => {
+  const grayscale = image instanceof Float32Array ? image : toGrayscale(image, width, height);
+  const levels = Math.max(1, Math.round(options?.levels ?? 4));
+  const smoothIterations = Math.max(0, Math.round(options?.smoothIterations ?? 1));
+
+  const base = new Float32Array(width * height);
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      const center = grayscale[y * width + x];
+      const right = grayscale[y * width + Math.min(width - 1, x + 1)];
+      const bottom = grayscale[Math.min(height - 1, y + 1) * width + x];
+      const gradientX = right - center;
+      const gradientY = bottom - center;
+      const magnitude = Math.sqrt(gradientX * gradientX + gradientY * gradientY);
+      base[y * width + x] = magnitude;
+    }
+  }
+
+  blurField(base, width, height, smoothIterations);
+
+  const pyramidLevels: CostLevel[] = [{ width, height, data: base, scale: 1 }];
+
+  let currentWidth = width;
+  let currentHeight = height;
+  let previous = base;
+  for (let level = 1; level < levels; level += 1) {
+    const nextWidth = Math.max(1, Math.floor(currentWidth / 2));
+    const nextHeight = Math.max(1, Math.floor(currentHeight / 2));
+    const downsampled = new Float32Array(nextWidth * nextHeight);
+    for (let y = 0; y < nextHeight; y += 1) {
+      for (let x = 0; x < nextWidth; x += 1) {
+        let total = 0;
+        let count = 0;
+        for (let dy = 0; dy < 2; dy += 1) {
+          for (let dx = 0; dx < 2; dx += 1) {
+            const srcX = Math.min(currentWidth - 1, x * 2 + dx);
+            const srcY = Math.min(currentHeight - 1, y * 2 + dy);
+            total += previous[srcY * currentWidth + srcX];
+            count += 1;
+          }
+        }
+        downsampled[y * nextWidth + x] = total / count;
+      }
+    }
+    blurField(downsampled, nextWidth, nextHeight, Math.max(0, smoothIterations - 1));
+    pyramidLevels.push({ width: nextWidth, height: nextHeight, data: downsampled, scale: 2 ** level });
+    previous = downsampled;
+    currentWidth = nextWidth;
+    currentHeight = nextHeight;
+  }
+
+  return { width, height, levels: pyramidLevels };
+};
+
+class MinHeap {
+  private heap: Array<{ index: number; cost: number }> = [];
+
+  push(node: { index: number; cost: number }) {
+    this.heap.push(node);
+    this.bubbleUp(this.heap.length - 1);
+  }
+
+  pop(): { index: number; cost: number } | undefined {
+    if (this.heap.length === 0) {
+      return undefined;
+    }
+    const top = this.heap[0];
+    const end = this.heap.pop()!;
+    if (this.heap.length > 0) {
+      this.heap[0] = end;
+      this.bubbleDown(0);
+    }
+    return top;
+  }
+
+  private bubbleUp(index: number) {
+    while (index > 0) {
+      const parent = Math.floor((index - 1) / 2);
+      if (this.heap[parent].cost <= this.heap[index].cost) {
+        break;
+      }
+      [this.heap[parent], this.heap[index]] = [this.heap[index], this.heap[parent]];
+      index = parent;
+    }
+  }
+
+  private bubbleDown(index: number) {
+    const length = this.heap.length;
+    while (true) {
+      let left = index * 2 + 1;
+      let right = left + 1;
+      let smallest = index;
+      if (left < length && this.heap[left].cost < this.heap[smallest].cost) {
+        smallest = left;
+      }
+      if (right < length && this.heap[right].cost < this.heap[smallest].cost) {
+        smallest = right;
+      }
+      if (smallest === index) {
+        break;
+      }
+      [this.heap[index], this.heap[smallest]] = [this.heap[smallest], this.heap[index]];
+      index = smallest;
+    }
+  }
+
+  get size() {
+    return this.heap.length;
+  }
+}
+
+export const traceLiveWire = (
+  pyramid: CostPyramid,
+  start: Point,
+  end: Point,
+  options?: LiveWireOptions
+): Point[] => {
+  const base = pyramid.levels[0];
+  const width = base.width;
+  const height = base.height;
+  const startX = clamp(Math.round(start.x * (width - 1)), 0, width - 1);
+  const startY = clamp(Math.round(start.y * (height - 1)), 0, height - 1);
+  const endX = clamp(Math.round(end.x * (width - 1)), 0, width - 1);
+  const endY = clamp(Math.round(end.y * (height - 1)), 0, height - 1);
+  const startIndex = startY * width + startX;
+  const endIndex = endY * width + endX;
+
+  const allowDiagonals = options?.allowDiagonals ?? true;
+
+  const dist = new Float32Array(width * height);
+  dist.fill(Number.POSITIVE_INFINITY);
+  const prev = new Int32Array(width * height);
+  prev.fill(-1);
+  const visited = new Uint8Array(width * height);
+
+  const heap = new MinHeap();
+  dist[startIndex] = 0;
+  heap.push({ index: startIndex, cost: 0 });
+
+  const directions = allowDiagonals
+    ? [
+        { dx: 1, dy: 0, weight: 1 },
+        { dx: -1, dy: 0, weight: 1 },
+        { dx: 0, dy: 1, weight: 1 },
+        { dx: 0, dy: -1, weight: 1 },
+        { dx: 1, dy: 1, weight: Math.SQRT2 },
+        { dx: -1, dy: 1, weight: Math.SQRT2 },
+        { dx: 1, dy: -1, weight: Math.SQRT2 },
+        { dx: -1, dy: -1, weight: Math.SQRT2 },
+      ]
+    : [
+        { dx: 1, dy: 0, weight: 1 },
+        { dx: -1, dy: 0, weight: 1 },
+        { dx: 0, dy: 1, weight: 1 },
+        { dx: 0, dy: -1, weight: 1 },
+      ];
+
+  while (heap.size) {
+    const node = heap.pop();
+    if (!node) break;
+    const { index, cost } = node;
+    if (visited[index]) continue;
+    visited[index] = 1;
+    if (index === endIndex) break;
+
+    const x = index % width;
+    const y = Math.floor(index / width);
+    for (const direction of directions) {
+      const nx = x + direction.dx;
+      const ny = y + direction.dy;
+      if (nx < 0 || nx >= width || ny < 0 || ny >= height) continue;
+      const neighborIndex = ny * width + nx;
+      if (visited[neighborIndex]) continue;
+      const edgeCost = (base.data[neighborIndex] + base.data[index]) * 0.5 + direction.weight;
+      const nextCost = cost + edgeCost;
+      if (nextCost < dist[neighborIndex]) {
+        dist[neighborIndex] = nextCost;
+        prev[neighborIndex] = index;
+        heap.push({ index: neighborIndex, cost: nextCost });
+      }
+    }
+  }
+
+  const path: Point[] = [];
+  let current = endIndex;
+  if (prev[current] === -1) {
+    path.push(start, end);
+    return path;
+  }
+  while (current !== -1) {
+    const x = (current % width) / (width - 1 || 1);
+    const y = Math.floor(current / width) / (height - 1 || 1);
+    path.push({ x, y });
+    if (current === startIndex) break;
+    current = prev[current];
+  }
+  path.reverse();
+  return path;
+};
+
+const colorDistance = (a: [number, number, number], b: [number, number, number]) => {
+  const dr = a[0] - b[0];
+  const dg = a[1] - b[1];
+  const db = a[2] - b[2];
+  return Math.sqrt(dr * dr + dg * dg + db * db);
+};
+
+const marchingSquares = (mask: Uint8Array, width: number, height: number) => {
+  const segments: Array<{ start: Point; end: Point }> = [];
+
+  const edgePoint = (x: number, y: number, edge: 'top' | 'bottom' | 'left' | 'right'): Point => {
+    switch (edge) {
+      case 'top':
+        return { x: x + 0.5, y };
+      case 'bottom':
+        return { x: x + 0.5, y: y + 1 };
+      case 'left':
+        return { x, y: y + 0.5 };
+      case 'right':
+        return { x: x + 1, y: y + 0.5 };
+    }
+  };
+
+  const templates: Record<number, Array<[Point, Point]>> = {
+    0: [],
+    1: [[edgePoint(0, 0, 'left'), edgePoint(0, 0, 'top')]],
+    2: [[edgePoint(0, 0, 'top'), edgePoint(0, 0, 'right')]],
+    3: [[edgePoint(0, 0, 'left'), edgePoint(0, 0, 'right')]],
+    4: [[edgePoint(0, 0, 'right'), edgePoint(0, 0, 'bottom')]],
+    5: [
+      [edgePoint(0, 0, 'left'), edgePoint(0, 0, 'bottom')],
+      [edgePoint(0, 0, 'top'), edgePoint(0, 0, 'right')],
+    ],
+    6: [[edgePoint(0, 0, 'top'), edgePoint(0, 0, 'bottom')]],
+    7: [[edgePoint(0, 0, 'left'), edgePoint(0, 0, 'bottom')]],
+    8: [[edgePoint(0, 0, 'bottom'), edgePoint(0, 0, 'left')]],
+    9: [[edgePoint(0, 0, 'top'), edgePoint(0, 0, 'bottom')]],
+    10: [
+      [edgePoint(0, 0, 'top'), edgePoint(0, 0, 'right')],
+      [edgePoint(0, 0, 'bottom'), edgePoint(0, 0, 'left')],
+    ],
+    11: [[edgePoint(0, 0, 'right'), edgePoint(0, 0, 'bottom')]],
+    12: [[edgePoint(0, 0, 'right'), edgePoint(0, 0, 'left')]],
+    13: [[edgePoint(0, 0, 'top'), edgePoint(0, 0, 'right')]],
+    14: [[edgePoint(0, 0, 'left'), edgePoint(0, 0, 'top')]],
+    15: [],
+  };
+
+  for (let y = 0; y < height - 1; y += 1) {
+    for (let x = 0; x < width - 1; x += 1) {
+      const topLeft = mask[y * width + x] > 0;
+      const topRight = mask[y * width + x + 1] > 0;
+      const bottomRight = mask[(y + 1) * width + x + 1] > 0;
+      const bottomLeft = mask[(y + 1) * width + x] > 0;
+      let key = 0;
+      if (topLeft) key |= 1;
+      if (topRight) key |= 2;
+      if (bottomRight) key |= 4;
+      if (bottomLeft) key |= 8;
+      if (key === 0 || key === 15) continue;
+      const template = templates[key];
+      for (const [start, end] of template) {
+        segments.push({
+          start: { x: start.x + x, y: start.y + y },
+          end: { x: end.x + x, y: end.y + y },
+        });
+      }
+    }
+  }
+
+  if (segments.length === 0) {
+    return [] as Point[];
+  }
+
+  const polygon: Point[] = [];
+  const used = new Array(segments.length).fill(false);
+  polygon.push(segments[0].start);
+  polygon.push(segments[0].end);
+  used[0] = true;
+
+  const equals = (a: Point, b: Point) => nearlyEqual(a.x, b.x, 1e-3) && nearlyEqual(a.y, b.y, 1e-3);
+
+  while (polygon.length < 5000) {
+    const current = polygon[polygon.length - 1];
+    let advanced = false;
+    for (let i = 0; i < segments.length; i += 1) {
+      if (used[i]) continue;
+      const segment = segments[i];
+      if (equals(segment.start, current)) {
+        polygon.push(segment.end);
+        used[i] = true;
+        advanced = true;
+        break;
+      }
+      if (equals(segment.end, current)) {
+        polygon.push(segment.start);
+        used[i] = true;
+        advanced = true;
+        break;
+      }
+    }
+    if (!advanced) {
+      break;
+    }
+    if (equals(polygon[polygon.length - 1], polygon[0])) {
+      polygon.pop();
+      break;
+    }
+  }
+
+  return polygon;
+};
+
+const dedupePoints = (points: Point[]) => {
+  const seen = new Set<string>();
+  return points.filter((point) => {
+    const key = pointKey(point);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+};
+
+const simplifyDouglasPeucker = (points: Point[], tolerance: number) => {
+  if (points.length <= 2) {
+    return points.slice();
+  }
+  const sqTolerance = tolerance * tolerance;
+
+  const sqDistanceToSegment = (p: Point, a: Point, b: Point) => {
+    let x = a.x;
+    let y = a.y;
+    let dx = b.x - x;
+    let dy = b.y - y;
+    if (dx !== 0 || dy !== 0) {
+      const t = ((p.x - x) * dx + (p.y - y) * dy) / (dx * dx + dy * dy);
+      if (t > 1) {
+        x = b.x;
+        y = b.y;
+      } else if (t > 0) {
+        x += dx * t;
+        y += dy * t;
+      }
+    }
+    dx = p.x - x;
+    dy = p.y - y;
+    return dx * dx + dy * dy;
+  };
+
+  const simplifyStep = (pts: Point[], first: number, last: number, simplified: Point[]) => {
+    let maxSqDist = sqTolerance;
+    let index = -1;
+    for (let i = first + 1; i < last; i += 1) {
+      const sqDist = sqDistanceToSegment(pts[i], pts[first], pts[last]);
+      if (sqDist > maxSqDist) {
+        index = i;
+        maxSqDist = sqDist;
+      }
+    }
+    if (index !== -1) {
+      if (index - first > 1) simplifyStep(pts, first, index, simplified);
+      simplified.push(pts[index]);
+      if (last - index > 1) simplifyStep(pts, index, last, simplified);
+    }
+  };
+
+  const last = points.length - 1;
+  const result = [points[0]];
+  simplifyStep(points, 0, last, result);
+  result.push(points[last]);
+  return result;
+};
+
+const maskToPolygon = (
+  mask: Uint8Array,
+  width: number,
+  height: number,
+  bounds: { minX: number; minY: number; maxX: number; maxY: number }
+) => {
+  const raw = marchingSquares(mask, width, height);
+  if (raw.length === 0) {
+    return [] as Point[];
+  }
+  const scaleX = bounds.maxX - bounds.minX || 1;
+  const scaleY = bounds.maxY - bounds.minY || 1;
+  const widthDenominator = width - 1 || 1;
+  const heightDenominator = height - 1 || 1;
+  const polygon = raw.map((point) => ({
+    x: bounds.minX + (point.x / widthDenominator) * scaleX,
+    y: bounds.minY + (point.y / heightDenominator) * scaleY,
+  }));
+  return simplifyDouglasPeucker(dedupePoints(polygon), 0.001);
+};
+
+const computeMaskBounds = (mask: Uint8Array, width: number, height: number) => {
+  let minX = width;
+  let minY = height;
+  let maxX = 0;
+  let maxY = 0;
+  let area = 0;
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      if (mask[y * width + x]) {
+        area += 1;
+        if (x < minX) minX = x;
+        if (y < minY) minY = y;
+        if (x > maxX) maxX = x;
+        if (y > maxY) maxY = y;
+      }
+    }
+  }
+  if (area === 0) {
+    return { bounds: { minX: 0, minY: 0, maxX: 0, maxY: 0 }, area: 0 };
+  }
+  return {
+    bounds: {
+      minX: minX / (width - 1 || 1),
+      minY: minY / (height - 1 || 1),
+      maxX: maxX / (width - 1 || 1),
+      maxY: maxY / (height - 1 || 1),
+    },
+    area,
+  };
+};
+
+export const smartWand = (
+  image: Uint8ClampedArray | Uint8Array,
+  width: number,
+  height: number,
+  seed: Point,
+  options?: SmartWandOptions
+): SmartWandResult => {
+  const pixels = width * height;
+  const channels = Math.floor(image.length / pixels);
+  if (channels < 3) {
+    throw new Error('Smart wand requires RGB or RGBA image data');
+  }
+  const stride = channels >= 4 ? 4 : 3;
+  const tolerance = clamp(options?.tolerance ?? 24, 1, 255);
+  const connectivity = options?.connectivity === 4 ? 4 : 8;
+
+  const sx = clamp(Math.round(seed.x * (width - 1)), 0, width - 1);
+  const sy = clamp(Math.round(seed.y * (height - 1)), 0, height - 1);
+  const seedIndex = sy * width + sx;
+  const seedColor: [number, number, number] = [
+    image[seedIndex * stride],
+    image[seedIndex * stride + 1],
+    image[seedIndex * stride + 2],
+  ];
+
+  const visited = new Uint8Array(pixels);
+  const mask = new Uint8Array(pixels);
+  const queue = new Uint32Array(pixels);
+  let head = 0;
+  let tail = 0;
+  queue[tail++] = seedIndex;
+  visited[seedIndex] = 1;
+  mask[seedIndex] = 1;
+
+  const neighborOffsets = connectivity === 8 ? [-width - 1, -width, -width + 1, -1, 1, width - 1, width, width + 1] : [-width, -1, 1, width];
+
+  while (head < tail) {
+    const currentIndex = queue[head++];
+    const currentColor: [number, number, number] = [
+      image[currentIndex * stride],
+      image[currentIndex * stride + 1],
+      image[currentIndex * stride + 2],
+    ];
+    for (const offset of neighborOffsets) {
+      const neighborIndex = currentIndex + offset;
+      if (neighborIndex < 0 || neighborIndex >= pixels) continue;
+      if (visited[neighborIndex]) continue;
+      const nx = neighborIndex % width;
+      const ny = Math.floor(neighborIndex / width);
+      const cx = currentIndex % width;
+      const cy = Math.floor(currentIndex / width);
+      if (Math.abs(nx - cx) > 1 || Math.abs(ny - cy) > 1) continue;
+      visited[neighborIndex] = 1;
+      const neighborColor: [number, number, number] = [
+        image[neighborIndex * stride],
+        image[neighborIndex * stride + 1],
+        image[neighborIndex * stride + 2],
+      ];
+      const diff = colorDistance(currentColor, neighborColor);
+      const seedDiff = colorDistance(seedColor, neighborColor);
+      if (diff <= tolerance && seedDiff <= tolerance * 1.5) {
+        mask[neighborIndex] = 1;
+        queue[tail++] = neighborIndex;
+      }
+    }
+  }
+
+  if (options?.softenEdges) {
+    const smoothed = new Float32Array(pixels);
+    for (let y = 0; y < height; y += 1) {
+      for (let x = 0; x < width; x += 1) {
+        let total = 0;
+        let count = 0;
+        for (let dy = -1; dy <= 1; dy += 1) {
+          for (let dx = -1; dx <= 1; dx += 1) {
+            const nx = x + dx;
+            const ny = y + dy;
+            if (nx < 0 || nx >= width || ny < 0 || ny >= height) continue;
+            total += mask[ny * width + nx];
+            count += 1;
+          }
+        }
+        smoothed[y * width + x] = total / count;
+      }
+    }
+    for (let i = 0; i < pixels; i += 1) {
+      mask[i] = smoothed[i] >= 0.35 ? 1 : 0;
+    }
+  }
+
+  let stats = computeMaskBounds(mask, width, height);
+  const minArea = Math.max(1, Math.round(options?.minArea ?? width * height * 0.0005));
+  if (stats.area < minArea) {
+    mask.fill(0);
+    mask[seedIndex] = 1;
+    stats = computeMaskBounds(mask, width, height);
+  }
+
+  const polygon = maskToPolygon(mask, width, height, { minX: 0, minY: 0, maxX: 1, maxY: 1 });
+  if (polygon.length === 0) {
+    polygon.push({ x: seed.x, y: seed.y });
+  }
+
+  return {
+    mask,
+    width,
+    height,
+    polygon,
+    bounds: stats.bounds,
+    seed,
+    area: stats.area,
+  };
+};
+
+const distanceTransform = (mask: Uint8Array, width: number, height: number, invert: boolean) => {
+  const dist = new Float32Array(width * height);
+  const INF = 1e6;
+  for (let i = 0; i < width * height; i += 1) {
+    const inside = mask[i] > 0;
+    dist[i] = invert ? (inside ? INF : 0) : inside ? 0 : INF;
+  }
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      const index = y * width + x;
+      let value = dist[index];
+      if (x > 0) value = Math.min(value, dist[index - 1] + 1);
+      if (y > 0) value = Math.min(value, dist[index - width] + 1);
+      if (x > 0 && y > 0) value = Math.min(value, dist[index - width - 1] + Math.SQRT2);
+      if (x < width - 1 && y > 0) value = Math.min(value, dist[index - width + 1] + Math.SQRT2);
+      dist[index] = value;
+    }
+  }
+  for (let y = height - 1; y >= 0; y -= 1) {
+    for (let x = width - 1; x >= 0; x -= 1) {
+      const index = y * width + x;
+      let value = dist[index];
+      if (x < width - 1) value = Math.min(value, dist[index + 1] + 1);
+      if (y < height - 1) value = Math.min(value, dist[index + width] + 1);
+      if (x < width - 1 && y < height - 1) value = Math.min(value, dist[index + width + 1] + Math.SQRT2);
+      if (x > 0 && y < height - 1) value = Math.min(value, dist[index + width - 1] + Math.SQRT2);
+      dist[index] = value;
+    }
+  }
+  return dist;
+};
+
+export const computeSignedDistanceField = (
+  mask: Uint8Array,
+  width: number,
+  height: number
+): SignedDistanceField => {
+  const inside = distanceTransform(mask, width, height, false);
+  const outside = distanceTransform(mask, width, height, true);
+  const values = new Float32Array(width * height);
+  const scale = Math.max(width, height) || 1;
+  for (let i = 0; i < values.length; i += 1) {
+    const outsideDist = Math.sqrt(outside[i]);
+    const insideDist = Math.sqrt(inside[i]);
+    values[i] = (outsideDist - insideDist) / scale;
+  }
+  return {
+    width,
+    height,
+    bounds: { minX: 0, minY: 0, maxX: 1, maxY: 1 },
+    values,
+  };
+};
+
+export const fitVectorPath = (
+  mask: Uint8Array,
+  width: number,
+  height: number,
+  options?: VectorFitOptions
+): Point[] => {
+  const polygon = maskToPolygon(mask, width, height, { minX: 0, minY: 0, maxX: 1, maxY: 1 });
+  if (polygon.length === 0) {
+    return [];
+  }
+  const tolerance = clamp(options?.simplifyTolerance ?? 0.0025, 0.0001, 0.01);
+  return simplifyDouglasPeucker(polygon, tolerance);
+};
+
+export class SegmentationWorker {
+  private image: Uint8ClampedArray | Uint8Array | null = null;
+
+  private width = 0;
+
+  private height = 0;
+
+  private pyramid: CostPyramid | null = null;
+
+  constructor(private readonly options?: CostPyramidOptions) {}
+
+  loadImage(image: Uint8ClampedArray | Uint8Array, width: number, height: number) {
+    this.image = image;
+    this.width = width;
+    this.height = height;
+    this.pyramid = buildCostPyramid(image, width, height, this.options);
+  }
+
+  ensureImage() {
+    if (!this.image) {
+      throw new Error('Segmentation worker has no source image loaded');
+    }
+  }
+
+  ensurePyramid() {
+    if (!this.pyramid) {
+      this.ensureImage();
+      this.pyramid = buildCostPyramid(this.image!, this.width, this.height, this.options);
+    }
+  }
+
+  async liveWire(start: Point, end: Point, options?: LiveWireOptions): Promise<Point[]> {
+    this.ensurePyramid();
+    return traceLiveWire(this.pyramid!, start, end, options);
+  }
+
+  async smartWand(seed: Point, options?: SmartWandOptions): Promise<SmartWandResult> {
+    this.ensureImage();
+    return smartWand(this.image!, this.width, this.height, seed, options);
+  }
+
+  async signedDistanceFromMask(mask: Uint8Array): Promise<SignedDistanceField> {
+    if (!this.width || !this.height) {
+      throw new Error('Segmentation worker is missing image dimensions');
+    }
+    return computeSignedDistanceField(mask, this.width, this.height);
+  }
+
+  async vectorFromMask(mask: Uint8Array, options?: VectorFitOptions): Promise<Point[]> {
+    if (!this.width || !this.height) {
+      throw new Error('Segmentation worker is missing image dimensions');
+    }
+    return fitVectorPath(mask, this.width, this.height, options);
+  }
+
+  getCostPyramid(): CostPyramid | null {
+    return this.pyramid;
+  }
+}
+
+export const createSegmentationWorker = (options?: CostPyramidOptions) => new SegmentationWorker(options);
+


### PR DESCRIPTION
## Summary
- add a defineRoomsStore module that manages editing state, brush interactions, gap markers, and SDF/vector round-trip helpers
- implement the seg worker with cost pyramid generation, live-wire pathing, smart wand region growing, and signed-distance/vector fitting utilities
- introduce paintbrush, lasso, smart lasso, and auto wand tool implementations that operate through a shared ToolContext

## Testing
- npm install *(fails: registry returned 403 for @types/react)*

------
https://chatgpt.com/codex/tasks/task_e_68d20e464378832399b57cd91d36fff2