### PR TITLE
test: scaffold DefineRoomsEditor harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/apps/pages/package.json
+++ b/apps/pages/package.json
@@ -14,6 +14,8 @@
   },
   "devDependencies": {
     "@types/react": "^18.2.14",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/user-event": "^14.4.3",
     "@types/react-dom": "^18.2.6",
     "@vitejs/plugin-react-swc": "^3.3.2",
     "autoprefixer": "^10.4.15",

--- a/apps/pages/src/components/__tests__/DefineRoomsEditor.spec.tsx
+++ b/apps/pages/src/components/__tests__/DefineRoomsEditor.spec.tsx
@@ -1,0 +1,211 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import DefineRoomsEditor from '../DefineRoomsEditor';
+
+const DEFAULT_IMAGE_DIMENSIONS = { width: 2048, height: 1024 };
+const DEFAULT_CONTAINER_RECT = {
+  x: 24,
+  y: 32,
+  width: 960,
+  height: 640,
+  top: 32,
+  left: 24,
+  right: 24 + 960,
+  bottom: 32 + 640,
+  toJSON() {
+    return {
+      x: this.x,
+      y: this.y,
+      width: this.width,
+      height: this.height,
+      top: this.top,
+      left: this.left,
+      right: this.right,
+      bottom: this.bottom,
+    };
+  },
+};
+
+let mockContainerRect = { ...DEFAULT_CONTAINER_RECT };
+let mockImageNaturalSize = { ...DEFAULT_IMAGE_DIMENSIONS };
+let mockImageComplete = true;
+
+const originalResizeObserver = globalThis.ResizeObserver;
+const originalSetPointerCapture = SVGElement.prototype.setPointerCapture;
+const originalReleasePointerCapture = SVGElement.prototype.releasePointerCapture;
+const originalDivGetBoundingClientRect = HTMLDivElement.prototype.getBoundingClientRect;
+const originalImageNaturalWidthDescriptor = Object.getOwnPropertyDescriptor(HTMLImageElement.prototype, 'naturalWidth');
+const originalImageNaturalHeightDescriptor = Object.getOwnPropertyDescriptor(HTMLImageElement.prototype, 'naturalHeight');
+const originalImageCompleteDescriptor = Object.getOwnPropertyDescriptor(HTMLImageElement.prototype, 'complete');
+
+class MockResizeObserver {
+  private callback: ResizeObserverCallback;
+
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback;
+  }
+
+  observe(target: Element) {
+    this.callback(
+      [
+        {
+          target,
+          contentRect: { ...mockContainerRect },
+        } as ResizeObserverEntry,
+      ],
+      this as unknown as ResizeObserver
+    );
+  }
+
+  unobserve() {}
+
+  disconnect() {}
+}
+
+beforeEach(() => {
+  mockContainerRect = { ...DEFAULT_CONTAINER_RECT };
+  mockImageNaturalSize = { ...DEFAULT_IMAGE_DIMENSIONS };
+  mockImageComplete = true;
+
+  (globalThis as { ResizeObserver?: typeof ResizeObserver }).ResizeObserver =
+    MockResizeObserver as unknown as typeof ResizeObserver;
+
+  Object.defineProperty(SVGElement.prototype, 'setPointerCapture', {
+    configurable: true,
+    value: vi.fn(),
+  });
+  Object.defineProperty(SVGElement.prototype, 'releasePointerCapture', {
+    configurable: true,
+    value: vi.fn(),
+  });
+
+  Object.defineProperty(HTMLDivElement.prototype, 'getBoundingClientRect', {
+    configurable: true,
+    value: vi.fn(() => ({ ...mockContainerRect })),
+  });
+
+  Object.defineProperty(HTMLImageElement.prototype, 'naturalWidth', {
+    configurable: true,
+    get() {
+      return mockImageNaturalSize.width;
+    },
+  });
+  Object.defineProperty(HTMLImageElement.prototype, 'naturalHeight', {
+    configurable: true,
+    get() {
+      return mockImageNaturalSize.height;
+    },
+  });
+  Object.defineProperty(HTMLImageElement.prototype, 'complete', {
+    configurable: true,
+    get() {
+      return mockImageComplete;
+    },
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+
+  mockContainerRect = { ...DEFAULT_CONTAINER_RECT };
+  mockImageNaturalSize = { ...DEFAULT_IMAGE_DIMENSIONS };
+  mockImageComplete = true;
+
+  if (originalResizeObserver) {
+    (globalThis as { ResizeObserver?: typeof ResizeObserver }).ResizeObserver = originalResizeObserver;
+  } else {
+    delete (globalThis as { ResizeObserver?: typeof ResizeObserver }).ResizeObserver;
+  }
+
+  if (originalSetPointerCapture) {
+    Object.defineProperty(SVGElement.prototype, 'setPointerCapture', {
+      configurable: true,
+      value: originalSetPointerCapture,
+    });
+  } else {
+    delete (SVGElement.prototype as { setPointerCapture?: typeof SVGElement.prototype.setPointerCapture }).setPointerCapture;
+  }
+
+  if (originalReleasePointerCapture) {
+    Object.defineProperty(SVGElement.prototype, 'releasePointerCapture', {
+      configurable: true,
+      value: originalReleasePointerCapture,
+    });
+  } else {
+    delete (
+      SVGElement.prototype as { releasePointerCapture?: typeof SVGElement.prototype.releasePointerCapture }
+    ).releasePointerCapture;
+  }
+
+  if (originalDivGetBoundingClientRect) {
+    Object.defineProperty(HTMLDivElement.prototype, 'getBoundingClientRect', {
+      configurable: true,
+      value: originalDivGetBoundingClientRect,
+    });
+  } else {
+    delete (HTMLDivElement.prototype as { getBoundingClientRect?: () => DOMRect }).getBoundingClientRect;
+  }
+
+  if (originalImageNaturalWidthDescriptor) {
+    Object.defineProperty(HTMLImageElement.prototype, 'naturalWidth', originalImageNaturalWidthDescriptor);
+  } else {
+    delete (HTMLImageElement.prototype as { naturalWidth?: number }).naturalWidth;
+  }
+
+  if (originalImageNaturalHeightDescriptor) {
+    Object.defineProperty(HTMLImageElement.prototype, 'naturalHeight', originalImageNaturalHeightDescriptor);
+  } else {
+    delete (HTMLImageElement.prototype as { naturalHeight?: number }).naturalHeight;
+  }
+
+  if (originalImageCompleteDescriptor) {
+    Object.defineProperty(HTMLImageElement.prototype, 'complete', originalImageCompleteDescriptor);
+  } else {
+    delete (HTMLImageElement.prototype as { complete?: boolean }).complete;
+  }
+});
+
+type DefineRoomsEditorProps = Parameters<typeof DefineRoomsEditor>[0];
+
+export const renderEditor = async (overrideProps: Partial<DefineRoomsEditorProps> = {}) => {
+  const onRoomsChange = overrideProps.onRoomsChange ?? vi.fn();
+
+  const props: DefineRoomsEditorProps = {
+    imageUrl: overrideProps.imageUrl ?? 'https://example.com/floorplan.png',
+    imageDimensions: overrideProps.imageDimensions ?? { ...DEFAULT_IMAGE_DIMENSIONS },
+    rooms: overrideProps.rooms ?? [],
+    onRoomsChange,
+  };
+
+  if (props.imageDimensions) {
+    mockImageNaturalSize = { ...props.imageDimensions };
+  }
+  mockImageComplete = true;
+
+  const user = userEvent.setup();
+
+  const view = render(<DefineRoomsEditor {...props} />);
+
+  const image = (await screen.findByRole('img', { name: 'Map editor' })) as HTMLImageElement;
+  fireEvent.load(image);
+
+  const overlay = (await screen.findByRole('presentation')) as SVGSVGElement;
+  const container = image.parentElement as HTMLDivElement;
+
+  return {
+    ...view,
+    container,
+    image,
+    overlay,
+    onRoomsChange,
+    user,
+  };
+};
+
+describe('DefineRoomsEditor harness', () => {
+  it('renders an overlay once the mocked image has loaded', async () => {
+    const { overlay } = await renderEditor();
+    expect(overlay.tagName).toBe('SVG');
+  });
+});

--- a/apps/pages/src/test-utils/testing-library-react.tsx
+++ b/apps/pages/src/test-utils/testing-library-react.tsx
@@ -1,0 +1,266 @@
+import type { ReactElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+interface RoleOptions {
+  name?: string | RegExp;
+}
+
+interface RenderRecord {
+  container: HTMLElement;
+  root: Root;
+  shouldRemove: boolean;
+}
+
+const mountedRoots = new Set<RenderRecord>();
+
+export const cleanup = () => {
+  for (const entry of Array.from(mountedRoots)) {
+    entry.root.unmount();
+    if (entry.shouldRemove && entry.container.parentNode) {
+      entry.container.parentNode.removeChild(entry.container);
+    }
+    mountedRoots.delete(entry);
+  }
+};
+
+export const render = (
+  ui: ReactElement,
+  options: { container?: HTMLElement; baseElement?: HTMLElement } = {}
+) => {
+  const baseElement = options.baseElement ?? document.body;
+  const container = options.container ?? document.createElement('div');
+  if (!options.container) {
+    baseElement.appendChild(container);
+  }
+  const root = createRoot(container);
+  root.render(ui);
+  const record: RenderRecord = { container, root, shouldRemove: !options.container };
+  mountedRoots.add(record);
+
+  return {
+    container,
+    baseElement,
+    rerender(nextUi: ReactElement) {
+      root.render(nextUi);
+    },
+    unmount() {
+      root.unmount();
+      mountedRoots.delete(record);
+      if (record.shouldRemove && container.parentNode) {
+        container.parentNode.removeChild(container);
+      }
+    },
+  };
+};
+
+const pointerEventCtor: typeof PointerEvent | typeof MouseEvent =
+  typeof PointerEvent === 'function' ? PointerEvent : (MouseEvent as unknown as typeof PointerEvent);
+const mouseEventCtor = typeof MouseEvent === 'function' ? MouseEvent : Event;
+
+const dispatch = (element: EventTarget, event: Event) => element.dispatchEvent(event);
+
+const createMouseEvent = (type: string, init: MouseEventInit = {}) =>
+  new mouseEventCtor(type, { bubbles: true, cancelable: true, ...init });
+
+const createPointerEvent = (type: string, init: PointerEventInit = {}) =>
+  new pointerEventCtor(type, {
+    bubbles: true,
+    cancelable: true,
+    pointerId: init.pointerId ?? 1,
+    pointerType: init.pointerType ?? 'mouse',
+    ...init,
+  });
+
+export const fireEvent = Object.assign(dispatch, {
+  load(element: EventTarget) {
+    return dispatch(element, new Event('load'));
+  },
+  pointerDown(element: EventTarget, init: PointerEventInit = {}) {
+    return dispatch(element, createPointerEvent('pointerdown', init));
+  },
+  pointerMove(element: EventTarget, init: PointerEventInit = {}) {
+    return dispatch(element, createPointerEvent('pointermove', init));
+  },
+  pointerUp(element: EventTarget, init: PointerEventInit = {}) {
+    return dispatch(element, createPointerEvent('pointerup', init));
+  },
+  pointerCancel(element: EventTarget, init: PointerEventInit = {}) {
+    return dispatch(element, createPointerEvent('pointercancel', init));
+  },
+  pointerLeave(element: EventTarget, init: PointerEventInit = {}) {
+    return dispatch(element, createPointerEvent('pointerleave', init));
+  },
+  contextMenu(element: EventTarget, init: MouseEventInit = {}) {
+    return dispatch(element, createMouseEvent('contextmenu', init));
+  },
+  click(element: EventTarget, init: MouseEventInit = {}) {
+    return dispatch(element, createMouseEvent('click', init));
+  },
+});
+
+const normalizeText = (value: string | null | undefined) => value?.replace(/\s+/g, ' ').trim() ?? '';
+
+const matchesRole = (element: Element, role: string) => {
+  const explicit = element.getAttribute('role');
+  if (explicit && explicit.split(/\s+/).includes(role)) {
+    return true;
+  }
+  const tag = element.tagName.toLowerCase();
+  if (role === 'img') {
+    return tag === 'img';
+  }
+  if (role === 'button') {
+    if (tag === 'button') return true;
+    if (tag === 'input') {
+      const type = (element as HTMLInputElement).type.toLowerCase();
+      return ['button', 'submit', 'reset'].includes(type);
+    }
+  }
+  if (role === 'textbox') {
+    if (tag === 'textarea') return true;
+    if (tag === 'input') {
+      const type = (element as HTMLInputElement).type.toLowerCase();
+      return (
+        type === '' ||
+        ['text', 'search', 'url', 'tel', 'email', 'password'].includes(type)
+      );
+    }
+  }
+  if (role === 'slider') {
+    return tag === 'input' && (element as HTMLInputElement).type.toLowerCase() === 'range';
+  }
+  if (role === 'checkbox') {
+    return tag === 'input' && (element as HTMLInputElement).type.toLowerCase() === 'checkbox';
+  }
+  if (role === 'radio') {
+    return tag === 'input' && (element as HTMLInputElement).type.toLowerCase() === 'radio';
+  }
+  if (role === 'spinbutton') {
+    return tag === 'input' && (element as HTMLInputElement).type.toLowerCase() === 'number';
+  }
+  if (role === 'combobox') {
+    return tag === 'select' && !(element as HTMLSelectElement).multiple;
+  }
+  if (role === 'listbox') {
+    return tag === 'select' && (element as HTMLSelectElement).multiple;
+  }
+  return false;
+};
+
+const getAccessibleName = (element: Element): string => {
+  const ariaLabel = element.getAttribute('aria-label');
+  if (ariaLabel) {
+    return normalizeText(ariaLabel);
+  }
+  const ariaLabelledBy = element.getAttribute('aria-labelledby');
+  if (ariaLabelledBy) {
+    const doc = element.ownerDocument ?? document;
+    const text = ariaLabelledBy
+      .split(/\s+/)
+      .map((id) => doc.getElementById(id))
+      .filter((node): node is HTMLElement => Boolean(node))
+      .map((node) => normalizeText(node.textContent))
+      .join(' ');
+    if (text) {
+      return normalizeText(text);
+    }
+  }
+  if (element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement || element instanceof HTMLSelectElement) {
+    const labels = element.labels ? Array.from(element.labels) : [];
+    if (labels.length) {
+      return normalizeText(labels.map((label) => normalizeText(label.textContent)).join(' '));
+    }
+  }
+  if (element instanceof HTMLImageElement && element.alt) {
+    return normalizeText(element.alt);
+  }
+  return normalizeText(element.textContent);
+};
+
+const filterByRole = (elements: Element[], role: string, options: RoleOptions) => {
+  const { name } = options;
+  return elements.filter((element) => {
+    if (!matchesRole(element, role)) {
+      return false;
+    }
+    if (name == null) {
+      return true;
+    }
+    const accessibleName = getAccessibleName(element);
+    if (typeof name === 'string') {
+      return accessibleName === name;
+    }
+    return name.test(accessibleName);
+  }) as HTMLElement[];
+};
+
+const queryAllByRole = (container: Element | Document, role: string, options: RoleOptions = {}) => {
+  const elements = [
+    ...(container instanceof Element && matchesRole(container, role) ? [container] : []),
+    ...Array.from(container.querySelectorAll('*')).filter((element) => matchesRole(element, role)),
+  ];
+  return filterByRole(Array.from(new Set(elements)), role, options);
+};
+
+const roleError = (role: string, options: RoleOptions, found: number) => {
+  const nameInfo = options.name
+    ? ` and name ${typeof options.name === 'string' ? `"${options.name}"` : options.name}`
+    : '';
+  const base = found === 0 ? 'Unable to find' : 'Found multiple';
+  const suffix = found === 0 ? '' : ` (${found} elements)`;
+  return new Error(`${base} element${found !== 1 ? 's' : ''} with role ${role}${nameInfo}${suffix}.`);
+};
+
+const getByRole = (container: Element | Document, role: string, options: RoleOptions = {}) => {
+  const results = queryAllByRole(container, role, options);
+  if (results.length === 0) {
+    throw roleError(role, options, 0);
+  }
+  if (results.length > 1) {
+    throw roleError(role, options, results.length);
+  }
+  return results[0];
+};
+
+const queryByRole = (container: Element | Document, role: string, options: RoleOptions = {}) => {
+  const results = queryAllByRole(container, role, options);
+  return results[0] ?? null;
+};
+
+const waitFor = <T,>(callback: () => T, timeout = 1000, interval = 20): Promise<T> =>
+  new Promise((resolve, reject) => {
+    const start = Date.now();
+    const check = () => {
+      try {
+        resolve(callback());
+      } catch (error) {
+        if (Date.now() - start >= timeout) {
+          reject(error);
+        } else {
+          setTimeout(check, interval);
+        }
+      }
+    };
+    check();
+  });
+
+const findByRole = (container: Element | Document, role: string, options: RoleOptions = {}) =>
+  waitFor(() => getByRole(container, role, options));
+
+const findAllByRole = (container: Element | Document, role: string, options: RoleOptions = {}) =>
+  waitFor(() => {
+    const results = queryAllByRole(container, role, options);
+    if (!results.length) {
+      throw roleError(role, options, 0);
+    }
+    return results;
+  });
+
+export const screen = {
+  getByRole: (role: string, options?: RoleOptions) => getByRole(document.body, role, options),
+  queryByRole: (role: string, options?: RoleOptions) => queryByRole(document.body, role, options),
+  findByRole: (role: string, options?: RoleOptions) => findByRole(document.body, role, options),
+  findAllByRole: (role: string, options?: RoleOptions) => findAllByRole(document.body, role, options),
+};
+
+export type RenderResult = ReturnType<typeof render>;

--- a/apps/pages/src/test-utils/testing-library-user-event.ts
+++ b/apps/pages/src/test-utils/testing-library-user-event.ts
@@ -1,0 +1,65 @@
+const pointerEventCtor: typeof PointerEvent | typeof MouseEvent =
+  typeof PointerEvent === 'function' ? PointerEvent : (MouseEvent as unknown as typeof PointerEvent);
+const mouseEventCtor = typeof MouseEvent === 'function' ? MouseEvent : Event;
+const inputEventCtor = typeof InputEvent === 'function' ? InputEvent : (Event as unknown as typeof InputEvent);
+
+const dispatch = (target: EventTarget, event: Event) => target.dispatchEvent(event);
+
+const createPointerEvent = (type: string, init: PointerEventInit = {}) =>
+  new pointerEventCtor(type, {
+    bubbles: true,
+    cancelable: true,
+    pointerId: init.pointerId ?? 1,
+    pointerType: init.pointerType ?? 'mouse',
+    ...init,
+  });
+
+const createMouseEvent = (type: string, init: MouseEventInit = {}) =>
+  new mouseEventCtor(type, { bubbles: true, cancelable: true, ...init });
+
+const fireInputEvent = (element: HTMLInputElement | HTMLTextAreaElement, value: string, data: string) => {
+  element.value = value;
+  dispatch(
+    element,
+    new inputEventCtor('input', {
+      data,
+      bubbles: true,
+      cancelable: true,
+      inputType: 'insertText',
+    } as InputEventInit)
+  );
+};
+
+class UserEventController {
+  async click(element: Element, init: MouseEventInit = {}) {
+    dispatch(element, createPointerEvent('pointerdown', { pointerType: 'mouse' }));
+    dispatch(element, createPointerEvent('pointerup', { pointerType: 'mouse' }));
+    dispatch(element, createMouseEvent('click', init));
+  }
+
+  async dblClick(element: Element, init: MouseEventInit = {}) {
+    await this.click(element, init);
+    await this.click(element, init);
+    dispatch(element, createMouseEvent('dblclick', init));
+  }
+
+  async type(element: Element, text: string) {
+    const target = element as HTMLInputElement | HTMLTextAreaElement;
+    for (const char of text) {
+      fireInputEvent(target, `${target.value}${char}`, char);
+    }
+  }
+
+  async clear(element: Element) {
+    const target = element as HTMLInputElement | HTMLTextAreaElement;
+    fireInputEvent(target, '', '');
+  }
+}
+
+const userEvent = {
+  setup() {
+    return new UserEventController();
+  },
+};
+
+export default userEvent;

--- a/apps/pages/tsconfig.json
+++ b/apps/pages/tsconfig.json
@@ -11,6 +11,11 @@
     "forceConsistentCasingInFileNames": true,
     "module": "ESNext",
     "moduleResolution": "Node",
+    "baseUrl": ".",
+    "paths": {
+      "@testing-library/react": ["src/test-utils/testing-library-react"],
+      "@testing-library/user-event": ["src/test-utils/testing-library-user-event"]
+    },
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,

--- a/apps/pages/vite.config.ts
+++ b/apps/pages/vite.config.ts
@@ -1,8 +1,36 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react-swc';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
+
+const resolvePath = (relativePath: string) => resolve(dirname(fileURLToPath(import.meta.url)), relativePath);
+const requireModule = createRequire(import.meta.url);
+
+const hasModule = (specifier: string) => {
+  try {
+    requireModule.resolve(specifier);
+    return true;
+  } catch (error) {
+    return false;
+  }
+};
+
+const alias: Record<string, string> = {};
+
+if (!hasModule('@testing-library/react')) {
+  alias['@testing-library/react'] = resolvePath('./src/test-utils/testing-library-react.tsx');
+}
+
+if (!hasModule('@testing-library/user-event')) {
+  alias['@testing-library/user-event'] = resolvePath('./src/test-utils/testing-library-user-event.ts');
+}
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias,
+  },
   server: {
     port: 5173,
   },
@@ -10,6 +38,6 @@ export default defineConfig({
     outDir: 'dist',
   },
   test: {
-    environment: 'node',
+    environment: 'jsdom',
   },
 });


### PR DESCRIPTION
## Summary
- add a DefineRoomsEditor test harness with DOM polyfills, reusable `renderEditor` helper, and a smoke test
- register lightweight shims for the testing library APIs and wire them through the TS config and Vite alias when real packages are unavailable
- declare testing-library devDependencies and ignore build artifacts so the harness can compile cleanly

## Testing
- pnpm test -- DefineRoomsEditor *(fails: requires jsdom package in the offline execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2198b657083238e8079349b30e7ea