### PR TITLE
Expand wizard layout to 90 percent width

### DIFF
--- a/apps/pages/src/components/MapCreationWizard.tsx
+++ b/apps/pages/src/components/MapCreationWizard.tsx
@@ -696,7 +696,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
           })}
         </div>
       </header>
-      <main className="flex-1 overflow-hidden px-5 py-4">
+      <main className="flex-1 overflow-hidden px-[5vw] py-4">
         <div className="flex h-full flex-col overflow-hidden">
           {step === 0 && (
             <div className="flex flex-1 items-center justify-center">
@@ -754,7 +754,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
           )}
           {step === 1 && (
             <div className="flex flex-1 items-stretch justify-center">
-              <div className="flex h-full w-full max-w-5xl flex-col rounded-3xl border border-slate-800/70 bg-slate-900/70 p-8">
+              <div className="flex h-full w-full flex-col rounded-3xl border border-slate-800/70 bg-slate-900/70 p-8">
                 <div className="grid flex-1 min-h-0 gap-6 md:grid-cols-[minmax(0,1fr)_260px]">
                   <div className="flex flex-col gap-5">
                     <div>
@@ -837,7 +837,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
             </div>
           )}
           {step === 2 && (
-            <div className="flex h-full min-h-0 flex-1">
+            <div className="flex h-full min-h-0 flex-1 justify-center">
               <div className="flex h-full min-h-0 w-full rounded-3xl border border-slate-800/70 bg-slate-900/70 p-4">
                 <div
                   ref={defineRoomContainerRef}


### PR DESCRIPTION
## Summary
- adjust the wizard main layout padding to enforce 5% margins on each side of the viewport
- expand the Map Details and Define Rooms containers to fill the available 90% viewport width

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9e17262cc83239e318a0ff6bb8b28