### PR TITLE
Refactor defineRooms tools to operate on raster masks

### DIFF
--- a/apps/pages/src/tools/defineRooms/LassoTool.ts
+++ b/apps/pages/src/tools/defineRooms/LassoTool.ts
@@ -1,11 +1,73 @@
-import type { Point } from '../../state/defineRoomsStore';
+import type { Bounds, Point } from '../../types/geometry';
+import type { RoomMask } from '../../utils/roomMask';
+import { useSegmentation } from './segmentationHelpers';
 import type { DefineRoomsTool, PointerState, ToolContext } from './ToolContext';
-
-const distance = (a: Point, b: Point) => Math.hypot(a.x - b.x, a.y - b.y);
 
 const clamp01 = (value: number) => Math.min(Math.max(value, 0), 1);
 
 const clampPoint = (point: Point): Point => ({ x: clamp01(point.x), y: clamp01(point.y) });
+
+const distance = (a: Point, b: Point) => Math.hypot(a.x - b.x, a.y - b.y);
+
+const computeBounds = (points: Point[]): Bounds => {
+  if (points.length === 0) {
+    return { minX: 0, minY: 0, maxX: 1, maxY: 1 };
+  }
+  let minX = points[0].x;
+  let minY = points[0].y;
+  let maxX = points[0].x;
+  let maxY = points[0].y;
+  for (const point of points) {
+    if (point.x < minX) minX = point.x;
+    if (point.y < minY) minY = point.y;
+    if (point.x > maxX) maxX = point.x;
+    if (point.y > maxY) maxY = point.y;
+  }
+  return { minX, minY, maxX, maxY };
+};
+
+const expandBounds = (bounds: Bounds, padding: number): Bounds => ({
+  minX: clamp01(bounds.minX - padding),
+  minY: clamp01(bounds.minY - padding),
+  maxX: clamp01(bounds.maxX + padding),
+  maxY: clamp01(bounds.maxY + padding),
+});
+
+const pointsToMask = (ctx: ToolContext, points: Point[]): RoomMask | null => {
+  if (points.length < 3) {
+    return null;
+  }
+  const baseBounds = computeBounds(points);
+  const rangeX = baseBounds.maxX - baseBounds.minX;
+  const rangeY = baseBounds.maxY - baseBounds.minY;
+  const padding = Math.max(rangeX, rangeY) * 0.1 + 0.01;
+  const bounds = expandBounds(baseBounds, padding);
+  const widthRatio = bounds.maxX - bounds.minX || 1;
+  const heightRatio = bounds.maxY - bounds.minY || 1;
+  const maxDimension = Math.max(widthRatio, heightRatio) || 1;
+  const baseResolution = 768;
+  const scale = baseResolution / Math.max(maxDimension, 0.02);
+  const width = Math.max(32, Math.min(1024, Math.round(Math.max(widthRatio, 0.02) * scale)));
+  const height = Math.max(32, Math.min(1024, Math.round(Math.max(heightRatio, 0.02) * scale)));
+  const localPoints = points.map((point) => ({
+    x: clamp01((point.x - bounds.minX) / widthRatio),
+    y: clamp01((point.y - bounds.minY) / heightRatio),
+  }));
+  const strokeRadius = Math.max(1 / Math.max(width, height), 0.003);
+  const boundary = useSegmentation(ctx.segmentation, 'rasterizeFreehandPath', localPoints, width, height, {
+    strokeRadius,
+    closePath: true,
+  });
+  const filled = useSegmentation(ctx.segmentation, 'fillMaskInterior', boundary, width, height);
+  const featherRadius = Math.max(1, Math.round(Math.max(width, height) * 0.01));
+  const feathered = useSegmentation(ctx.segmentation, 'featherMask', filled, width, height, featherRadius);
+  return {
+    width,
+    height,
+    bounds,
+    data: feathered,
+  };
+};
 
 export class LassoTool implements DefineRoomsTool {
   readonly id = 'lasso';
@@ -21,7 +83,7 @@ export class LassoTool implements DefineRoomsTool {
     const start = clampPoint(ctx.snap(ctx.clamp(pointer.point)));
     this.active = true;
     this.points = [start];
-    ctx.store.previewPolygon(this.points.slice());
+    ctx.store.previewMask(null);
   }
 
   onPointerMove(ctx: ToolContext, pointer: PointerState) {
@@ -32,10 +94,12 @@ export class LassoTool implements DefineRoomsTool {
     const last = this.points[this.points.length - 1];
     if (!last || distance(last, current) > 0.003) {
       this.points.push(current);
-      ctx.store.previewPolygon(this.points.slice());
     } else if (this.points.length) {
       this.points[this.points.length - 1] = current;
-      ctx.store.previewPolygon(this.points.slice());
+    }
+    const preview = pointsToMask(ctx, this.points);
+    if (preview) {
+      ctx.store.previewMask(preview);
     }
   }
 
@@ -49,24 +113,19 @@ export class LassoTool implements DefineRoomsTool {
     } else {
       this.points[this.points.length - 1] = endPoint;
     }
-    this.finish(ctx);
+    const mask = pointsToMask(ctx, this.points);
+    this.active = false;
+    this.points = [];
+    ctx.store.previewMask(null);
+    if (mask) {
+      ctx.store.commitMask(mask);
+    }
   }
 
   onCancel(ctx: ToolContext) {
     this.active = false;
     this.points = [];
-    ctx.store.previewPolygon(null);
-  }
-
-  private finish(ctx: ToolContext) {
-    this.active = false;
-    const polygon = this.points.slice();
-    this.points = [];
-    if (polygon.length >= 3) {
-      ctx.store.commitPolygon(polygon);
-    } else {
-      ctx.store.previewPolygon(null);
-    }
+    ctx.store.previewMask(null);
   }
 }
 

--- a/apps/pages/src/tools/defineRooms/PaintbrushTool.ts
+++ b/apps/pages/src/tools/defineRooms/PaintbrushTool.ts
@@ -1,16 +1,65 @@
-import type { Point } from '../../state/defineRoomsStore';
+import type { Point } from '../../types/geometry';
+import { cloneRoomMask, type RoomMask } from '../../utils/roomMask';
+import { useSegmentation } from './segmentationHelpers';
 import type { DefineRoomsTool, PointerState, ToolContext } from './ToolContext';
-
-const distance = (a: Point, b: Point) => Math.hypot(a.x - b.x, a.y - b.y);
-
-const interpolate = (a: Point, b: Point, t: number): Point => ({
-  x: a.x + (b.x - a.x) * t,
-  y: a.y + (b.y - a.y) * t,
-});
 
 const clamp01 = (value: number) => Math.min(Math.max(value, 0), 1);
 
 const clampPoint = (point: Point): Point => ({ x: clamp01(point.x), y: clamp01(point.y) });
+
+const createDefaultMask = (resolution = 512): RoomMask => ({
+  width: resolution,
+  height: resolution,
+  bounds: { minX: 0, minY: 0, maxX: 1, maxY: 1 },
+  data: new Uint8ClampedArray(resolution * resolution),
+});
+
+const toMaskSpace = (mask: RoomMask, point: Point) => {
+  const width = mask.bounds.maxX - mask.bounds.minX || 1;
+  const height = mask.bounds.maxY - mask.bounds.minY || 1;
+  return {
+    x: clamp01(width === 0 ? 0.5 : (point.x - mask.bounds.minX) / width),
+    y: clamp01(height === 0 ? 0.5 : (point.y - mask.bounds.minY) / height),
+  };
+};
+
+const computeStrokeRadius = (mask: RoomMask, radius: number) => {
+  const maxAxis = Math.max(mask.bounds.maxX - mask.bounds.minX, mask.bounds.maxY - mask.bounds.minY) || 1;
+  const normalized = clamp01(radius / maxAxis);
+  const minimum = 0.5 / Math.max(mask.width, mask.height);
+  return Math.max(normalized, minimum);
+};
+
+const paintStroke = (
+  mask: RoomMask,
+  points: Point[],
+  radius: number,
+  mode: 'add' | 'erase',
+  segmentation: ToolContext['segmentation'],
+) => {
+  if (points.length === 0) {
+    return;
+  }
+  const localPoints = points.map((point) => toMaskSpace(mask, point));
+  const stroke = useSegmentation(segmentation, 'rasterizeFreehandPath', localPoints, mask.width, mask.height, {
+    strokeRadius: computeStrokeRadius(mask, radius),
+    closePath: false,
+  });
+  const target = mask.data;
+  for (let i = 0; i < target.length; i += 1) {
+    const coverage = stroke[i];
+    if (coverage === 0) {
+      continue;
+    }
+    if (mode === 'add') {
+      if (coverage > target[i]) {
+        target[i] = coverage;
+      }
+    } else {
+      target[i] = Math.round((target[i] * (255 - coverage)) / 255);
+    }
+  }
+};
 
 export class PaintbrushTool implements DefineRoomsTool {
   readonly id = 'paintbrush';
@@ -21,12 +70,17 @@ export class PaintbrushTool implements DefineRoomsTool {
 
   private lastPoint: Point | null = null;
 
+  private workingMask: RoomMask | null = null;
+
   onPointerDown(ctx: ToolContext, pointer: PointerState) {
     const initial = clampPoint(ctx.snap(ctx.clamp(pointer.point)));
     this.mode = pointer.button === 2 || pointer.buttons === 2 || pointer.altKey || pointer.ctrlKey ? 'erase' : 'add';
     this.active = true;
     this.lastPoint = initial;
-    ctx.store.applyBrushSample(initial, this.mode);
+    ctx.store.previewMask(null);
+    const mask = this.ensureWorkingMask(ctx);
+    paintStroke(mask, [initial], this.getBrushRadius(ctx, pointer), this.mode, ctx.segmentation);
+    ctx.store.commitMask(mask);
   }
 
   onPointerMove(ctx: ToolContext, pointer: PointerState) {
@@ -34,8 +88,10 @@ export class PaintbrushTool implements DefineRoomsTool {
       return;
     }
     const point = clampPoint(ctx.snap(ctx.clamp(pointer.point)));
-    this.strokeSegment(ctx, this.lastPoint, point);
+    const mask = this.ensureWorkingMask(ctx);
+    paintStroke(mask, [this.lastPoint, point], this.getBrushRadius(ctx, pointer), this.mode, ctx.segmentation);
     this.lastPoint = point;
+    ctx.store.commitMask(mask);
   }
 
   onPointerUp(ctx: ToolContext, pointer: PointerState) {
@@ -43,35 +99,38 @@ export class PaintbrushTool implements DefineRoomsTool {
       return;
     }
     const point = clampPoint(ctx.snap(ctx.clamp(pointer.point)));
+    const mask = this.ensureWorkingMask(ctx);
     if (this.lastPoint) {
-      this.strokeSegment(ctx, this.lastPoint, point);
-    } else {
-      ctx.store.applyBrushSample(point, this.mode);
+      paintStroke(mask, [this.lastPoint, point], this.getBrushRadius(ctx, pointer), this.mode, ctx.segmentation);
+      ctx.store.commitMask(mask);
     }
     this.active = false;
     this.lastPoint = null;
+    this.workingMask = null;
   }
 
   onCancel(ctx: ToolContext) {
     this.active = false;
     this.lastPoint = null;
-    ctx.store.previewPolygon(null);
+    this.workingMask = null;
+    ctx.store.previewMask(null);
   }
 
-  private strokeSegment(ctx: ToolContext, from: Point, to: Point) {
-    const radius = Math.max(0.0025, ctx.store.getState().brushRadius);
-    const dist = distance(from, to);
-    if (dist === 0) {
-      ctx.store.applyBrushSample(to, this.mode);
-      return;
+  private ensureWorkingMask(ctx: ToolContext): RoomMask {
+    if (this.workingMask) {
+      return this.workingMask;
     }
-    const step = Math.max(radius * 0.5, 0.003);
-    const steps = Math.max(1, Math.ceil(dist / step));
-    for (let i = 1; i <= steps; i += 1) {
-      const t = i / steps;
-      const point = clampPoint(ctx.snap(ctx.clamp(interpolate(from, to, t))));
-      ctx.store.applyBrushSample(point, this.mode);
+    const current = ctx.store.getState().selection.mask;
+    this.workingMask = current ? cloneRoomMask(current) : createDefaultMask();
+    return this.workingMask;
+  }
+
+  private getBrushRadius(ctx: ToolContext, pointer?: PointerState) {
+    const base = ctx.store.getState().selection.brushRadius ?? 0.05;
+    if (pointer?.pressure !== undefined) {
+      return Math.max(base * clamp01(pointer.pressure), 0.001);
     }
+    return Math.max(base, 0.001);
   }
 }
 

--- a/apps/pages/src/tools/defineRooms/ToolContext.ts
+++ b/apps/pages/src/tools/defineRooms/ToolContext.ts
@@ -1,5 +1,12 @@
 import type { DefineRoomsStore, Point } from '../../state/defineRoomsStore';
-import type { SegmentationWorker } from '../../workers/seg';
+import type { RasterLayer, SegmentationWorker } from '../../workers/seg';
+
+export interface RasterContext {
+  layers: RasterLayer | RasterLayer[];
+  width: number;
+  height: number;
+  edgeEnergy?: Float32Array | null;
+}
 
 export interface PointerState {
   point: Point;
@@ -15,6 +22,7 @@ export interface PointerState {
 export interface ToolContext {
   store: DefineRoomsStore;
   segmentation: SegmentationWorker | null;
+  raster: RasterContext | null;
   snap(point: Point): Point;
   clamp(point: Point): Point;
 }

--- a/apps/pages/src/tools/defineRooms/segmentationHelpers.ts
+++ b/apps/pages/src/tools/defineRooms/segmentationHelpers.ts
@@ -1,0 +1,32 @@
+import {
+  compositeMax as compositeMaxSync,
+  dilateMask as dilateMaskSync,
+  edgeEnergyMultiScale as edgeEnergyMultiScaleSync,
+  featherMask as featherMaskSync,
+  fillMaskInterior as fillMaskInteriorSync,
+  magicWandSelect as magicWandSelectSync,
+  rasterizeFreehandPath as rasterizeFreehandPathSync,
+  refineBoundaryToEdges as refineBoundaryToEdgesSync,
+  type SegmentationWorker,
+} from '../../workers/seg';
+
+const fallback: SegmentationWorker = {
+  magicWandSelect: magicWandSelectSync,
+  refineBoundaryToEdges: refineBoundaryToEdgesSync,
+  edgeEnergyMultiScale: edgeEnergyMultiScaleSync,
+  rasterizeFreehandPath: rasterizeFreehandPathSync,
+  fillMaskInterior: fillMaskInteriorSync,
+  dilateMask: dilateMaskSync,
+  featherMask: featherMaskSync,
+  compositeMax: compositeMaxSync,
+};
+
+export const useSegmentation = <K extends keyof SegmentationWorker>(
+  segmentation: SegmentationWorker | null,
+  key: K,
+  ...args: Parameters<SegmentationWorker[K]>
+): ReturnType<SegmentationWorker[K]> => {
+  const fn = segmentation?.[key] ?? fallback[key];
+  return fn(...args);
+};
+


### PR DESCRIPTION
## Summary
- add a segmentation helper with fallbacks so tools can invoke raster worker functionality in the main thread
- update paintbrush, lasso, smart lasso, and auto wand tools to manipulate RoomMask data directly via raster helpers
- extend the tool context with raster metadata required for wand and refinement operations

## Testing
- npm test *(fails: missing jsdom dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68d2e7fea12483238c71736d0f55f347