### PR TITLE
Align signed distance field sign with vector tools

### DIFF
--- a/apps/pages/src/workers/seg.ts
+++ b/apps/pages/src/workers/seg.ts
@@ -684,7 +684,7 @@ export const computeSignedDistanceField = (
   for (let i = 0; i < values.length; i += 1) {
     const outsideDist = Math.sqrt(outside[i]);
     const insideDist = Math.sqrt(inside[i]);
-    values[i] = (outsideDist - insideDist) / scale;
+    values[i] = (insideDist - outsideDist) / scale;
   }
   return {
     width,


### PR DESCRIPTION
## Summary
- invert the sign of computeSignedDistanceField so mask interiors report negative distances
- extend the geometry spec with a circular brush mask regression test that checks smooth radial gradients
- update the existing mask fixture test to validate the new interior/exterior sign convention

## Testing
- npx vitest --run --environment node src/workers/__tests__/seg.geometry.spec.ts


------
https://chatgpt.com/codex/tasks/task_e_68d2b1b0d2f483239bc3a0e6a532e056