### PR TITLE
Fix brush slider visibility

### DIFF
--- a/apps/pages/src/define-rooms/styles.css
+++ b/apps/pages/src/define-rooms/styles.css
@@ -541,8 +541,8 @@
 .brush-slider-container {
   position: absolute;
   top: 50%;
-  left: -94px;
-  transform: translateX(28px) translateY(-50%);
+  left: 0;
+  transform: translateX(-120%) translateY(-50%);
   width: 68px;
   padding: 18px 16px 22px;
   border-radius: 22px;

--- a/defineRooms/styles.css
+++ b/defineRooms/styles.css
@@ -657,8 +657,8 @@ body {
 .brush-slider-container {
   position: absolute;
   top: 50%;
-  left: -94px;
-  transform: translateX(28px) translateY(-50%);
+  left: 0;
+  transform: translateX(-120%) translateY(-50%);
   width: 68px;
   padding: 18px 16px 22px;
   border-radius: 22px;


### PR DESCRIPTION
## Summary
- adjust the brush slider container positioning so the control stays within the viewport when shown
- keep the slide-in animation by hiding it off-screen with a transform instead of a negative left offset

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9fa6359988323b6194011e3483264