### PR TITLE
Fix brush slider visibility in define rooms UI

### DIFF
--- a/apps/pages/src/define-rooms/styles.css
+++ b/apps/pages/src/define-rooms/styles.css
@@ -541,8 +541,8 @@
 .brush-slider-container {
   position: absolute;
   top: 50%;
-  left: -94px;
-  transform: translateX(28px) translateY(-50%);
+  right: calc(100% + 16px);
+  transform: translateX(12px) translateY(-50%);
   width: 68px;
   padding: 18px 16px 22px;
   border-radius: 22px;

--- a/defineRooms/styles.css
+++ b/defineRooms/styles.css
@@ -657,8 +657,8 @@ body {
 .brush-slider-container {
   position: absolute;
   top: 50%;
-  left: -94px;
-  transform: translateX(28px) translateY(-50%);
+  right: calc(100% + 16px);
+  transform: translateX(12px) translateY(-50%);
   width: 68px;
   padding: 18px 16px 22px;
   border-radius: 22px;


### PR DESCRIPTION
## Summary
- anchor the brush slider container to the toolbar with a right offset so it remains within the viewport when shown
- mirror the updated positioning in the standalone DefineRoom stylesheet

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9fa6359988323b6194011e3483264