### PR TITLE
Fix brush slider positioning

### DIFF
--- a/apps/pages/src/define-rooms/styles.css
+++ b/apps/pages/src/define-rooms/styles.css
@@ -541,8 +541,8 @@
 .brush-slider-container {
   position: absolute;
   top: 50%;
-  left: -94px;
-  transform: translateX(28px) translateY(-50%);
+  left: 16px;
+  transform: translateX(-120%) translateY(-50%);
   width: 68px;
   padding: 18px 16px 22px;
   border-radius: 22px;

--- a/defineRooms/styles.css
+++ b/defineRooms/styles.css
@@ -657,8 +657,8 @@ body {
 .brush-slider-container {
   position: absolute;
   top: 50%;
-  left: -94px;
-  transform: translateX(28px) translateY(-50%);
+  left: 16px;
+  transform: translateX(-120%) translateY(-50%);
   width: 68px;
   padding: 18px 16px 22px;
   border-radius: 22px;


### PR DESCRIPTION
## Summary
- adjust the brush slider container positioning so the widget slides in from off-screen without staying out of view
- ensure the slider is anchored within the viewport when visible

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9f5dbea948323b5e50d9823a8ca5d