### PR TITLE
Adjust Define Rooms layout for larger sidebar and map fit

### DIFF
--- a/defineRooms/dist/components/DefineRoom.js
+++ b/defineRooms/dist/components/DefineRoom.js
@@ -886,6 +886,9 @@ export class DefineRoom {
         this.overlayCanvas.height = height;
         this.selectionCanvas.width = width;
         this.selectionCanvas.height = height;
+        if (this.canvasWrapper) {
+            this.canvasWrapper.style.setProperty("--image-aspect-ratio", `${width} / ${height}`);
+        }
         this.imageCanvas.style.width = "100%";
         this.overlayCanvas.style.width = "100%";
         this.selectionCanvas.style.width = "100%";

--- a/defineRooms/src/components/DefineRoom.tsx
+++ b/defineRooms/src/components/DefineRoom.tsx
@@ -1267,6 +1267,10 @@ export class DefineRoom {
     this.selectionCanvas.width = width;
     this.selectionCanvas.height = height;
 
+    if (this.canvasWrapper) {
+      this.canvasWrapper.style.setProperty("--image-aspect-ratio", `${width} / ${height}`);
+    }
+
     this.imageCanvas.style.width = "100%";
     this.overlayCanvas.style.width = "100%";
     this.selectionCanvas.style.width = "100%";

--- a/defineRooms/styles.css
+++ b/defineRooms/styles.css
@@ -316,8 +316,9 @@ body {
 }
 
 .define-room-sidebar {
-  width: 20%;
-  min-width: 220px;
+  width: 28%;
+  min-width: 260px;
+  flex: 0 0 28%;
   background: rgba(15, 23, 42, 0.6);
   border-right: 1px solid rgba(148, 163, 184, 0.16);
   padding: 18px;
@@ -958,11 +959,15 @@ body {
 
 .canvas-wrapper {
   position: relative;
-  flex: 1;
+  flex: 1 1 0%;
   background: rgba(15, 23, 42, 0.5);
   border-radius: 18px;
   overflow: hidden;
   border: 1px solid rgba(148, 163, 184, 0.18);
+  aspect-ratio: var(--image-aspect-ratio, 16 / 9);
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .canvas-wrapper canvas {


### PR DESCRIPTION
## Summary
- widen the Define Rooms sidebar to provide more room for room details
- preserve the map canvas aspect ratio so the full image stays visible when editing

## Testing
- npm run build *(fails: Cannot find module './App.js' referenced by src/main.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d9c2cc64bc832386bf32b5248869f5