### PR TITLE
Adjust Define Rooms dialog width

### DIFF
--- a/defineRooms/styles.css
+++ b/defineRooms/styles.css
@@ -162,7 +162,7 @@ body {
 }
 
 .define-room-window {
-  width: min(1200px, 92vw);
+  width: min(1200px, 80vw);
   height: min(760px, 88vh);
   background: #0b1220;
   border-radius: 24px;


### PR DESCRIPTION
## Summary
- limit the Define Rooms modal container to a maximum of 80% of the viewport width

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9e17262cc83239e318a0ff6bb8b28