### PR TITLE
Fix brush slider visibility

### DIFF
--- a/apps/pages/src/define-rooms/styles.css
+++ b/apps/pages/src/define-rooms/styles.css
@@ -541,8 +541,8 @@
 .brush-slider-container {
   position: absolute;
   top: 50%;
-  left: -94px;
-  transform: translateX(28px) translateY(-50%);
+  right: calc(100% + 18px);
+  transform: translateX(18px) translateY(-50%);
   width: 68px;
   padding: 18px 16px 22px;
   border-radius: 22px;

--- a/defineRooms/styles.css
+++ b/defineRooms/styles.css
@@ -657,8 +657,8 @@ body {
 .brush-slider-container {
   position: absolute;
   top: 50%;
-  left: -94px;
-  transform: translateX(28px) translateY(-50%);
+  right: calc(100% + 18px);
+  transform: translateX(18px) translateY(-50%);
   width: 68px;
   padding: 18px 16px 22px;
   border-radius: 22px;


### PR DESCRIPTION
## Summary
- keep the brush size slider positioned relative to the toolbar so it stays on screen
- preserve the slide-in animation while preventing the container from moving off the viewport

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9fa6359988323b6194011e3483264