### PR TITLE
Refactor room authoring to use raster masks

### DIFF
--- a/apps/pages/src/components/MapCreationWizard.tsx
+++ b/apps/pages/src/components/MapCreationWizard.tsx
@@ -389,6 +389,9 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
       if (tags.length > 0) {
         metadata.tags = tags;
       }
+      if (rooms.length > 0) {
+        metadata.roomMaskManifest = rooms.map((room) => room.maskManifest);
+      }
 
       const response = await apiClient.createMap({
         campaignId: campaign.id,
@@ -436,7 +439,8 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
           .join('\n');
         const region = await apiClient.createRegion(map.id, {
           name: room.name.trim() || `Room ${index + 1}`,
-          polygon: room.polygon,
+          mask: room.mask,
+          maskManifest: room.maskManifest,
           notes: compiledNotes || undefined,
           revealOrder: index + 1,
         });

--- a/apps/pages/src/components/__tests__/DefineRoomsEditor.spec.tsx
+++ b/apps/pages/src/components/__tests__/DefineRoomsEditor.spec.tsx
@@ -294,11 +294,12 @@ describe('DefineRoomsEditor room authoring', () => {
     expect(call).toBeDefined();
     const roomsArg = call?.[0];
     expect(Array.isArray(roomsArg)).toBe(true);
-    const rooms = roomsArg as Array<{ polygon: Array<{ x: number; y: number }> }>;
+    const rooms = roomsArg as Array<{ mask: { data: Uint8ClampedArray }; maskManifest: { dataUrl: string } }>;
     expect(rooms).toHaveLength(1);
     const room = rooms[0];
     expect(room).toBeDefined();
-    expect(room.polygon.length).toBeGreaterThan(0);
+    expect(room.mask.data.some((value) => value > 0)).toBe(true);
+    expect(room.maskManifest.dataUrl).toMatch(/^data:image\/png;base64,/);
 
     const addRoomButton = await screen.findByRole('button', { name: /add room/i });
     expect(addRoomButton).toBeInTheDocument();

--- a/apps/pages/src/state/defineRoomsStore.ts
+++ b/apps/pages/src/state/defineRoomsStore.ts
@@ -1,4 +1,13 @@
-export type Point = { x: number; y: number };
+import { createEmptySelectionState, type SelectionState, type SelectionTool } from './selection';
+import {
+  applyCircularBrushToMask,
+  cloneRoomMask,
+  createRoomMaskFromPolygon,
+  emptyRoomMask,
+  roomMaskToPolygon,
+  type RoomMask,
+} from '../utils/roomMask';
+import type { Bounds, Point } from '../types/geometry';
 
 export interface GapMarker {
   id: string;
@@ -11,12 +20,13 @@ export interface GapMarker {
 export interface SignedDistanceField {
   width: number;
   height: number;
-  bounds: { minX: number; minY: number; maxX: number; maxY: number };
+  bounds: Bounds;
   values: Float32Array;
 }
 
 export interface RoundTripResult {
   sdf: SignedDistanceField;
+  mask: RoomMask;
   polygon: Point[];
   error: number;
 }
@@ -32,15 +42,11 @@ export interface RoundTripOptions extends SdfOptions {
 
 export interface DefineRoomsState {
   mode: 'idle' | 'editing';
-  polygon: Point[];
-  preview: Point[] | null;
-  samples: Point[];
-  brushRadius: number;
-  snapStrength: number;
+  selection: SelectionState;
+  previewMask: RoomMask | null;
   busyMessage: string | null;
   gapMarkers: GapMarker[];
   signedDistanceField: SignedDistanceField | null;
-  vectorDraft: Point[] | null;
   lastRoundTrip: RoundTripResult | null;
   lastUpdated: number;
 }
@@ -52,204 +58,27 @@ export interface DefineRoomsStore {
   subscribe(listener: DefineRoomsListener): () => void;
   setMode(mode: DefineRoomsState['mode']): void;
   setBusy(message: string | null): void;
-  setBrushRadius(radius: number): void;
-  setSnapStrength(strength: number): void;
-  setPolygon(polygon: Point[]): void;
-  previewPolygon(polygon: Point[] | null): void;
-  commitPolygon(polygon: Point[]): void;
-  setSamples(samples: Point[]): void;
-  applyBrushSample(point: Point, mode: 'add' | 'erase'): void;
+  setSelection(selection: SelectionState): void;
+  setTool(tool: SelectionTool | null): void;
+  previewMask(mask: RoomMask | null): void;
+  commitMask(mask: RoomMask): void;
+  applyBrush(point: Point, radius: number, mode: 'add' | 'erase'): void;
   clear(): void;
   setGapMarkers(markers: GapMarker[]): void;
   refreshGapMarkers(): void;
   setSignedDistanceField(field: SignedDistanceField | null): void;
-  setVectorDraft(polygon: Point[] | null): void;
-  roundTrip(polygon: Point[], options?: RoundTripOptions): RoundTripResult;
-  vectorToSdf(polygon: Point[], options?: SdfOptions): SignedDistanceField;
-  sdfToVector(field: SignedDistanceField, threshold?: number): Point[];
-  snapPoint(point: Point): Point;
+  setLastRoundTrip(result: RoundTripResult | null): void;
 }
-
-const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
 
 const distance = (a: Point, b: Point) => Math.hypot(a.x - b.x, a.y - b.y);
 
-const nearlyEqual = (a: number, b: number, epsilon = 1e-6) => Math.abs(a - b) <= epsilon;
-
-const pointKey = (point: Point) => `${point.x.toFixed(6)}:${point.y.toFixed(6)}`;
-
-const dedupePoints = (points: Point[]) => {
-  const seen = new Set<string>();
-  return points.filter((point) => {
-    const key = pointKey(point);
-    if (seen.has(key)) {
-      return false;
-    }
-    seen.add(key);
-    return true;
-  });
-};
-
-const simplifyDouglasPeucker = (points: Point[], tolerance: number) => {
-  if (points.length <= 2) {
-    return points.slice();
+const computeGapMarkers = (mask: RoomMask | null): GapMarker[] => {
+  if (!mask) {
+    return [];
   }
-
-  const sqTolerance = tolerance * tolerance;
-
-  const sqDistanceToSegment = (p: Point, a: Point, b: Point) => {
-    let x = a.x;
-    let y = a.y;
-    let dx = b.x - x;
-    let dy = b.y - y;
-
-    if (dx !== 0 || dy !== 0) {
-      const t = ((p.x - x) * dx + (p.y - y) * dy) / (dx * dx + dy * dy);
-      if (t > 1) {
-        x = b.x;
-        y = b.y;
-      } else if (t > 0) {
-        x += dx * t;
-        y += dy * t;
-      }
-    }
-
-    dx = p.x - x;
-    dy = p.y - y;
-    return dx * dx + dy * dy;
-  };
-
-  const simplifyDPStep = (pointsToSimplify: Point[], first: number, last: number, simplified: Point[]) => {
-    let maxSqDist = sqTolerance;
-    let index = -1;
-
-    for (let i = first + 1; i < last; i += 1) {
-      const sqDist = sqDistanceToSegment(pointsToSimplify[i], pointsToSimplify[first], pointsToSimplify[last]);
-      if (sqDist > maxSqDist) {
-        index = i;
-        maxSqDist = sqDist;
-      }
-    }
-
-    if (index !== -1) {
-      if (index - first > 1) {
-        simplifyDPStep(pointsToSimplify, first, index, simplified);
-      }
-      simplified.push(pointsToSimplify[index]);
-      if (last - index > 1) {
-        simplifyDPStep(pointsToSimplify, index, last, simplified);
-      }
-    }
-  };
-
-  const last = points.length - 1;
-  const result = [points[0]];
-  simplifyDPStep(points, 0, last, result);
-  result.push(points[last]);
-  return result;
-};
-
-const pointInPolygon = (point: Point, polygon: Point[]) => {
-  let inside = false;
-  for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i += 1) {
-    const xi = polygon[i].x;
-    const yi = polygon[i].y;
-    const xj = polygon[j].x;
-    const yj = polygon[j].y;
-    const intersect = yi > point.y !== yj > point.y && point.x < ((xj - xi) * (point.y - yi)) / (yj - yi) + xi;
-    if (intersect) inside = !inside;
-  }
-  return inside;
-};
-
-const distanceToSegment = (point: Point, a: Point, b: Point) => {
-  const vx = b.x - a.x;
-  const vy = b.y - a.y;
-  const wx = point.x - a.x;
-  const wy = point.y - a.y;
-  const c1 = vx * wx + vy * wy;
-  if (c1 <= 0) {
-    return Math.hypot(point.x - a.x, point.y - a.y);
-  }
-  const c2 = vx * vx + vy * vy;
-  if (c2 <= c1) {
-    return Math.hypot(point.x - b.x, point.y - b.y);
-  }
-  const t = c1 / c2;
-  const px = a.x + vx * t;
-  const py = a.y + vy * t;
-  return Math.hypot(point.x - px, point.y - py);
-};
-
-const ensureBounds = (polygon: Point[]) => {
-  if (polygon.length === 0) {
-    return { minX: 0, minY: 0, maxX: 1, maxY: 1 };
-  }
-  let minX = polygon[0].x;
-  let minY = polygon[0].y;
-  let maxX = polygon[0].x;
-  let maxY = polygon[0].y;
-  for (const point of polygon) {
-    if (point.x < minX) minX = point.x;
-    if (point.y < minY) minY = point.y;
-    if (point.x > maxX) maxX = point.x;
-    if (point.y > maxY) maxY = point.y;
-  }
-  const width = maxX - minX || 1;
-  const height = maxY - minY || 1;
-  const padding = Math.max(width, height) * 0.05;
-  return {
-    minX: minX - padding,
-    minY: minY - padding,
-    maxX: maxX + padding,
-    maxY: maxY + padding,
-  };
-};
-
-const defaultState: DefineRoomsState = {
-  mode: 'idle',
-  polygon: [],
-  preview: null,
-  samples: [],
-  brushRadius: 0.08,
-  snapStrength: 0.65,
-  busyMessage: null,
-  gapMarkers: [],
-  signedDistanceField: null,
-  vectorDraft: null,
-  lastRoundTrip: null,
-  lastUpdated: Date.now(),
-};
-
-let state: DefineRoomsState = { ...defaultState };
-
-const listeners = new Set<DefineRoomsListener>();
-
-const notify = () => {
-  listeners.forEach((listener) => listener(state));
-};
-
-const commitState = (updater: (current: DefineRoomsState) => DefineRoomsState) => {
-  state = { ...updater(state), lastUpdated: Date.now() };
-  notify();
-};
-
-const generateBrushSamples = (center: Point, radius: number, segments = 16) => {
-  const samples: Point[] = [];
-  samples.push(center);
-  for (let i = 0; i < segments; i += 1) {
-    const angle = (i / segments) * Math.PI * 2;
-    samples.push({
-      x: center.x + Math.cos(angle) * radius,
-      y: center.y + Math.sin(angle) * radius,
-    });
-  }
-  return samples;
-};
-
-const computeGapMarkers = (polygon: Point[]) => {
+  const polygon = roomMaskToPolygon(mask);
   if (polygon.length < 2) {
-    return [] as GapMarker[];
+    return [];
   }
   const markers: GapMarker[] = [];
   const threshold = 0.075;
@@ -267,237 +96,41 @@ const computeGapMarkers = (polygon: Point[]) => {
       position: { x: (current.x + next.x) / 2, y: (current.y + next.y) / 2 },
       radius,
       severity,
-      description: `Gap of ${(gap * 100).toFixed(1)}% between segments`,
+      description: `Gap of ${(gap * 100).toFixed(1)}% between mask edges`,
     });
   }
   return markers;
 };
 
-const rasterizePolygon = (polygon: Point[], width: number, height: number, bounds: SignedDistanceField['bounds']) => {
-  const mask = new Uint8Array(width * height);
-  if (polygon.length === 0) {
-    return mask;
-  }
-  const scaleX = bounds.maxX - bounds.minX || 1;
-  const scaleY = bounds.maxY - bounds.minY || 1;
-  for (let y = 0; y < height; y += 1) {
-    for (let x = 0; x < width; x += 1) {
-      const worldPoint = {
-        x: bounds.minX + ((x + 0.5) / width) * scaleX,
-        y: bounds.minY + ((y + 0.5) / height) * scaleY,
-      };
-      if (pointInPolygon(worldPoint, polygon)) {
-        mask[y * width + x] = 1;
-      }
-    }
-  }
-  return mask;
+const defaultState: DefineRoomsState = {
+  mode: 'idle',
+  selection: createEmptySelectionState(),
+  previewMask: null,
+  busyMessage: null,
+  gapMarkers: [],
+  signedDistanceField: null,
+  lastRoundTrip: null,
+  lastUpdated: Date.now(),
 };
 
-const marchingSquares = (mask: Uint8Array, width: number, height: number) => {
-  const segments: Array<{ start: Point; end: Point }> = [];
+let state: DefineRoomsState = { ...defaultState, selection: { ...defaultState.selection } };
 
-  const edgePoint = (x: number, y: number, edge: 'top' | 'bottom' | 'left' | 'right'): Point => {
-    switch (edge) {
-      case 'top':
-        return { x: x + 0.5, y };
-      case 'bottom':
-        return { x: x + 0.5, y: y + 1 };
-      case 'left':
-        return { x, y: y + 0.5 };
-      case 'right':
-        return { x: x + 1, y: y + 0.5 };
-    }
-  };
+const listeners = new Set<DefineRoomsListener>();
 
-  const cases: Record<number, Array<[Point, Point]>> = {
-    0: [],
-    1: [[edgePoint(0, 0, 'left'), edgePoint(0, 0, 'top')]],
-    2: [[edgePoint(0, 0, 'top'), edgePoint(0, 0, 'right')]],
-    3: [[edgePoint(0, 0, 'left'), edgePoint(0, 0, 'right')]],
-    4: [[edgePoint(0, 0, 'right'), edgePoint(0, 0, 'bottom')]],
-    5: [
-      [edgePoint(0, 0, 'left'), edgePoint(0, 0, 'bottom')],
-      [edgePoint(0, 0, 'top'), edgePoint(0, 0, 'right')],
-    ],
-    6: [[edgePoint(0, 0, 'top'), edgePoint(0, 0, 'bottom')]],
-    7: [[edgePoint(0, 0, 'left'), edgePoint(0, 0, 'bottom')]],
-    8: [[edgePoint(0, 0, 'bottom'), edgePoint(0, 0, 'left')]],
-    9: [[edgePoint(0, 0, 'top'), edgePoint(0, 0, 'bottom')]],
-    10: [
-      [edgePoint(0, 0, 'top'), edgePoint(0, 0, 'right')],
-      [edgePoint(0, 0, 'bottom'), edgePoint(0, 0, 'left')],
-    ],
-    11: [[edgePoint(0, 0, 'right'), edgePoint(0, 0, 'bottom')]],
-    12: [[edgePoint(0, 0, 'right'), edgePoint(0, 0, 'left')]],
-    13: [[edgePoint(0, 0, 'top'), edgePoint(0, 0, 'right')]],
-    14: [[edgePoint(0, 0, 'left'), edgePoint(0, 0, 'top')]],
-    15: [],
-  };
-
-  for (let y = 0; y < height - 1; y += 1) {
-    for (let x = 0; x < width - 1; x += 1) {
-      const topLeft = mask[y * width + x] > 0;
-      const topRight = mask[y * width + x + 1] > 0;
-      const bottomRight = mask[(y + 1) * width + x + 1] > 0;
-      const bottomLeft = mask[(y + 1) * width + x] > 0;
-      let key = 0;
-      if (topLeft) key |= 1;
-      if (topRight) key |= 2;
-      if (bottomRight) key |= 4;
-      if (bottomLeft) key |= 8;
-      if (key === 0 || key === 15) {
-        continue;
-      }
-      const template = cases[key];
-      for (const [start, end] of template) {
-        segments.push({
-          start: { x: start.x + x, y: start.y + y },
-          end: { x: end.x + x, y: end.y + y },
-        });
-      }
-    }
-  }
-
-  if (segments.length === 0) {
-    return [] as Point[];
-  }
-
-  const polygon: Point[] = [];
-  const used = new Array(segments.length).fill(false);
-  polygon.push(segments[0].start);
-  polygon.push(segments[0].end);
-  used[0] = true;
-
-  const equals = (a: Point, b: Point) => nearlyEqual(a.x, b.x, 1e-4) && nearlyEqual(a.y, b.y, 1e-4);
-
-  while (polygon.length < 5000) {
-    const current = polygon[polygon.length - 1];
-    let advanced = false;
-    for (let i = 0; i < segments.length; i += 1) {
-      if (used[i]) continue;
-      const segment = segments[i];
-      if (equals(segment.start, current)) {
-        polygon.push(segment.end);
-        used[i] = true;
-        advanced = true;
-        break;
-      }
-      if (equals(segment.end, current)) {
-        polygon.push(segment.start);
-        used[i] = true;
-        advanced = true;
-        break;
-      }
-    }
-    if (!advanced) {
-      break;
-    }
-    if (equals(polygon[polygon.length - 1], polygon[0])) {
-      polygon.pop();
-      break;
-    }
-  }
-
-  return polygon;
+const notify = () => {
+  listeners.forEach((listener) => listener(state));
 };
 
-const convertMaskToPolygon = (mask: Uint8Array, width: number, height: number, bounds: SignedDistanceField['bounds']) => {
-  const rawPolygon = marchingSquares(mask, width, height);
-  if (rawPolygon.length === 0) {
-    return [];
-  }
-  const scaleX = bounds.maxX - bounds.minX || 1;
-  const scaleY = bounds.maxY - bounds.minY || 1;
-  const widthDenominator = width - 1 || 1;
-  const heightDenominator = height - 1 || 1;
-  const polygon = rawPolygon.map((point) => ({
-    x: bounds.minX + (point.x / widthDenominator) * scaleX,
-    y: bounds.minY + (point.y / heightDenominator) * scaleY,
-  }));
-  return simplifyDouglasPeucker(dedupePoints(polygon), 0.001);
+const commitState = (updater: (current: DefineRoomsState) => DefineRoomsState) => {
+  state = { ...updater(state), lastUpdated: Date.now() };
+  notify();
 };
 
-const averageDistanceBetweenPolygons = (a: Point[], b: Point[]) => {
-  if (a.length === 0 || b.length === 0) {
-    return 1;
-  }
-  const sampleCount = Math.min(a.length, 256);
-  let total = 0;
-  for (let i = 0; i < sampleCount; i += 1) {
-    const index = Math.floor((i / sampleCount) * a.length);
-    const point = a[index];
-    let closest = Infinity;
-    for (const other of b) {
-      const d = distance(point, other);
-      if (d < closest) {
-        closest = d;
-      }
-    }
-    total += closest;
-  }
-  return total / sampleCount;
+const withSelection = (updater: (selection: SelectionState) => SelectionState) => {
+  commitState((current) => ({ ...current, selection: updater(current.selection) }));
 };
 
-const vectorToSdf = (polygon: Point[], options?: SdfOptions): SignedDistanceField => {
-  const bounds = ensureBounds(polygon);
-  const resolution = clamp(options?.resolution ?? 128, 16, 1024);
-  const padding = options?.padding ?? 0;
-  const width = Math.max(8, Math.round((bounds.maxX - bounds.minX + padding) * resolution));
-  const height = Math.max(8, Math.round((bounds.maxY - bounds.minY + padding) * resolution));
-  const adjustedBounds = {
-    minX: bounds.minX - padding / 2,
-    minY: bounds.minY - padding / 2,
-    maxX: bounds.maxX + padding / 2,
-    maxY: bounds.maxY + padding / 2,
-  };
-  const values = new Float32Array(width * height);
-  const mask = rasterizePolygon(polygon, width, height, adjustedBounds);
-
-  const scaleX = adjustedBounds.maxX - adjustedBounds.minX || 1;
-  const scaleY = adjustedBounds.maxY - adjustedBounds.minY || 1;
-  for (let y = 0; y < height; y += 1) {
-    for (let x = 0; x < width; x += 1) {
-      const worldPoint = {
-        x: adjustedBounds.minX + ((x + 0.5) / width) * scaleX,
-        y: adjustedBounds.minY + ((y + 0.5) / height) * scaleY,
-      };
-      let minDist = Infinity;
-      for (let i = 0; i < polygon.length; i += 1) {
-        const a = polygon[i];
-        const b = polygon[(i + 1) % polygon.length];
-        const dist = distanceToSegment(worldPoint, a, b);
-        if (dist < minDist) {
-          minDist = dist;
-        }
-      }
-      const inside = mask[y * width + x] > 0;
-      values[y * width + x] = inside ? -minDist : minDist;
-    }
-  }
-
-  return {
-    width,
-    height,
-    bounds: adjustedBounds,
-    values,
-  };
-};
-
-const sdfToVector = (field: SignedDistanceField, threshold = 0) => {
-  const mask = new Uint8Array(field.width * field.height);
-  for (let i = 0; i < field.values.length; i += 1) {
-    mask[i] = field.values[i] <= threshold ? 1 : 0;
-  }
-  return convertMaskToPolygon(mask, field.width, field.height, field.bounds);
-};
-
-const roundTripPolygon = (polygon: Point[], options?: RoundTripOptions): RoundTripResult => {
-  const sdf = vectorToSdf(polygon, options);
-  const reconstructed = sdfToVector(sdf, options?.threshold ?? 0);
-  const error = averageDistanceBetweenPolygons(polygon, reconstructed);
-  return { sdf, polygon: reconstructed, error };
-};
+const ensureMask = (mask: RoomMask | null) => mask ?? emptyRoomMask();
 
 export const defineRoomsStore: DefineRoomsStore = {
   getState: () => state,
@@ -514,108 +147,69 @@ export const defineRoomsStore: DefineRoomsStore = {
   setBusy(message) {
     commitState((current) => ({ ...current, busyMessage: message }));
   },
-  setBrushRadius(radius) {
-    const next = clamp(radius, 0.01, 0.5);
-    commitState((current) => ({ ...current, brushRadius: next }));
-  },
-  setSnapStrength(strength) {
-    commitState((current) => ({ ...current, snapStrength: clamp(strength, 0, 1) }));
-  },
-  setPolygon(polygon) {
-    const deduped = dedupePoints(polygon);
-    const simplified = simplifyDouglasPeucker(deduped, 0.0005);
+  setSelection(selection) {
     commitState((current) => ({
       ...current,
-      polygon: simplified,
-      samples: simplified.slice(),
-      preview: null,
-      gapMarkers: computeGapMarkers(simplified),
-      lastRoundTrip: null,
+      selection: {
+        ...selection,
+        mask: selection.mask ? cloneRoomMask(selection.mask) : null,
+        lastUpdated: Date.now(),
+      },
+      gapMarkers: computeGapMarkers(selection.mask ?? null),
     }));
   },
-  previewPolygon(polygon) {
-    commitState((current) => ({ ...current, preview: polygon ? polygon.slice() : null }));
+  setTool(tool) {
+    withSelection((selection) => ({ ...selection, tool }));
   },
-  commitPolygon(polygon) {
-    const deduped = dedupePoints(polygon);
-    const simplified = simplifyDouglasPeucker(deduped, 0.0005);
+  previewMask(mask) {
+    commitState((current) => ({ ...current, previewMask: mask ? cloneRoomMask(mask) : null }));
+  },
+  commitMask(mask) {
     commitState((current) => ({
       ...current,
       mode: 'editing',
-      polygon: simplified,
-      samples: simplified.slice(),
-      preview: null,
-      gapMarkers: computeGapMarkers(simplified),
-      lastRoundTrip: null,
+      selection: {
+        ...current.selection,
+        mask: cloneRoomMask(mask),
+        lastUpdated: Date.now(),
+      },
+      previewMask: null,
+      gapMarkers: computeGapMarkers(mask),
     }));
   },
-  setSamples(samples) {
-    const deduped = dedupePoints(samples);
-    commitState((current) => ({
-      ...current,
-      samples: deduped,
-      polygon: deduped.slice(),
-      preview: null,
-      gapMarkers: computeGapMarkers(deduped),
-      lastRoundTrip: null,
-    }));
-  },
-  applyBrushSample(point, mode) {
+  applyBrush(point, radius, mode) {
     commitState((current) => {
-      const snapped = defineRoomsStore.snapPoint(point);
-      const radius = current.brushRadius;
-      const samples = [...current.samples];
-      if (mode === 'add') {
-        const additions = generateBrushSamples(snapped, radius);
-        for (const sample of additions) {
-          samples.push(sample);
-        }
-      } else {
-        const filtered = samples.filter((sample) => distance(sample, snapped) > radius * 0.6);
-        samples.length = 0;
-        samples.push(...filtered);
-      }
-      const deduped = dedupePoints(samples);
-      const simplified = simplifyDouglasPeucker(deduped, 0.0005);
+      const baseMask = ensureMask(current.selection.mask);
+      const mutated = applyCircularBrushToMask(baseMask, point, radius, mode);
       return {
         ...current,
-        samples: deduped,
-        polygon: simplified,
-        preview: null,
-        gapMarkers: computeGapMarkers(simplified),
-        lastRoundTrip: null,
+        selection: {
+          ...current.selection,
+          mask: mutated,
+          lastUpdated: Date.now(),
+        },
+        gapMarkers: computeGapMarkers(mutated),
       };
     });
   },
   clear() {
-    commitState(() => ({ ...defaultState, lastUpdated: Date.now() }));
+    commitState(() => ({ ...defaultState, selection: createEmptySelectionState(), lastUpdated: Date.now() }));
   },
   setGapMarkers(markers) {
     commitState((current) => ({ ...current, gapMarkers: markers.slice() }));
   },
   refreshGapMarkers() {
-    commitState((current) => ({ ...current, gapMarkers: computeGapMarkers(current.polygon) }));
+    commitState((current) => ({ ...current, gapMarkers: computeGapMarkers(current.selection.mask ?? null) }));
   },
   setSignedDistanceField(field) {
     commitState((current) => ({ ...current, signedDistanceField: field }));
   },
-  setVectorDraft(polygon) {
-    commitState((current) => ({ ...current, vectorDraft: polygon ? polygon.slice() : null }));
-  },
-  roundTrip(polygon, options) {
-    const result = roundTripPolygon(polygon, options);
-    commitState((current) => ({ ...current, signedDistanceField: result.sdf, vectorDraft: result.polygon, lastRoundTrip: result }));
-    return result;
-  },
-  vectorToSdf,
-  sdfToVector,
-  snapPoint(point) {
-    const strength = clamp(state.snapStrength, 0, 1);
-    const resolution = clamp(Math.round(12 + strength * 20), 6, 64);
-    return {
-      x: clamp(Math.round(point.x * resolution) / resolution, 0, 1),
-      y: clamp(Math.round(point.y * resolution) / resolution, 0, 1),
-    };
+  setLastRoundTrip(result) {
+    commitState((current) => ({ ...current, lastRoundTrip: result }));
   },
 };
 
+export const polygonToRoomMask = (polygon: Point[], options?: SdfOptions): RoomMask =>
+  createRoomMaskFromPolygon(polygon, { resolution: options?.resolution, padding: options?.padding });
+
+export const roomMaskToVector = (mask: RoomMask): Point[] => roomMaskToPolygon(mask);

--- a/apps/pages/src/state/selection.ts
+++ b/apps/pages/src/state/selection.ts
@@ -1,8 +1,14 @@
-export type SelectionTool = 'magneticLasso' | 'smartWand';
+import { cloneRoomMask, type RoomMask } from '../utils/roomMask';
+
+export type SelectionTool = 'smartLasso' | 'lasso' | 'autoWand' | 'refineBrush';
 
 export interface SelectionState {
-  polygon: Array<{ x: number; y: number }> | null;
+  mask: RoomMask | null;
   tool: SelectionTool | null;
+  brushRadius: number;
+  wandTolerance: number;
+  wandConnectivity: 4 | 8;
+  snapStrength: number;
   entranceLocked: boolean;
   lockedEntranceId: string | null;
   cacheKey: string | null;
@@ -10,8 +16,12 @@ export interface SelectionState {
 }
 
 const defaultState: SelectionState = {
-  polygon: null,
+  mask: null,
   tool: null,
+  brushRadius: 0.08,
+  wandTolerance: 0.15,
+  wandConnectivity: 8,
+  snapStrength: 0.65,
   entranceLocked: false,
   lockedEntranceId: null,
   cacheKey: null,
@@ -26,8 +36,8 @@ const notify = () => {
   listeners.forEach((listener) => listener(state));
 };
 
-const setState = (updater: (current: SelectionState) => SelectionState) => {
-  state = updater(state);
+const commit = (updater: (current: SelectionState) => SelectionState) => {
+  state = { ...updater(state), lastUpdated: Date.now() };
   notify();
 };
 
@@ -40,32 +50,65 @@ export const selectionStore = {
       listeners.delete(listener);
     };
   },
+  setTool(tool: SelectionTool | null) {
+    commit((current) => ({ ...current, tool }));
+  },
   setSelection(
     tool: SelectionTool,
-    polygon: Array<{ x: number; y: number }> | null,
-    options?: { entranceLocked?: boolean; lockedEntranceId?: string | null; cacheKey?: string | null }
+    mask: RoomMask | null,
+    options?: {
+      entranceLocked?: boolean;
+      lockedEntranceId?: string | null;
+      cacheKey?: string | null;
+      brushRadius?: number;
+      wandTolerance?: number;
+      wandConnectivity?: 4 | 8;
+      snapStrength?: number;
+    },
   ) {
-    setState((current) => ({
-      polygon: polygon ? polygon.map((point) => ({ x: point.x, y: point.y })) : null,
+    commit((current) => ({
+      mask: mask ? cloneRoomMask(mask) : null,
       tool,
+      brushRadius: options?.brushRadius ?? current.brushRadius,
+      wandTolerance: options?.wandTolerance ?? current.wandTolerance,
+      wandConnectivity: options?.wandConnectivity ?? current.wandConnectivity,
+      snapStrength: options?.snapStrength ?? current.snapStrength,
       entranceLocked: options?.entranceLocked ?? false,
       lockedEntranceId: options?.lockedEntranceId ?? null,
       cacheKey: options?.cacheKey ?? current.cacheKey,
       lastUpdated: Date.now(),
     }));
   },
+  updateMask(mask: RoomMask | null) {
+    commit((current) => ({ ...current, mask: mask ? cloneRoomMask(mask) : null }));
+  },
+  setBrushRadius(radius: number) {
+    commit((current) => ({ ...current, brushRadius: Math.min(Math.max(radius, 0.01), 0.5) }));
+  },
+  setWandTolerance(tolerance: number) {
+    commit((current) => ({ ...current, wandTolerance: Math.min(Math.max(tolerance, 0), 1) }));
+  },
+  setWandConnectivity(connectivity: 4 | 8) {
+    commit((current) => ({ ...current, wandConnectivity: connectivity }));
+  },
+  setSnapStrength(strength: number) {
+    commit((current) => ({ ...current, snapStrength: Math.min(Math.max(strength, 0), 1) }));
+  },
   clearSelection() {
-    setState(() => ({ ...defaultState, lastUpdated: Date.now() }));
+    commit(() => ({ ...defaultState, lastUpdated: Date.now() }));
   },
   setEntranceLocked(locked: boolean, entranceId?: string | null) {
-    setState((current) => ({
+    commit((current) => ({
       ...current,
       entranceLocked: locked,
       lockedEntranceId: entranceId ?? current.lockedEntranceId,
-      lastUpdated: Date.now(),
     }));
   },
 };
 
-export type SelectionStore = typeof selectionStore;
+export const createEmptySelectionState = (): SelectionState => ({
+  ...defaultState,
+  lastUpdated: Date.now(),
+});
 
+export type SelectionStore = typeof selectionStore;

--- a/apps/pages/src/types.ts
+++ b/apps/pages/src/types.ts
@@ -1,3 +1,5 @@
+import type { RoomMask } from './utils/roomMask';
+
 export interface User {
   id: string;
   email: string;
@@ -29,11 +31,19 @@ export interface MapRecord {
   metadata?: Record<string, unknown> | null;
 }
 
+
+export interface RoomMaskManifestEntry {
+  roomId: string;
+  key: string;
+  dataUrl: string;
+}
+
 export interface Region {
   id: string;
   mapId: string;
   name: string;
-  polygon: Array<{ x: number; y: number }>;
+  mask: RoomMask;
+  maskManifest?: RoomMaskManifestEntry | null;
   notes?: string | null;
   revealOrder?: number | null;
 }

--- a/apps/pages/src/types/geometry.ts
+++ b/apps/pages/src/types/geometry.ts
@@ -1,0 +1,11 @@
+export interface Point {
+  x: number;
+  y: number;
+}
+
+export interface Bounds {
+  minX: number;
+  minY: number;
+  maxX: number;
+  maxY: number;
+}

--- a/apps/pages/src/utils/roomMask.ts
+++ b/apps/pages/src/utils/roomMask.ts
@@ -1,0 +1,639 @@
+import { Bounds, Point } from '../types/geometry';
+
+export interface RoomMask {
+  width: number;
+  height: number;
+  bounds: Bounds;
+  data: Uint8ClampedArray;
+}
+
+export interface RoomMaskOptions {
+  resolution?: number;
+  bounds?: Bounds;
+  padding?: number;
+}
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+const nearlyEqual = (a: number, b: number, epsilon = 1e-6) => Math.abs(a - b) <= epsilon;
+
+const pointKey = (point: Point) => `${point.x.toFixed(6)}:${point.y.toFixed(6)}`;
+
+const dedupePoints = (points: Point[]) => {
+  const seen = new Set<string>();
+  const result: Point[] = [];
+  for (const point of points) {
+    const key = pointKey(point);
+    if (!seen.has(key)) {
+      seen.add(key);
+      result.push(point);
+    }
+  }
+  return result;
+};
+
+const simplifyDouglasPeucker = (points: Point[], tolerance: number) => {
+  if (points.length <= 2) {
+    return points.slice();
+  }
+
+  const sqTolerance = tolerance * tolerance;
+
+  const sqDistanceToSegment = (p: Point, a: Point, b: Point) => {
+    let x = a.x;
+    let y = a.y;
+    let dx = b.x - x;
+    let dy = b.y - y;
+
+    if (dx !== 0 || dy !== 0) {
+      const t = ((p.x - x) * dx + (p.y - y) * dy) / (dx * dx + dy * dy);
+      if (t > 1) {
+        x = b.x;
+        y = b.y;
+      } else if (t > 0) {
+        x += dx * t;
+        y += dy * t;
+      }
+    }
+
+    dx = p.x - x;
+    dy = p.y - y;
+    return dx * dx + dy * dy;
+  };
+
+  const simplifyDPStep = (pointsToSimplify: Point[], first: number, last: number, simplified: Point[]) => {
+    let maxSqDist = sqTolerance;
+    let index = -1;
+
+    for (let i = first + 1; i < last; i += 1) {
+      const sqDist = sqDistanceToSegment(pointsToSimplify[i], pointsToSimplify[first], pointsToSimplify[last]);
+      if (sqDist > maxSqDist) {
+        index = i;
+        maxSqDist = sqDist;
+      }
+    }
+
+    if (index !== -1) {
+      if (index - first > 1) {
+        simplifyDPStep(pointsToSimplify, first, index, simplified);
+      }
+      simplified.push(pointsToSimplify[index]);
+      if (last - index > 1) {
+        simplifyDPStep(pointsToSimplify, index, last, simplified);
+      }
+    }
+  };
+
+  const last = points.length - 1;
+  const result = [points[0]];
+  simplifyDPStep(points, 0, last, result);
+  result.push(points[last]);
+  return result;
+};
+
+const pointInPolygon = (point: Point, polygon: Point[]) => {
+  let inside = false;
+  for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i += 1) {
+    const xi = polygon[i].x;
+    const yi = polygon[i].y;
+    const xj = polygon[j].x;
+    const yj = polygon[j].y;
+    const intersect = yi > point.y !== yj > point.y && point.x < ((xj - xi) * (point.y - yi)) / (yj - yi + Number.EPSILON) + xi;
+    if (intersect) inside = !inside;
+  }
+  return inside;
+};
+
+const ensureBounds = (polygon: Point[]): Bounds => {
+  if (polygon.length === 0) {
+    return { minX: 0, minY: 0, maxX: 1, maxY: 1 };
+  }
+  let minX = polygon[0].x;
+  let minY = polygon[0].y;
+  let maxX = polygon[0].x;
+  let maxY = polygon[0].y;
+  for (const point of polygon) {
+    if (point.x < minX) minX = point.x;
+    if (point.y < minY) minY = point.y;
+    if (point.x > maxX) maxX = point.x;
+    if (point.y > maxY) maxY = point.y;
+  }
+  const width = maxX - minX || 1;
+  const height = maxY - minY || 1;
+  const padding = Math.max(width, height) * 0.05;
+  return {
+    minX: clamp(minX - padding, 0, 1),
+    minY: clamp(minY - padding, 0, 1),
+    maxX: clamp(maxX + padding, 0, 1),
+    maxY: clamp(maxY + padding, 0, 1),
+  };
+};
+
+const rasterizePolygon = (polygon: Point[], width: number, height: number, bounds: Bounds) => {
+  const mask = new Uint8ClampedArray(width * height);
+  if (polygon.length === 0) {
+    return mask;
+  }
+  const scaleX = bounds.maxX - bounds.minX || 1;
+  const scaleY = bounds.maxY - bounds.minY || 1;
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      const worldPoint = {
+        x: bounds.minX + ((x + 0.5) / width) * scaleX,
+        y: bounds.minY + ((y + 0.5) / height) * scaleY,
+      };
+      if (pointInPolygon(worldPoint, polygon)) {
+        mask[y * width + x] = 255;
+      }
+    }
+  }
+  return mask;
+};
+
+const marchingSquares = (mask: Uint8ClampedArray, width: number, height: number) => {
+  const segments: Array<{ start: Point; end: Point }> = [];
+
+  const edgePoint = (x: number, y: number, edge: 'top' | 'bottom' | 'left' | 'right'): Point => {
+    switch (edge) {
+      case 'top':
+        return { x: x + 0.5, y };
+      case 'bottom':
+        return { x: x + 0.5, y: y + 1 };
+      case 'left':
+        return { x, y: y + 0.5 };
+      case 'right':
+        return { x: x + 1, y: y + 0.5 };
+    }
+  };
+
+  const cases: Record<number, Array<[Point, Point]>> = {
+    0: [],
+    1: [[edgePoint(0, 0, 'left'), edgePoint(0, 0, 'top')]],
+    2: [[edgePoint(0, 0, 'top'), edgePoint(0, 0, 'right')]],
+    3: [[edgePoint(0, 0, 'left'), edgePoint(0, 0, 'right')]],
+    4: [[edgePoint(0, 0, 'right'), edgePoint(0, 0, 'bottom')]],
+    5: [
+      [edgePoint(0, 0, 'left'), edgePoint(0, 0, 'bottom')],
+      [edgePoint(0, 0, 'top'), edgePoint(0, 0, 'right')],
+    ],
+    6: [[edgePoint(0, 0, 'top'), edgePoint(0, 0, 'bottom')]],
+    7: [[edgePoint(0, 0, 'left'), edgePoint(0, 0, 'bottom')]],
+    8: [[edgePoint(0, 0, 'bottom'), edgePoint(0, 0, 'left')]],
+    9: [[edgePoint(0, 0, 'top'), edgePoint(0, 0, 'bottom')]],
+    10: [
+      [edgePoint(0, 0, 'top'), edgePoint(0, 0, 'right')],
+      [edgePoint(0, 0, 'bottom'), edgePoint(0, 0, 'left')],
+    ],
+    11: [[edgePoint(0, 0, 'right'), edgePoint(0, 0, 'bottom')]],
+    12: [[edgePoint(0, 0, 'right'), edgePoint(0, 0, 'left')]],
+    13: [[edgePoint(0, 0, 'top'), edgePoint(0, 0, 'right')]],
+    14: [[edgePoint(0, 0, 'left'), edgePoint(0, 0, 'top')]],
+    15: [],
+  };
+
+  for (let y = 0; y < height - 1; y += 1) {
+    for (let x = 0; x < width - 1; x += 1) {
+      const topLeft = mask[y * width + x] > 0;
+      const topRight = mask[y * width + x + 1] > 0;
+      const bottomRight = mask[(y + 1) * width + x + 1] > 0;
+      const bottomLeft = mask[(y + 1) * width + x] > 0;
+      let key = 0;
+      if (topLeft) key |= 1;
+      if (topRight) key |= 2;
+      if (bottomRight) key |= 4;
+      if (bottomLeft) key |= 8;
+      if (key === 0 || key === 15) {
+        continue;
+      }
+      const template = cases[key];
+      for (const [start, end] of template) {
+        segments.push({
+          start: { x: start.x + x, y: start.y + y },
+          end: { x: end.x + x, y: end.y + y },
+        });
+      }
+    }
+  }
+
+  if (segments.length === 0) {
+    return [] as Point[];
+  }
+
+  const polygon: Point[] = [];
+  const used = new Array(segments.length).fill(false);
+  polygon.push(segments[0].start);
+  polygon.push(segments[0].end);
+  used[0] = true;
+
+  const equals = (a: Point, b: Point) => nearlyEqual(a.x, b.x, 1e-4) && nearlyEqual(a.y, b.y, 1e-4);
+
+  while (polygon.length < 5000) {
+    const current = polygon[polygon.length - 1];
+    let advanced = false;
+    for (let i = 0; i < segments.length; i += 1) {
+      if (used[i]) continue;
+      const segment = segments[i];
+      if (equals(segment.start, current)) {
+        polygon.push(segment.end);
+        used[i] = true;
+        advanced = true;
+        break;
+      }
+      if (equals(segment.end, current)) {
+        polygon.push(segment.start);
+        used[i] = true;
+        advanced = true;
+        break;
+      }
+    }
+    if (!advanced) {
+      break;
+    }
+    if (equals(polygon[polygon.length - 1], polygon[0])) {
+      polygon.pop();
+      break;
+    }
+  }
+
+  return polygon;
+};
+
+export const createRoomMaskFromPolygon = (polygon: Point[], options?: RoomMaskOptions): RoomMask => {
+  const resolution = clamp(options?.resolution ?? 256, 16, 1024);
+  const padding = options?.padding ?? 0;
+  const baseBounds = options?.bounds ?? ensureBounds(polygon);
+  const bounds: Bounds = {
+    minX: clamp(baseBounds.minX - padding, 0, 1),
+    minY: clamp(baseBounds.minY - padding, 0, 1),
+    maxX: clamp(baseBounds.maxX + padding, 0, 1),
+    maxY: clamp(baseBounds.maxY + padding, 0, 1),
+  };
+  const width = Math.max(8, Math.round((bounds.maxX - bounds.minX) * resolution));
+  const height = Math.max(8, Math.round((bounds.maxY - bounds.minY) * resolution));
+  const mask = rasterizePolygon(polygon, width, height, bounds);
+  return {
+    width,
+    height,
+    bounds,
+    data: mask,
+  };
+};
+
+export const roomMaskToPolygon = (mask: RoomMask, tolerance = 0.001): Point[] => {
+  const raw = marchingSquares(mask.data, mask.width, mask.height);
+  if (raw.length === 0) {
+    return [];
+  }
+  const { bounds } = mask;
+  const scaleX = bounds.maxX - bounds.minX || 1;
+  const scaleY = bounds.maxY - bounds.minY || 1;
+  const widthDenominator = mask.width - 1 || 1;
+  const heightDenominator = mask.height - 1 || 1;
+  const polygon = raw.map((point) => ({
+    x: bounds.minX + (point.x / widthDenominator) * scaleX,
+    y: bounds.minY + (point.y / heightDenominator) * scaleY,
+  }));
+  return simplifyDouglasPeucker(dedupePoints(polygon), tolerance);
+};
+
+const crcTable = (() => {
+  const table = new Uint32Array(256);
+  for (let n = 0; n < 256; n += 1) {
+    let c = n;
+    for (let k = 0; k < 8; k += 1) {
+      c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    }
+    table[n] = c >>> 0;
+  }
+  return table;
+})();
+
+const crc32 = (data: Uint8Array, start = 0, length = data.length) => {
+  let c = 0xffffffff;
+  for (let i = 0; i < length; i += 1) {
+    c = crcTable[(c ^ data[start + i]) & 0xff] ^ (c >>> 8);
+  }
+  return (c ^ 0xffffffff) >>> 0;
+};
+
+const adler32 = (data: Uint8Array) => {
+  let a = 1;
+  let b = 0;
+  const MOD_ADLER = 65521;
+  for (let i = 0; i < data.length; i += 1) {
+    a = (a + data[i]) % MOD_ADLER;
+    b = (b + a) % MOD_ADLER;
+  }
+  return ((b << 16) | a) >>> 0;
+};
+
+const writeChunk = (type: string, data: Uint8Array) => {
+  const chunk = new Uint8Array(8 + data.length + 4);
+  const length = data.length;
+  chunk[0] = (length >>> 24) & 0xff;
+  chunk[1] = (length >>> 16) & 0xff;
+  chunk[2] = (length >>> 8) & 0xff;
+  chunk[3] = length & 0xff;
+  for (let i = 0; i < 4; i += 1) {
+    chunk[4 + i] = type.charCodeAt(i);
+  }
+  chunk.set(data, 8);
+  const crc = crc32(chunk, 4, data.length + 4);
+  const crcOffset = 8 + data.length;
+  chunk[crcOffset] = (crc >>> 24) & 0xff;
+  chunk[crcOffset + 1] = (crc >>> 16) & 0xff;
+  chunk[crcOffset + 2] = (crc >>> 8) & 0xff;
+  chunk[crcOffset + 3] = crc & 0xff;
+  return chunk;
+};
+
+const buildZlibStream = (data: Uint8Array) => {
+  const chunks: number[] = [];
+  chunks.push(0x78, 0x01);
+  let offset = 0;
+  while (offset < data.length) {
+    const remaining = data.length - offset;
+    const blockSize = Math.min(0xffff, remaining);
+    const isFinal = offset + blockSize >= data.length ? 1 : 0;
+    chunks.push(isFinal);
+    chunks.push(blockSize & 0xff, (blockSize >>> 8) & 0xff);
+    const nlen = 0xffff - blockSize;
+    chunks.push(nlen & 0xff, (nlen >>> 8) & 0xff);
+    for (let i = 0; i < blockSize; i += 1) {
+      chunks.push(data[offset + i]);
+    }
+    offset += blockSize;
+  }
+  const adler = adler32(data);
+  chunks.push((adler >>> 24) & 0xff, (adler >>> 16) & 0xff, (adler >>> 8) & 0xff, adler & 0xff);
+  return new Uint8Array(chunks);
+};
+
+const serializeBounds = (bounds: Bounds) => {
+  const payload = JSON.stringify(bounds);
+  const text = new TextEncoder().encode(`bounds\0${payload}`);
+  return text;
+};
+
+export const encodeRoomMaskToPngBytes = (mask: RoomMask): Uint8Array => {
+  const rows = mask.height;
+  const cols = mask.width;
+  const raw = new Uint8Array((cols + 1) * rows);
+  for (let y = 0; y < rows; y += 1) {
+    raw[y * (cols + 1)] = 0; // filter type 0
+    for (let x = 0; x < cols; x += 1) {
+      raw[y * (cols + 1) + 1 + x] = mask.data[y * cols + x];
+    }
+  }
+  const idat = buildZlibStream(raw);
+  const ihdr = new Uint8Array(13);
+  ihdr[0] = (cols >>> 24) & 0xff;
+  ihdr[1] = (cols >>> 16) & 0xff;
+  ihdr[2] = (cols >>> 8) & 0xff;
+  ihdr[3] = cols & 0xff;
+  ihdr[4] = (rows >>> 24) & 0xff;
+  ihdr[5] = (rows >>> 16) & 0xff;
+  ihdr[6] = (rows >>> 8) & 0xff;
+  ihdr[7] = rows & 0xff;
+  ihdr[8] = 8; // bit depth
+  ihdr[9] = 0; // grayscale
+  ihdr[10] = 0; // compression
+  ihdr[11] = 0; // filter
+  ihdr[12] = 0; // interlace
+  const signature = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]);
+  const chunks = [
+    writeChunk('IHDR', ihdr),
+    writeChunk('tEXt', serializeBounds(mask.bounds)),
+    writeChunk('IDAT', idat),
+    writeChunk('IEND', new Uint8Array(0)),
+  ];
+  const totalLength = signature.length + chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+  const result = new Uint8Array(totalLength);
+  let offset = 0;
+  result.set(signature, offset);
+  offset += signature.length;
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return result;
+};
+
+const base64Encode = (bytes: Uint8Array) => {
+  if (typeof btoa === 'function') {
+    let binary = '';
+    for (let i = 0; i < bytes.length; i += 1) {
+      binary += String.fromCharCode(bytes[i]);
+    }
+    return btoa(binary);
+  }
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength).toString('base64');
+  }
+  let binary = '';
+  for (let i = 0; i < bytes.length; i += 1) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return binary;
+};
+
+const base64Decode = (input: string) => {
+  if (typeof atob === 'function') {
+    const binary = atob(input);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i += 1) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes;
+  }
+  if (typeof Buffer !== 'undefined') {
+    const buffer = Buffer.from(input, 'base64');
+    return new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength);
+  }
+  const bytes = new Uint8Array(input.length);
+  for (let i = 0; i < input.length; i += 1) {
+    bytes[i] = input.charCodeAt(i);
+  }
+  return bytes;
+};
+
+export const encodeRoomMaskToDataUrl = (mask: RoomMask) => {
+  const pngBytes = encodeRoomMaskToPngBytes(mask);
+  const encoded = base64Encode(pngBytes);
+  return `data:image/png;base64,${encoded}`;
+};
+
+const parseBoundsFromText = (data: Uint8Array): Bounds | null => {
+  try {
+    const text = new TextDecoder().decode(data);
+    const [keyword, value] = text.split('\0');
+    if (keyword === 'bounds' && value) {
+      const parsed = JSON.parse(value);
+      if (
+        typeof parsed === 'object' &&
+        parsed !== null &&
+        typeof parsed.minX === 'number' &&
+        typeof parsed.minY === 'number' &&
+        typeof parsed.maxX === 'number' &&
+        typeof parsed.maxY === 'number'
+      ) {
+        return parsed;
+      }
+    }
+  } catch (_error) {
+    return null;
+  }
+  return null;
+};
+
+const readUInt32BE = (data: Uint8Array, offset: number) =>
+  (data[offset] << 24) | (data[offset + 1] << 16) | (data[offset + 2] << 8) | data[offset + 3];
+
+const decompressZlib = (data: Uint8Array) => {
+  if (data.length < 6) {
+    throw new Error('Invalid zlib stream');
+  }
+  // skip zlib header (2 bytes)
+  let offset = 2;
+  const chunks: number[] = [];
+  while (offset < data.length - 4) {
+    const bfinal = data[offset] & 1;
+    const btype = (data[offset] >>> 1) & 0x3;
+    offset += 1;
+    if (btype !== 0) {
+      throw new Error('Unsupported compression method');
+    }
+    const len = data[offset] | (data[offset + 1] << 8);
+    offset += 2;
+    const nlen = data[offset] | (data[offset + 1] << 8);
+    offset += 2;
+    if ((len & 0xffff) !== (~nlen & 0xffff)) {
+      throw new Error('Corrupted zlib stream');
+    }
+    for (let i = 0; i < len; i += 1) {
+      chunks.push(data[offset + i]);
+    }
+    offset += len;
+    if (bfinal) {
+      break;
+    }
+  }
+  return new Uint8Array(chunks);
+};
+
+export const decodeRoomMaskFromPngBytes = (pngBytes: Uint8Array): RoomMask => {
+  const signature = [137, 80, 78, 71, 13, 10, 26, 10];
+  for (let i = 0; i < signature.length; i += 1) {
+    if (pngBytes[i] !== signature[i]) {
+      throw new Error('Invalid PNG signature');
+    }
+  }
+  let offset = signature.length;
+  let width = 0;
+  let height = 0;
+  let bounds: Bounds | null = null;
+  const idatParts: Uint8Array[] = [];
+  while (offset < pngBytes.length) {
+    const length = readUInt32BE(pngBytes, offset);
+    offset += 4;
+    const type = String.fromCharCode(
+      pngBytes[offset],
+      pngBytes[offset + 1],
+      pngBytes[offset + 2],
+      pngBytes[offset + 3],
+    );
+    offset += 4;
+    const data = pngBytes.slice(offset, offset + length);
+    offset += length;
+    offset += 4; // skip CRC
+    if (type === 'IHDR') {
+      width = readUInt32BE(data, 0);
+      height = readUInt32BE(data, 4);
+    } else if (type === 'tEXt') {
+      bounds = parseBoundsFromText(data) ?? bounds;
+    } else if (type === 'IDAT') {
+      idatParts.push(data);
+    } else if (type === 'IEND') {
+      break;
+    }
+  }
+  if (width === 0 || height === 0) {
+    throw new Error('PNG missing IHDR data');
+  }
+  const concatenated = new Uint8Array(idatParts.reduce((sum, part) => sum + part.length, 0));
+  let cursor = 0;
+  for (const part of idatParts) {
+    concatenated.set(part, cursor);
+    cursor += part.length;
+  }
+  const raw = decompressZlib(concatenated);
+  const stride = width + 1;
+  const data = new Uint8ClampedArray(width * height);
+  for (let y = 0; y < height; y += 1) {
+    const filter = raw[y * stride];
+    if (filter !== 0) {
+      throw new Error('Unsupported PNG filter');
+    }
+    for (let x = 0; x < width; x += 1) {
+      data[y * width + x] = raw[y * stride + 1 + x];
+    }
+  }
+  return {
+    width,
+    height,
+    bounds: bounds ?? { minX: 0, minY: 0, maxX: 1, maxY: 1 },
+    data,
+  };
+};
+
+export const decodeRoomMaskFromDataUrl = (dataUrl: string): RoomMask => {
+  const [, encoded] = dataUrl.split(',');
+  if (!encoded) {
+    throw new Error('Invalid data URL');
+  }
+  const bytes = base64Decode(encoded);
+  return decodeRoomMaskFromPngBytes(bytes);
+};
+
+export const cloneRoomMask = (mask: RoomMask): RoomMask => ({
+  width: mask.width,
+  height: mask.height,
+  bounds: { ...mask.bounds },
+  data: new Uint8ClampedArray(mask.data),
+});
+
+export const applyCircularBrushToMask = (
+  mask: RoomMask,
+  center: Point,
+  radius: number,
+  mode: 'add' | 'erase',
+): RoomMask => {
+  const next = cloneRoomMask(mask);
+  const { width, height, bounds } = next;
+  const scaleX = bounds.maxX - bounds.minX || 1;
+  const scaleY = bounds.maxY - bounds.minY || 1;
+  const pixelRadiusX = Math.max(1, Math.round((radius / scaleX) * width));
+  const pixelRadiusY = Math.max(1, Math.round((radius / scaleY) * height));
+  const centerX = Math.round(((center.x - bounds.minX) / scaleX) * width);
+  const centerY = Math.round(((center.y - bounds.minY) / scaleY) * height);
+  for (let dy = -pixelRadiusY; dy <= pixelRadiusY; dy += 1) {
+    const y = centerY + dy;
+    if (y < 0 || y >= height) continue;
+    for (let dx = -pixelRadiusX; dx <= pixelRadiusX; dx += 1) {
+      const x = centerX + dx;
+      if (x < 0 || x >= width) continue;
+      const distance = Math.sqrt((dx / pixelRadiusX) ** 2 + (dy / pixelRadiusY) ** 2);
+      if (distance <= 1) {
+        next.data[y * width + x] = mode === 'add' ? 255 : 0;
+      }
+    }
+  }
+  return next;
+};
+
+export const emptyRoomMask = (): RoomMask => ({
+  width: 32,
+  height: 32,
+  bounds: { minX: 0, minY: 0, maxX: 1, maxY: 1 },
+  data: new Uint8ClampedArray(32 * 32),
+});


### PR DESCRIPTION
## Summary
- add geometry and room mask utilities to rasterize polygons, apply brush strokes, and encode masks to PNG manifests
- migrate selection/define rooms state, editor UI, and map workflows to use RoomMask data instead of polygon samples, including manifest metadata
- adapt API client, map mask rendering, and tests to serialize raster masks while keeping polygon compatibility where needed

## Testing
- npm run test *(fails: jsdom dependency unavailable in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68d2d9ff7a088323b4f4e5a7dd6f59c7