### PR TITLE
Fit define rooms viewport and slim footer

### DIFF
--- a/apps/pages/src/components/MapCreationWizard.tsx
+++ b/apps/pages/src/components/MapCreationWizard.tsx
@@ -837,11 +837,11 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
             </div>
           )}
           {step === 2 && (
-            <div className="flex flex-1 items-stretch justify-center">
-              <div className="flex h-full w-full max-w-6xl rounded-3xl border border-slate-800/70 bg-slate-900/70 p-4">
+            <div className="flex h-full min-h-0 flex-1">
+              <div className="flex h-full min-h-0 w-full rounded-3xl border border-slate-800/70 bg-slate-900/70 p-4">
                 <div
                   ref={defineRoomContainerRef}
-                  className={`flex h-full w-full flex-col overflow-hidden rounded-2xl border border-slate-800/70 bg-slate-950/80 ${
+                  className={`flex h-full min-h-0 w-full flex-col overflow-hidden rounded-2xl border border-slate-800/70 bg-slate-950/80 ${
                     canLaunchRoomsEditor ? '' : 'items-center justify-center text-sm text-slate-500'
                   }`}
                 >
@@ -1023,23 +1023,23 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
           )}
         </div>
       </main>
-      <footer className="border-t border-slate-800/70 px-6 py-5">
-        <div className="flex flex-wrap items-center justify-between gap-4">
+      <footer className="border-t border-slate-800/70 px-4 py-2">
+        <div className="flex flex-wrap items-center justify-between gap-2.5">
           <button
             type="button"
             onClick={handleBack}
-            className="rounded-full border border-slate-700/70 px-5 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-300 transition hover:border-teal-400/60 hover:text-teal-200"
+            className="rounded-full border border-slate-700/70 px-4 py-1.5 text-xs font-semibold uppercase tracking-[0.3em] text-slate-300 transition hover:border-teal-400/60 hover:text-teal-200"
           >
             {step === 0 ? 'Cancel' : 'Back'}
           </button>
-          <div className="flex flex-wrap items-center gap-4">
+          <div className="flex flex-wrap items-center gap-2.5">
             {error && <p className="text-xs font-semibold text-rose-300">{error}</p>}
             {step < steps.length - 1 ? (
               <button
                 type="button"
                 disabled={!allowNext}
                 onClick={handleContinue}
-                className={`rounded-full border px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] transition ${
+                className={`rounded-full border px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] transition ${
                   allowNext
                     ? 'border-teal-400/60 bg-teal-500/80 text-slate-900 hover:bg-teal-400/90'
                     : 'cursor-not-allowed border-slate-800/70 bg-slate-900/70 text-slate-500'
@@ -1052,7 +1052,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                 type="button"
                 onClick={handleComplete}
                 disabled={creating}
-                className={`rounded-full border px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] transition ${
+                className={`rounded-full border px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] transition ${
                   creating
                     ? 'cursor-wait border-slate-800/70 bg-slate-900/70 text-slate-500'
                     : 'border-teal-400/60 bg-teal-500/80 text-slate-900 hover:bg-teal-400/90'


### PR DESCRIPTION
## Summary
- reduce the map creation wizard footer padding and button sizing to further shrink its height
- ensure the embedded Define Rooms editor fits the full map image within the available viewport and recenters on resize
- observe the canvas wrapper for size changes so the base scaling updates when the wizard layout changes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9a6be54ec83239aa52bcbdbba37e2