### PR TITLE
Use ToolContext state in SmartLassoTool

### DIFF
--- a/apps/pages/src/tools/defineRooms/SmartLassoTool.ts
+++ b/apps/pages/src/tools/defineRooms/SmartLassoTool.ts
@@ -206,7 +206,7 @@ export class SmartLassoTool implements DefineRoomsTool {
     }
     const preview = buildFreehandMask(ctx, this.rawPoints);
     if (preview) {
-      const selection = this.store.getState().selection;
+      const selection = ctx.store.getState().selection;
       ctx.store.previewMask(refineMask(ctx, preview, null, selection));
     }
   }
@@ -232,7 +232,7 @@ export class SmartLassoTool implements DefineRoomsTool {
       ctx.store.setBusy('Refining edges…');
     }
     try {
-      const selection = this.store.getState().selection;
+      const selection = ctx.store.getState().selection;
       const refined = refineMask(ctx, mask, this.energy, selection);
       ctx.store.commitMask(refined);
     } finally {


### PR DESCRIPTION
## Summary
- read the Smart Lasso selection data from the ToolContext store so the tool remains stateless

## Testing
- pnpm test -- --run --environment node *(fails: Vitest cannot install the required `jsdom` dependency due to a 403 from the npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d2fd40cf648323930b2f6bb61194bd