### PR TITLE
Constrain Define Rooms wizard to 80 percent width

### DIFF
--- a/apps/pages/src/components/MapCreationWizard.tsx
+++ b/apps/pages/src/components/MapCreationWizard.tsx
@@ -754,7 +754,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
           )}
           {step === 1 && (
             <div className="flex flex-1 items-stretch justify-center">
-              <div className="flex h-full w-full max-w-5xl flex-col rounded-3xl border border-slate-800/70 bg-slate-900/70 p-8">
+              <div className="flex h-full w-[80vw] max-w-5xl flex-col rounded-3xl border border-slate-800/70 bg-slate-900/70 p-8">
                 <div className="grid flex-1 min-h-0 gap-6 md:grid-cols-[minmax(0,1fr)_260px]">
                   <div className="flex flex-col gap-5">
                     <div>
@@ -838,7 +838,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
           )}
           {step === 2 && (
             <div className="flex h-full min-h-0 flex-1">
-              <div className="flex h-full min-h-0 w-full rounded-3xl border border-slate-800/70 bg-slate-900/70 p-4">
+              <div className="flex h-full min-h-0 w-[80vw] max-w-5xl rounded-3xl border border-slate-800/70 bg-slate-900/70 p-4 mx-[10vw]">
                 <div
                   ref={defineRoomContainerRef}
                   className={`flex h-full min-h-0 w-full flex-col overflow-hidden rounded-2xl border border-slate-800/70 bg-slate-950/80 ${


### PR DESCRIPTION
## Summary
- ensure the Define Rooms wizard container uses 80% of the viewport width with 10% margins on each side to match the requested layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9e17262cc83239e318a0ff6bb8b28