### PR TITLE
Adjust Define Rooms sidebar layout and canvas scaling

### DIFF
--- a/defineRooms/dist/components/DefineRoom.js
+++ b/defineRooms/dist/components/DefineRoom.js
@@ -886,6 +886,9 @@ export class DefineRoom {
         this.overlayCanvas.height = height;
         this.selectionCanvas.width = width;
         this.selectionCanvas.height = height;
+        if (this.canvasWrapper) {
+            this.canvasWrapper.style.aspectRatio = `${width} / ${height}`;
+        }
         this.imageCanvas.style.width = "100%";
         this.overlayCanvas.style.width = "100%";
         this.selectionCanvas.style.width = "100%";

--- a/defineRooms/src/components/DefineRoom.tsx
+++ b/defineRooms/src/components/DefineRoom.tsx
@@ -1267,6 +1267,10 @@ export class DefineRoom {
     this.selectionCanvas.width = width;
     this.selectionCanvas.height = height;
 
+    if (this.canvasWrapper) {
+      this.canvasWrapper.style.aspectRatio = `${width} / ${height}`;
+    }
+
     this.imageCanvas.style.width = "100%";
     this.overlayCanvas.style.width = "100%";
     this.selectionCanvas.style.width = "100%";

--- a/defineRooms/styles.css
+++ b/defineRooms/styles.css
@@ -316,8 +316,9 @@ body {
 }
 
 .define-room-sidebar {
-  width: 20%;
-  min-width: 220px;
+  flex: 0 0 28%;
+  min-width: 260px;
+  max-width: 360px;
   background: rgba(15, 23, 42, 0.6);
   border-right: 1px solid rgba(148, 163, 184, 0.16);
   padding: 18px;
@@ -1046,11 +1047,14 @@ body {
   }
 
   .define-room-sidebar {
+    flex: 1 1 100%;
     width: 100%;
     border-right: none;
     border-bottom: 1px solid rgba(148, 163, 184, 0.16);
     flex-direction: row;
     flex-wrap: wrap;
+    min-width: 0;
+    max-width: none;
   }
 
   .rooms-list {


### PR DESCRIPTION
## Summary
- widen the Define Rooms sidebar and adjust responsive sizing to give room details more space
- set the canvas wrapper aspect ratio from the image so the full map remains visible within the editor

## Testing
- npm run build *(fails: Cannot find module './App.js')*


------
https://chatgpt.com/codex/tasks/task_e_68d9c2cc64bc832386bf32b5248869f5