### PR TITLE
Reduce wizard chrome spacing for map creation

### DIFF
--- a/apps/pages/src/components/MapCreationWizard.tsx
+++ b/apps/pages/src/components/MapCreationWizard.tsx
@@ -657,7 +657,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
 
   return (
     <div className="fixed inset-0 z-50 flex flex-col bg-slate-950/95 backdrop-blur-sm">
-      <header className="border-b border-slate-800/70 px-6 py-5">
+      <header className="mb-0.5 border-b border-slate-800/70 px-5 py-3">
         <div className="flex flex-wrap items-center justify-between gap-4">
           <div>
             <p className="text-xs uppercase tracking-[0.4em] text-teal-300">New Map Wizard</p>
@@ -696,7 +696,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
           })}
         </div>
       </header>
-      <main className="flex-1 overflow-hidden px-6 py-6">
+      <main className="flex-1 overflow-hidden px-5 py-4">
         <div className="flex h-full flex-col overflow-hidden">
           {step === 0 && (
             <div className="flex flex-1 items-center justify-center">
@@ -837,11 +837,11 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
             </div>
           )}
           {step === 2 && (
-            <div className="flex flex-1 items-stretch justify-center">
-              <div className="flex h-full w-full max-w-6xl rounded-3xl border border-slate-800/70 bg-slate-900/70 p-4">
+            <div className="flex h-full min-h-0 flex-1">
+              <div className="flex h-full min-h-0 w-full rounded-3xl border border-slate-800/70 bg-slate-900/70 p-4">
                 <div
                   ref={defineRoomContainerRef}
-                  className={`flex h-full w-full flex-col overflow-hidden rounded-2xl border border-slate-800/70 bg-slate-950/80 ${
+                  className={`flex h-full min-h-0 w-full flex-col overflow-hidden rounded-2xl border border-slate-800/70 bg-slate-950/80 ${
                     canLaunchRoomsEditor ? '' : 'items-center justify-center text-sm text-slate-500'
                   }`}
                 >
@@ -1023,23 +1023,23 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
           )}
         </div>
       </main>
-      <footer className="border-t border-slate-800/70 px-6 py-5">
-        <div className="flex flex-wrap items-center justify-between gap-4">
+      <footer className="mt-0.5 border-t border-slate-800/70 px-5 py-1.5">
+        <div className="flex flex-wrap items-center justify-between gap-2">
           <button
             type="button"
             onClick={handleBack}
-            className="rounded-full border border-slate-700/70 px-5 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-300 transition hover:border-teal-400/60 hover:text-teal-200"
+            className="rounded-full border border-slate-700/70 px-4 py-1.5 text-[11px] font-semibold uppercase tracking-[0.3em] text-slate-300 transition hover:border-teal-400/60 hover:text-teal-200"
           >
             {step === 0 ? 'Cancel' : 'Back'}
           </button>
-          <div className="flex flex-wrap items-center gap-4">
+          <div className="flex flex-wrap items-center gap-3">
             {error && <p className="text-xs font-semibold text-rose-300">{error}</p>}
             {step < steps.length - 1 ? (
               <button
                 type="button"
                 disabled={!allowNext}
                 onClick={handleContinue}
-                className={`rounded-full border px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] transition ${
+                className={`rounded-full border px-5 py-1.5 text-[11px] font-semibold uppercase tracking-[0.3em] transition ${
                   allowNext
                     ? 'border-teal-400/60 bg-teal-500/80 text-slate-900 hover:bg-teal-400/90'
                     : 'cursor-not-allowed border-slate-800/70 bg-slate-900/70 text-slate-500'
@@ -1052,7 +1052,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                 type="button"
                 onClick={handleComplete}
                 disabled={creating}
-                className={`rounded-full border px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] transition ${
+                className={`rounded-full border px-5 py-1.5 text-[11px] font-semibold uppercase tracking-[0.3em] transition ${
                   creating
                     ? 'cursor-wait border-slate-800/70 bg-slate-900/70 text-slate-500'
                     : 'border-teal-400/60 bg-teal-500/80 text-slate-900 hover:bg-teal-400/90'

--- a/apps/pages/src/define-rooms/DefineRoom.tsx
+++ b/apps/pages/src/define-rooms/DefineRoom.tsx
@@ -528,7 +528,7 @@ export class DefineRoom {
 
   private hoverLabel!: HTMLElement;
 
-  private closeButton!: HTMLButtonElement;
+  private closeButton: HTMLButtonElement | null = null;
 
   private imageContext!: CanvasRenderingContext2D;
 
@@ -626,15 +626,24 @@ export class DefineRoom {
 
   constructor(options: DefineRoomOptions = {}) {
     this.mode = options.mode ?? 'overlay';
+    const header =
+      this.mode === 'embedded'
+        ? null
+        : (
+            <div class="define-room-header">
+              <h1>Define Rooms</h1>
+              <button class="define-room-close" type="button">
+                Close
+              </button>
+            </div>
+          );
+
     this.root = (
       <div
         class={`define-room-overlay hidden${this.mode === 'embedded' ? ' define-room-embedded' : ''}`}
       >
         <div class="define-room-window">
-          <div class="define-room-header">
-            <h1>Define Rooms</h1>
-            <button class="define-room-close" type="button">Close</button>
-          </div>
+          {header}
           <div class="define-room-body">
             <section class="define-room-editor">
               <div class="toolbar-area">
@@ -768,6 +777,8 @@ export class DefineRoom {
     this.root.classList.remove("hidden");
     if (shouldReset) {
       this.prepareImage(image);
+    } else {
+      this.resetMagnifyTransform(true);
     }
   }
 
@@ -823,7 +834,9 @@ export class DefineRoom {
     this.overlayCanvas = this.root.querySelector(".mask-layer") as HTMLCanvasElement;
     this.selectionCanvas = this.root.querySelector(".selection-layer") as HTMLCanvasElement;
     this.hoverLabel = this.root.querySelector(".room-hover-label") as HTMLElement;
-    this.closeButton = this.root.querySelector(".define-room-close") as HTMLButtonElement;
+    this.closeButton = this.root.querySelector(
+      ".define-room-close",
+    ) as HTMLButtonElement | null;
 
     this.initializeColorMenu();
 
@@ -949,7 +962,9 @@ export class DefineRoom {
   }
 
   private attachEventListeners(): void {
-    this.closeButton.addEventListener("click", () => this.close());
+    if (this.closeButton) {
+      this.closeButton.addEventListener("click", () => this.close());
+    }
     this.root.addEventListener("click", (event) => {
       if (event.target === this.root) {
         this.close();

--- a/apps/pages/src/define-rooms/styles.css
+++ b/apps/pages/src/define-rooms/styles.css
@@ -195,6 +195,7 @@
 .define-room-body {
   display: flex;
   flex: 1;
+  min-height: 0;
 }
 
 .define-room-sidebar {
@@ -508,6 +509,7 @@
   align-items: stretch;
   padding: 18px;
   gap: 18px;
+  min-height: 0;
 }
 
 .toolbar-area {
@@ -845,6 +847,7 @@
   border-radius: 18px;
   overflow: hidden;
   border: 1px solid rgba(148, 163, 184, 0.18);
+  min-height: 0;
 }
 
 .canvas-wrapper canvas {


### PR DESCRIPTION
## Summary
- add minimal gaps around the wizard header and footer to keep them visually separated from the content
- shrink header/footer padding and button sizing to further reduce the wizard footer height

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9a6be54ec83239aa52bcbdbba37e2