### PR TITLE
Limit Define Rooms wizard width

### DIFF
--- a/apps/pages/src/components/MapCreationWizard.tsx
+++ b/apps/pages/src/components/MapCreationWizard.tsx
@@ -754,7 +754,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
           )}
           {step === 1 && (
             <div className="flex flex-1 items-stretch justify-center">
-              <div className="flex h-full w-full max-w-5xl flex-col rounded-3xl border border-slate-800/70 bg-slate-900/70 p-8">
+              <div className="flex h-full w-[80vw] max-w-5xl flex-col rounded-3xl border border-slate-800/70 bg-slate-900/70 p-8">
                 <div className="grid flex-1 min-h-0 gap-6 md:grid-cols-[minmax(0,1fr)_260px]">
                   <div className="flex flex-col gap-5">
                     <div>


### PR DESCRIPTION
## Summary
- constrain the Define Rooms wizard container to 80% of the viewport width to better match the design

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68d9e17262cc83239e318a0ff6bb8b28