### PR TITLE
Add tests for tool indicator and brush size wiring

### DIFF
--- a/apps/pages/src/components/__tests__/DefineRoomsEditor.spec.tsx
+++ b/apps/pages/src/components/__tests__/DefineRoomsEditor.spec.tsx
@@ -307,4 +307,40 @@ describe('DefineRoomsEditor room authoring', () => {
       expect(screen.queryByRole('button', { name: /finish room/i })).not.toBeInTheDocument();
     });
   });
+
+  it('updates the active tool indicator and brush size slider across tool switches', async () => {
+    const { user } = await renderEditor();
+
+    await user.click(screen.getByRole('button', { name: /add room/i }));
+
+    const activeToolIndicator = await screen.findByText(/active tool:/i);
+    expect(activeToolIndicator).toHaveTextContent(/Active tool:\s*Smart Lasso/i);
+
+    await user.click(screen.getByRole('button', { name: /auto wand/i }));
+    await waitFor(() =>
+      expect(activeToolIndicator).toHaveTextContent(/Active tool:\s*Auto Wand/i)
+    );
+
+    await user.click(screen.getByRole('button', { name: /refine brush/i }));
+    await waitFor(() =>
+      expect(activeToolIndicator).toHaveTextContent(/Active tool:\s*Refine Brush/i)
+    );
+
+    const brushSizeSlider = (await screen.findByLabelText(/brush size/i)) as HTMLInputElement;
+    expect(Number(brushSizeSlider.value)).toBeCloseTo(0.08);
+
+    fireEvent.change(brushSizeSlider, { target: { value: '0.14' } });
+
+    await waitFor(() =>
+      expect(screen.getByText(/current radius:/i)).toHaveTextContent(/14% of the image width/i)
+    );
+
+    await user.click(screen.getByRole('button', { name: /smart lasso/i }));
+
+    await waitFor(() =>
+      expect(activeToolIndicator).toHaveTextContent(/Active tool:\s*Smart Lasso/i)
+    );
+    expect(Number((screen.getByLabelText(/brush size/i) as HTMLInputElement).value)).toBeCloseTo(0.14, 5);
+    expect(screen.getByText(/current radius:/i)).toHaveTextContent(/14% of the image width/i);
+  });
 });


### PR DESCRIPTION
## Summary
- add coverage ensuring the vector authoring tool indicator reflects the selected tool
- verify brush size slider updates helper text and keeps its value when switching tools

## Testing
- npm test *(fails: missing `jsdom` dependency in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d29a0fe06883238fba5eba784a8102