### PR TITLE
Ensure brush slider stays within viewport

### DIFF
--- a/apps/pages/src/define-rooms/DefineRoom.tsx
+++ b/apps/pages/src/define-rooms/DefineRoom.tsx
@@ -518,6 +518,50 @@ export class DefineRoom {
 
   private brushSliderCaptureElement: HTMLElement | null = null;
 
+  private updateBrushSliderPosition = (): void => {
+    if (!this.brushSliderContainer || !this.brushSliderContainer.isConnected) {
+      return;
+    }
+
+    if (!this.brushSliderContainer.classList.contains("visible")) {
+      this.brushSliderContainer.style.removeProperty("--brush-slider-offset");
+      return;
+    }
+
+    const parentElement = this.brushSliderContainer.parentElement;
+    if (!parentElement) {
+      return;
+    }
+
+    const viewportHeight =
+      typeof window !== "undefined"
+        ? window.innerHeight || document.documentElement?.clientHeight || 0
+        : 0;
+
+    if (viewportHeight === 0) {
+      this.brushSliderContainer.style.removeProperty("--brush-slider-offset");
+      return;
+    }
+
+    const parentRect = parentElement.getBoundingClientRect();
+    const sliderRect = this.brushSliderContainer.getBoundingClientRect();
+
+    if (parentRect.height === 0 || sliderRect.height === 0) {
+      this.brushSliderContainer.style.removeProperty("--brush-slider-offset");
+      return;
+    }
+
+    const targetCenter = parentRect.top + parentRect.height / 2;
+    const sliderHalfHeight = sliderRect.height / 2;
+    const padding = 16;
+    const minCenter = padding + sliderHalfHeight;
+    const maxCenter = Math.max(minCenter, viewportHeight - padding - sliderHalfHeight);
+    const clampedCenter = clamp(targetCenter, minCenter, maxCenter);
+    const offset = clampedCenter - targetCenter;
+
+    this.brushSliderContainer.style.setProperty("--brush-slider-offset", `${offset}px`);
+  };
+
   private imageCanvas!: HTMLCanvasElement;
 
   private overlayCanvas!: HTMLCanvasElement;
@@ -808,6 +852,9 @@ export class DefineRoom {
   public destroy(): void {
     this.close();
     document.removeEventListener("click", this.handleColorMenuOutsideClick);
+    if (typeof window !== "undefined") {
+      window.removeEventListener("resize", this.updateBrushSliderPosition);
+    }
     this.root.remove();
   }
 
@@ -979,6 +1026,10 @@ export class DefineRoom {
     this.overlayCanvas.style.touchAction = "none";
 
     this.attachBrushSliderEvents();
+
+    if (typeof window !== "undefined") {
+      window.addEventListener("resize", this.updateBrushSliderPosition);
+    }
   }
 
   private initializeColorMenu(): void {
@@ -1301,6 +1352,8 @@ export class DefineRoom {
     this.brushSliderContainer.setAttribute("aria-valuemax", `${this.brushRadiusMax}`);
     this.brushSliderContainer.setAttribute("aria-valuenow", `${this.brushRadius}`);
     this.brushSliderContainer.setAttribute("aria-orientation", "vertical");
+
+    this.updateBrushSliderPosition();
   }
 
   private updateBrushSliderVisibility(): void {
@@ -1314,6 +1367,16 @@ export class DefineRoom {
 
     if (!isBrushTool && this.isAdjustingBrushSize) {
       this.stopBrushSliderInteraction();
+    }
+
+    if (isBrushTool) {
+      if (typeof requestAnimationFrame === "function") {
+        requestAnimationFrame(() => this.updateBrushSliderPosition());
+      } else {
+        this.updateBrushSliderPosition();
+      }
+    } else {
+      this.brushSliderContainer.style.removeProperty("--brush-slider-offset");
     }
   }
 

--- a/apps/pages/src/define-rooms/styles.css
+++ b/apps/pages/src/define-rooms/styles.css
@@ -542,7 +542,8 @@
   position: absolute;
   top: 50%;
   left: -94px;
-  transform: translateX(28px) translateY(-50%);
+  --brush-slider-offset: 0px;
+  transform: translateX(28px) translateY(calc(-50% + var(--brush-slider-offset)));
   width: 68px;
   padding: 18px 16px 22px;
   border-radius: 22px;
@@ -560,7 +561,7 @@
 }
 
 .brush-slider-container.visible {
-  transform: translateX(0) translateY(-50%);
+  transform: translateX(0) translateY(calc(-50% + var(--brush-slider-offset)));
   opacity: 1;
   pointer-events: auto;
 }

--- a/defineRooms/styles.css
+++ b/defineRooms/styles.css
@@ -658,7 +658,8 @@ body {
   position: absolute;
   top: 50%;
   left: -94px;
-  transform: translateX(28px) translateY(-50%);
+  --brush-slider-offset: 0px;
+  transform: translateX(28px) translateY(calc(-50% + var(--brush-slider-offset)));
   width: 68px;
   padding: 18px 16px 22px;
   border-radius: 22px;
@@ -676,7 +677,7 @@ body {
 }
 
 .brush-slider-container.visible {
-  transform: translateX(0) translateY(-50%);
+  transform: translateX(0) translateY(calc(-50% + var(--brush-slider-offset)));
   opacity: 1;
   pointer-events: auto;
 }


### PR DESCRIPTION
## Summary
- prevent the brush size slider from sliding off-screen by measuring its position and constraining it within the viewport
- drive the new positioning logic through a CSS offset variable that is shared between the app and legacy build
- keep the slider responsive on window resize and clean up listeners when the components are destroyed

## Testing
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68d9f5dbea948323b5e50d9823a8ca5d