### PR TITLE
Ensure brush slider stays visible

### DIFF
--- a/apps/pages/src/define-rooms/DefineRoom.tsx
+++ b/apps/pages/src/define-rooms/DefineRoom.tsx
@@ -518,6 +518,8 @@ export class DefineRoom {
 
   private brushSliderCaptureElement: HTMLElement | null = null;
 
+  private brushSliderPositionFrame: number | null = null;
+
   private imageCanvas!: HTMLCanvasElement;
 
   private overlayCanvas!: HTMLCanvasElement;
@@ -808,6 +810,11 @@ export class DefineRoom {
   public destroy(): void {
     this.close();
     document.removeEventListener("click", this.handleColorMenuOutsideClick);
+    window.removeEventListener("resize", this.updateBrushSliderPosition);
+    if (this.brushSliderPositionFrame !== null) {
+      cancelAnimationFrame(this.brushSliderPositionFrame);
+      this.brushSliderPositionFrame = null;
+    }
     this.root.remove();
   }
 
@@ -979,6 +986,7 @@ export class DefineRoom {
     this.overlayCanvas.style.touchAction = "none";
 
     this.attachBrushSliderEvents();
+    window.addEventListener("resize", this.updateBrushSliderPosition);
   }
 
   private initializeColorMenu(): void {
@@ -1177,6 +1185,66 @@ export class DefineRoom {
     this.brushSliderThumb.addEventListener("pointerdown", pointerDownHandler);
   }
 
+  private updateBrushSliderPosition = (): void => {
+    if (this.brushSliderPositionFrame !== null) {
+      cancelAnimationFrame(this.brushSliderPositionFrame);
+    }
+
+    this.brushSliderPositionFrame = requestAnimationFrame(() => {
+      this.brushSliderPositionFrame = null;
+      if (!this.brushSliderContainer) {
+        return;
+      }
+
+      if (!this.brushSliderContainer.classList.contains("visible")) {
+        this.brushSliderContainer.style.removeProperty("--brush-slider-horizontal-offset");
+        this.brushSliderContainer.style.removeProperty("--brush-slider-vertical-offset");
+        return;
+      }
+
+      const rect = this.brushSliderContainer.getBoundingClientRect();
+      if (!rect.width || !rect.height) {
+        return;
+      }
+
+      const viewportWidth = window.innerWidth || document.documentElement.clientWidth || rect.width;
+      const viewportHeight = window.innerHeight || document.documentElement.clientHeight || rect.height;
+      const padding = 16;
+
+      let horizontalOffset = 0;
+      if (rect.left < padding) {
+        horizontalOffset = padding - rect.left;
+      } else if (rect.right > viewportWidth - padding) {
+        horizontalOffset = viewportWidth - padding - rect.right;
+      }
+
+      if (horizontalOffset !== 0) {
+        this.brushSliderContainer.style.setProperty(
+          "--brush-slider-horizontal-offset",
+          `${horizontalOffset}px`,
+        );
+      } else {
+        this.brushSliderContainer.style.removeProperty("--brush-slider-horizontal-offset");
+      }
+
+      let verticalOffset = 0;
+      if (rect.top < padding) {
+        verticalOffset = padding - rect.top;
+      } else if (rect.bottom > viewportHeight - padding) {
+        verticalOffset = viewportHeight - padding - rect.bottom;
+      }
+
+      if (verticalOffset !== 0) {
+        this.brushSliderContainer.style.setProperty(
+          "--brush-slider-vertical-offset",
+          `${verticalOffset}px`,
+        );
+      } else {
+        this.brushSliderContainer.style.removeProperty("--brush-slider-vertical-offset");
+      }
+    });
+  };
+
   private startBrushSliderInteraction(event: PointerEvent): void {
     if (!this.brushSliderTrack || !this.brushSliderContainer) {
       return;
@@ -1311,6 +1379,8 @@ export class DefineRoom {
     const isBrushTool = this.currentTool === "brush" || this.currentTool === "eraser";
     this.brushSliderContainer.classList.toggle("visible", isBrushTool);
     this.brushSliderContainer.setAttribute("aria-hidden", isBrushTool ? "false" : "true");
+
+    this.updateBrushSliderPosition();
 
     if (!isBrushTool && this.isAdjustingBrushSize) {
       this.stopBrushSliderInteraction();

--- a/apps/pages/src/define-rooms/styles.css
+++ b/apps/pages/src/define-rooms/styles.css
@@ -541,8 +541,9 @@
 .brush-slider-container {
   position: absolute;
   top: 50%;
-  left: -94px;
-  transform: translateX(28px) translateY(-50%);
+  left: calc(-94px + var(--brush-slider-horizontal-offset, 0px));
+  transform: translateX(28px)
+    translateY(calc(-50% + var(--brush-slider-vertical-offset, 0px)));
   width: 68px;
   padding: 18px 16px 22px;
   border-radius: 22px;
@@ -560,7 +561,8 @@
 }
 
 .brush-slider-container.visible {
-  transform: translateX(0) translateY(-50%);
+  transform: translateX(0)
+    translateY(calc(-50% + var(--brush-slider-vertical-offset, 0px)));
   opacity: 1;
   pointer-events: auto;
 }

--- a/defineRooms/styles.css
+++ b/defineRooms/styles.css
@@ -657,8 +657,9 @@ body {
 .brush-slider-container {
   position: absolute;
   top: 50%;
-  left: -94px;
-  transform: translateX(28px) translateY(-50%);
+  left: calc(-94px + var(--brush-slider-horizontal-offset, 0px));
+  transform: translateX(28px)
+    translateY(calc(-50% + var(--brush-slider-vertical-offset, 0px)));
   width: 68px;
   padding: 18px 16px 22px;
   border-radius: 22px;
@@ -676,7 +677,8 @@ body {
 }
 
 .brush-slider-container.visible {
-  transform: translateX(0) translateY(-50%);
+  transform: translateX(0)
+    translateY(calc(-50% + var(--brush-slider-vertical-offset, 0px)));
   opacity: 1;
   pointer-events: auto;
 }


### PR DESCRIPTION
## Summary
- allow the brush size slider to shift using CSS offsets so it can stay inside the viewport
- compute dynamic offsets in the DefineRoom controller and update them on tool changes or window resizes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9fa6359988323b6194011e3483264