### PR TITLE
Stretch define rooms wizard layout

### DIFF
--- a/apps/pages/src/components/DefineRoomsEditor.tsx
+++ b/apps/pages/src/components/DefineRoomsEditor.tsx
@@ -619,7 +619,7 @@ const DefineRoomsEditor: React.FC<DefineRoomsEditorProps> = ({
   }
 
   return (
-    <div className="flex h-full flex-col gap-4">
+    <div className="flex h-full min-h-0 flex-col gap-4">
       <div className="flex items-center justify-between gap-4 rounded-2xl border border-slate-800/70 bg-slate-950/70 px-5 py-4">
         <div>
           <p className="text-xs uppercase tracking-[0.4em] text-teal-300">Define Rooms</p>
@@ -662,7 +662,7 @@ const DefineRoomsEditor: React.FC<DefineRoomsEditorProps> = ({
           )}
         </div>
       </div>
-      <div className="grid h-full gap-4 xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]">
+      <div className="grid flex-1 min-h-0 gap-4 xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]">
         <div className="relative flex min-h-[420px] flex-col rounded-3xl border border-slate-800/70 bg-slate-950/70">
           <div ref={containerRef} className="relative flex flex-1 items-center justify-center overflow-hidden rounded-3xl">
             <img

--- a/apps/pages/src/components/MapCreationWizard.tsx
+++ b/apps/pages/src/components/MapCreationWizard.tsx
@@ -633,8 +633,8 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
             </div>
           )}
           {step === 2 && (
-            <div className="flex flex-1 items-center justify-center">
-              <div className="h-full w-full max-w-6xl rounded-3xl border border-slate-800/70 bg-slate-900/70 p-8">
+            <div className="flex flex-1 min-h-0">
+              <div className="flex h-full w-full min-h-0 flex-col overflow-hidden rounded-3xl border border-slate-800/70 bg-slate-900/70 p-8">
                 <DefineRoomsEditor
                   imageUrl={previewUrl}
                   imageDimensions={imageDimensions}


### PR DESCRIPTION
## Summary
- expand the Define Rooms step container so it stretches across the wizard content area
- update the Define Rooms editor layout to fill the available height between the wizard header and footer

## Testing
- npm test *(fails: missing jsdom dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68d2b7e5c63483239e934b4ac1f6c620