### PR TITLE
Add latency regression test for traceLiveWire

### DIFF
--- a/apps/pages/src/workers/__tests__/seg.performance.spec.ts
+++ b/apps/pages/src/workers/__tests__/seg.performance.spec.ts
@@ -13,6 +13,39 @@ interface LiveWireFixture extends Uint8Fixture {
   end: Point;
 }
 
+const createSparseEdgeFixture = (width = 128, height = 128): Uint8Fixture => {
+  const data = new Uint8Array(width * height);
+  const verticalEdges = [Math.floor(width * 0.25), Math.floor(width * 0.65)];
+  const horizontalEdge = Math.floor(height * 0.55);
+
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      const base = (x / Math.max(1, width - 1)) * 80 + (y / Math.max(1, height - 1)) * 20;
+      data[y * width + x] = Math.round(base);
+    }
+  }
+
+  for (const x of verticalEdges) {
+    for (let y = Math.floor(height * 0.1); y < Math.floor(height * 0.9); y += 1) {
+      data[y * width + x] = 240;
+    }
+  }
+
+  for (let x = Math.floor(width * 0.2); x < Math.floor(width * 0.9); x += 1) {
+    data[horizontalEdge * width + x] = 12;
+  }
+
+  for (let i = 0; i < Math.min(width, height); i += 1) {
+    const x = Math.min(width - 1, Math.floor(width * 0.45) + Math.floor(i * 0.35));
+    const y = Math.min(height - 1, Math.floor(height * 0.2) + i);
+    if (x >= 0 && x < width && y >= 0 && y < height) {
+      data[y * width + x] = 200;
+    }
+  }
+
+  return { width, height, data };
+};
+
 const createLiveWireFixture = (width = 128, height = 128): LiveWireFixture => {
   const data = new Uint8Array(width * height);
   const corridorTop = Math.floor(height * 0.4);
@@ -95,6 +128,66 @@ const createMaskFixture = (width = 128, height = 128): Uint8Fixture & {
 };
 
 describe('segmentation performance characteristics', () => {
+  it('keeps repeated live wire traces on sparse edges within latency budget', () => {
+    const fixture = createSparseEdgeFixture();
+    const pyramid = buildCostPyramid(fixture.data, fixture.width, fixture.height, {
+      levels: 4,
+      smoothIterations: 1,
+    });
+
+    const toNormalized = (x: number, size: number) => x / Math.max(1, size - 1);
+
+    const pointPairs: Array<{ start: Point; end: Point }> = [
+      {
+        start: { x: toNormalized(Math.floor(fixture.width * 0.1), fixture.width), y: toNormalized(Math.floor(fixture.height * 0.2), fixture.height) },
+        end: { x: toNormalized(Math.floor(fixture.width * 0.4), fixture.width), y: toNormalized(Math.floor(fixture.height * 0.28), fixture.height) },
+      },
+      {
+        start: { x: toNormalized(Math.floor(fixture.width * 0.32), fixture.width), y: toNormalized(Math.floor(fixture.height * 0.12), fixture.height) },
+        end: { x: toNormalized(Math.floor(fixture.width * 0.35), fixture.width), y: toNormalized(Math.floor(fixture.height * 0.45), fixture.height) },
+      },
+      {
+        start: { x: toNormalized(Math.floor(fixture.width * 0.45), fixture.width), y: toNormalized(Math.floor(fixture.height * 0.45), fixture.height) },
+        end: { x: toNormalized(Math.floor(fixture.width * 0.68), fixture.width), y: toNormalized(Math.floor(fixture.height * 0.68), fixture.height) },
+      },
+      {
+        start: { x: toNormalized(Math.floor(fixture.width * 0.55), fixture.width), y: toNormalized(Math.floor(fixture.height * 0.6), fixture.height) },
+        end: { x: toNormalized(Math.floor(fixture.width * 0.82), fixture.width), y: toNormalized(Math.floor(fixture.height * 0.75), fixture.height) },
+      },
+    ];
+
+    for (const pair of pointPairs) {
+      const path = traceLiveWire(pyramid, pair.start, pair.end, { allowDiagonals: true });
+      expect(path.length).toBeGreaterThan(5);
+      expect(Math.abs(path[0].x - pair.start.x)).toBeLessThan(0.05);
+      expect(Math.abs(path[path.length - 1].y - pair.end.y)).toBeLessThan(0.05);
+    }
+
+    const iterations = 20;
+    const durations: number[] = [];
+
+    for (let iteration = 0; iteration < iterations; iteration += 1) {
+      for (const pair of pointPairs) {
+        const start = performance.now();
+        traceLiveWire(pyramid, pair.start, pair.end, { allowDiagonals: true });
+        const duration = performance.now() - start;
+        durations.push(duration);
+      }
+    }
+
+    const average = durations.reduce((sum, duration) => sum + duration, 0) / durations.length;
+    const sorted = [...durations].sort((a, b) => a - b);
+    const index95 = Math.min(sorted.length - 1, Math.floor(sorted.length * 0.95));
+    const percentile95 = sorted[index95];
+    const thresholdMs = 12;
+
+    if (average >= thresholdMs) {
+      throw new Error(
+        `traceLiveWire average ${average.toFixed(3)}ms exceeded latency budget of ${thresholdMs}ms (95th percentile ${percentile95.toFixed(3)}ms across ${durations.length} runs)`
+      );
+    }
+  });
+
   it('traces a live wire path through a moderately sized image quickly', () => {
     const fixture = createLiveWireFixture();
     const pyramid = buildCostPyramid(fixture.data, fixture.width, fixture.height, {


### PR DESCRIPTION
## Summary
- create a synthetic sparse-edge fixture that builds a 128×128 cost pyramid
- add a regression test that times repeated traceLiveWire calls and enforces a 12 ms average latency budget

## Testing
- pnpm vitest --run --environment node src/workers/__tests__/seg.performance.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68d2bc70ff6c8323ac80f08aa8943ac0