### PR TITLE
Adjust define room sidebar spacing and canvas scaling

### DIFF
--- a/defineRooms/dist/components/DefineRoom.js
+++ b/defineRooms/dist/components/DefineRoom.js
@@ -886,12 +886,10 @@ export class DefineRoom {
         this.overlayCanvas.height = height;
         this.selectionCanvas.width = width;
         this.selectionCanvas.height = height;
-        this.imageCanvas.style.width = "100%";
-        this.overlayCanvas.style.width = "100%";
-        this.selectionCanvas.style.width = "100%";
-        this.imageCanvas.style.height = "auto";
-        this.overlayCanvas.style.height = "auto";
-        this.selectionCanvas.style.height = "auto";
+        [this.imageCanvas, this.overlayCanvas, this.selectionCanvas].forEach((canvas) => {
+            canvas.style.width = "auto";
+            canvas.style.height = "auto";
+        });
         this.resetMagnifyTransform(true);
         this.imageContext.clearRect(0, 0, width, height);
         this.imageContext.drawImage(image, 0, 0, width, height);

--- a/defineRooms/src/components/DefineRoom.tsx
+++ b/defineRooms/src/components/DefineRoom.tsx
@@ -1267,13 +1267,10 @@ export class DefineRoom {
     this.selectionCanvas.width = width;
     this.selectionCanvas.height = height;
 
-    this.imageCanvas.style.width = "100%";
-    this.overlayCanvas.style.width = "100%";
-    this.selectionCanvas.style.width = "100%";
-
-    this.imageCanvas.style.height = "auto";
-    this.overlayCanvas.style.height = "auto";
-    this.selectionCanvas.style.height = "auto";
+    [this.imageCanvas, this.overlayCanvas, this.selectionCanvas].forEach((canvas) => {
+      canvas.style.width = "auto";
+      canvas.style.height = "auto";
+    });
 
     this.resetMagnifyTransform(true);
 

--- a/defineRooms/styles.css
+++ b/defineRooms/styles.css
@@ -313,11 +313,13 @@ body {
 .define-room-body {
   display: flex;
   flex: 1;
+  min-height: 0;
 }
 
 .define-room-sidebar {
-  width: 20%;
-  min-width: 220px;
+  width: 26%;
+  flex: 0 0 26%;
+  min-width: 260px;
   background: rgba(15, 23, 42, 0.6);
   border-right: 1px solid rgba(148, 163, 184, 0.16);
   padding: 18px;
@@ -626,6 +628,8 @@ body {
   align-items: stretch;
   padding: 18px;
   gap: 18px;
+  min-width: 0;
+  min-height: 0;
 }
 
 .toolbar-area {
@@ -956,20 +960,26 @@ body {
   box-shadow: 0 22px 46px rgba(248, 113, 113, 0.4);
 }
 
+
 .canvas-wrapper {
   position: relative;
   flex: 1;
+  display: grid;
+  place-items: center;
   background: rgba(15, 23, 42, 0.5);
   border-radius: 18px;
   overflow: hidden;
   border: 1px solid rgba(148, 163, 184, 0.18);
+  height: 100%;
+  min-height: 0;
 }
 
 .canvas-wrapper canvas {
-  position: absolute;
-  inset: 0;
-  width: 100%;
-  height: 100%;
+  grid-area: 1 / 1;
+  width: auto;
+  height: auto;
+  max-width: 100%;
+  max-height: 100%;
   image-rendering: pixelated;
 }
 
@@ -1047,10 +1057,12 @@ body {
 
   .define-room-sidebar {
     width: 100%;
+    flex: 1 1 100%;
     border-right: none;
     border-bottom: 1px solid rgba(148, 163, 184, 0.16);
     flex-direction: row;
     flex-wrap: wrap;
+    min-width: auto;
   }
 
   .rooms-list {


### PR DESCRIPTION
## Summary
- expand the Define Rooms sidebar and update flex constraints so the room list has more breathing room
- update the canvas wrapper styling so the map image centers itself and scales to stay fully visible inside its container

## Testing
- npm run build *(fails: Cannot find module './App.js')*

------
https://chatgpt.com/codex/tasks/task_e_68d9c6150a508323af3af8bc4439e22f