### PR TITLE
Adjust define rooms layout in map wizard

### DIFF
--- a/apps/pages/src/components/MapCreationWizard.tsx
+++ b/apps/pages/src/components/MapCreationWizard.tsx
@@ -837,11 +837,11 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
             </div>
           )}
           {step === 2 && (
-            <div className="flex flex-1 items-stretch justify-center">
-              <div className="flex h-full w-full max-w-6xl rounded-3xl border border-slate-800/70 bg-slate-900/70 p-4">
+            <div className="flex h-full min-h-0 flex-1 items-stretch">
+              <div className="flex h-full min-h-0 w-full flex-1 rounded-3xl border border-slate-800/70 bg-slate-900/70 p-4">
                 <div
                   ref={defineRoomContainerRef}
-                  className={`flex h-full w-full flex-col overflow-hidden rounded-2xl border border-slate-800/70 bg-slate-950/80 ${
+                  className={`flex h-full min-h-0 w-full flex-col overflow-hidden rounded-2xl border border-slate-800/70 bg-slate-950/80 ${
                     canLaunchRoomsEditor ? '' : 'items-center justify-center text-sm text-slate-500'
                   }`}
                 >
@@ -1023,7 +1023,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
           )}
         </div>
       </main>
-      <footer className="border-t border-slate-800/70 px-6 py-5">
+      <footer className="border-t border-slate-800/70 px-6 py-4">
         <div className="flex flex-wrap items-center justify-between gap-4">
           <button
             type="button"
@@ -1039,7 +1039,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                 type="button"
                 disabled={!allowNext}
                 onClick={handleContinue}
-                className={`rounded-full border px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] transition ${
+                className={`rounded-full border px-5 py-2.5 text-xs font-semibold uppercase tracking-[0.3em] transition ${
                   allowNext
                     ? 'border-teal-400/60 bg-teal-500/80 text-slate-900 hover:bg-teal-400/90'
                     : 'cursor-not-allowed border-slate-800/70 bg-slate-900/70 text-slate-500'
@@ -1052,7 +1052,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                 type="button"
                 onClick={handleComplete}
                 disabled={creating}
-                className={`rounded-full border px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] transition ${
+                className={`rounded-full border px-5 py-2.5 text-xs font-semibold uppercase tracking-[0.3em] transition ${
                   creating
                     ? 'cursor-wait border-slate-800/70 bg-slate-900/70 text-slate-500'
                     : 'border-teal-400/60 bg-teal-500/80 text-slate-900 hover:bg-teal-400/90'

--- a/apps/pages/src/define-rooms/DefineRoom.tsx
+++ b/apps/pages/src/define-rooms/DefineRoom.tsx
@@ -528,7 +528,7 @@ export class DefineRoom {
 
   private hoverLabel!: HTMLElement;
 
-  private closeButton!: HTMLButtonElement;
+  private closeButton: HTMLButtonElement | null = null;
 
   private imageContext!: CanvasRenderingContext2D;
 
@@ -631,10 +631,12 @@ export class DefineRoom {
         class={`define-room-overlay hidden${this.mode === 'embedded' ? ' define-room-embedded' : ''}`}
       >
         <div class="define-room-window">
-          <div class="define-room-header">
-            <h1>Define Rooms</h1>
-            <button class="define-room-close" type="button">Close</button>
-          </div>
+          {this.mode !== 'embedded' ? (
+            <div class="define-room-header">
+              <h1>Define Rooms</h1>
+              <button class="define-room-close" type="button">Close</button>
+            </div>
+          ) : null}
           <div class="define-room-body">
             <section class="define-room-editor">
               <div class="toolbar-area">
@@ -823,7 +825,7 @@ export class DefineRoom {
     this.overlayCanvas = this.root.querySelector(".mask-layer") as HTMLCanvasElement;
     this.selectionCanvas = this.root.querySelector(".selection-layer") as HTMLCanvasElement;
     this.hoverLabel = this.root.querySelector(".room-hover-label") as HTMLElement;
-    this.closeButton = this.root.querySelector(".define-room-close") as HTMLButtonElement;
+    this.closeButton = this.root.querySelector<HTMLButtonElement>(".define-room-close");
 
     this.initializeColorMenu();
 
@@ -949,7 +951,7 @@ export class DefineRoom {
   }
 
   private attachEventListeners(): void {
-    this.closeButton.addEventListener("click", () => this.close());
+    this.closeButton?.addEventListener("click", () => this.close());
     this.root.addEventListener("click", (event) => {
       if (event.target === this.root) {
         this.close();

--- a/apps/pages/src/define-rooms/styles.css
+++ b/apps/pages/src/define-rooms/styles.css
@@ -195,6 +195,7 @@
 .define-room-body {
   display: flex;
   flex: 1;
+  min-height: 0;
 }
 
 .define-room-sidebar {


### PR DESCRIPTION
## Summary
- expand the Define Rooms step so the embedded editor spans the full wizard width
- hide the header/close controls when the room editor is embedded in the wizard
- tighten the map creation wizard footer spacing for a smaller visual footprint

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68d9a6be54ec83239aa52bcbdbba37e2