### PR TITLE
Fix brush slider positioning

### DIFF
--- a/apps/pages/src/define-rooms/styles.css
+++ b/apps/pages/src/define-rooms/styles.css
@@ -541,8 +541,8 @@
 .brush-slider-container {
   position: absolute;
   top: 50%;
-  left: -94px;
-  transform: translateX(28px) translateY(-50%);
+  right: calc(100% + 16px);
+  transform: translateX(16px) translateY(-50%);
   width: 68px;
   padding: 18px 16px 22px;
   border-radius: 22px;

--- a/defineRooms/styles.css
+++ b/defineRooms/styles.css
@@ -657,8 +657,8 @@ body {
 .brush-slider-container {
   position: absolute;
   top: 50%;
-  left: -94px;
-  transform: translateX(28px) translateY(-50%);
+  right: calc(100% + 16px);
+  transform: translateX(16px) translateY(-50%);
   width: 68px;
   padding: 18px 16px 22px;
   border-radius: 22px;


### PR DESCRIPTION
## Summary
- reposition the brush size slider so it anchors to the toolbar and stays inside the viewport when displayed

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da0440f0ac83239d83354a3b9397ec