### PR TITLE
Ensure brush slider stays visible

### DIFF
--- a/apps/pages/src/define-rooms/styles.css
+++ b/apps/pages/src/define-rooms/styles.css
@@ -541,8 +541,9 @@
 .brush-slider-container {
   position: absolute;
   top: 50%;
-  left: -94px;
-  transform: translateX(28px) translateY(-50%);
+  right: calc(100% + 16px);
+  left: auto;
+  transform: translateX(16px) translateY(-50%);
   width: 68px;
   padding: 18px 16px 22px;
   border-radius: 22px;

--- a/defineRooms/styles.css
+++ b/defineRooms/styles.css
@@ -657,8 +657,9 @@ body {
 .brush-slider-container {
   position: absolute;
   top: 50%;
-  left: -94px;
-  transform: translateX(28px) translateY(-50%);
+  right: calc(100% + 16px);
+  left: auto;
+  transform: translateX(16px) translateY(-50%);
   width: 68px;
   padding: 18px 16px 22px;
   border-radius: 22px;


### PR DESCRIPTION
## Summary
- anchor the brush size slider to the toolbar edge so it no longer slides off screen
- adjust the hidden offset to keep the entrance animation while staying within the viewport

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d9f5dbea948323b5e50d9823a8ca5d