### PR TITLE
Adjust define rooms layout and wizard footer

### DIFF
--- a/apps/pages/src/components/MapCreationWizard.tsx
+++ b/apps/pages/src/components/MapCreationWizard.tsx
@@ -837,11 +837,11 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
             </div>
           )}
           {step === 2 && (
-            <div className="flex flex-1 items-stretch justify-center">
-              <div className="flex h-full w-full max-w-6xl rounded-3xl border border-slate-800/70 bg-slate-900/70 p-4">
+            <div className="flex h-full min-h-0 flex-1 items-stretch">
+              <div className="flex h-full min-h-0 w-full flex-1 rounded-3xl border border-slate-800/70 bg-slate-900/70 p-4">
                 <div
                   ref={defineRoomContainerRef}
-                  className={`flex h-full w-full flex-col overflow-hidden rounded-2xl border border-slate-800/70 bg-slate-950/80 ${
+                  className={`flex h-full min-h-0 w-full flex-1 flex-col overflow-hidden rounded-2xl border border-slate-800/70 bg-slate-950/80 ${
                     canLaunchRoomsEditor ? '' : 'items-center justify-center text-sm text-slate-500'
                   }`}
                 >
@@ -1023,7 +1023,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
           )}
         </div>
       </main>
-      <footer className="border-t border-slate-800/70 px-6 py-5">
+      <footer className="border-t border-slate-800/70 px-5 py-4">
         <div className="flex flex-wrap items-center justify-between gap-4">
           <button
             type="button"

--- a/apps/pages/src/define-rooms/DefineRoom.tsx
+++ b/apps/pages/src/define-rooms/DefineRoom.tsx
@@ -528,7 +528,7 @@ export class DefineRoom {
 
   private hoverLabel!: HTMLElement;
 
-  private closeButton!: HTMLButtonElement;
+  private closeButton: HTMLButtonElement | null = null;
 
   private imageContext!: CanvasRenderingContext2D;
 
@@ -631,10 +631,12 @@ export class DefineRoom {
         class={`define-room-overlay hidden${this.mode === 'embedded' ? ' define-room-embedded' : ''}`}
       >
         <div class="define-room-window">
-          <div class="define-room-header">
-            <h1>Define Rooms</h1>
-            <button class="define-room-close" type="button">Close</button>
-          </div>
+          {this.mode === 'overlay' && (
+            <div class="define-room-header">
+              <h1>Define Rooms</h1>
+              <button class="define-room-close" type="button">Close</button>
+            </div>
+          )}
           <div class="define-room-body">
             <section class="define-room-editor">
               <div class="toolbar-area">
@@ -949,7 +951,9 @@ export class DefineRoom {
   }
 
   private attachEventListeners(): void {
-    this.closeButton.addEventListener("click", () => this.close());
+    if (this.closeButton) {
+      this.closeButton.addEventListener("click", () => this.close());
+    }
     this.root.addEventListener("click", (event) => {
       if (event.target === this.root) {
         this.close();

--- a/apps/pages/src/define-rooms/styles.css
+++ b/apps/pages/src/define-rooms/styles.css
@@ -21,6 +21,8 @@
   backdrop-filter: none;
   align-items: stretch;
   justify-content: stretch;
+  flex: 1;
+  min-height: 0;
   width: 100%;
   height: 100%;
   padding: 0;
@@ -34,6 +36,7 @@
 .define-room-overlay.define-room-embedded .define-room-window {
   width: 100%;
   height: 100%;
+  min-height: 0;
   border-radius: inherit;
   border: none;
   box-shadow: none;
@@ -195,6 +198,7 @@
 .define-room-body {
   display: flex;
   flex: 1;
+  min-height: 0;
 }
 
 .define-room-sidebar {


### PR DESCRIPTION
## Summary
- allow the embedded Define Rooms editor to stretch across the wizard container similar to the marker step
- hide the Define Rooms header/close button when embedded while keeping overlay behaviour intact
- tighten the wizard footer padding to shrink its overall height

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9a6be54ec83239aa52bcbdbba37e2