### PR TITLE
Keep brush slider aligned beside toolbar

### DIFF
--- a/apps/pages/src/define-rooms/styles.css
+++ b/apps/pages/src/define-rooms/styles.css
@@ -541,8 +541,9 @@
 .brush-slider-container {
   position: absolute;
   top: 50%;
-  left: -94px;
-  transform: translateX(28px) translateY(-50%);
+  left: 100%;
+  margin-left: 16px;
+  transform: translate3d(12px, -50%, 0);
   width: 68px;
   padding: 18px 16px 22px;
   border-radius: 22px;
@@ -560,7 +561,7 @@
 }
 
 .brush-slider-container.visible {
-  transform: translateX(0) translateY(-50%);
+  transform: translate3d(0, -50%, 0);
   opacity: 1;
   pointer-events: auto;
 }

--- a/defineRooms/styles.css
+++ b/defineRooms/styles.css
@@ -657,8 +657,9 @@ body {
 .brush-slider-container {
   position: absolute;
   top: 50%;
-  left: -94px;
-  transform: translateX(28px) translateY(-50%);
+  left: 100%;
+  margin-left: 16px;
+  transform: translate3d(12px, -50%, 0);
   width: 68px;
   padding: 18px 16px 22px;
   border-radius: 22px;
@@ -676,7 +677,7 @@ body {
 }
 
 .brush-slider-container.visible {
-  transform: translateX(0) translateY(-50%);
+  transform: translate3d(0, -50%, 0);
   opacity: 1;
   pointer-events: auto;
 }


### PR DESCRIPTION
## Summary
- reposition the brush size slider so it opens to the right of the toolbar and stays inside the viewport
- keep the slider transition and interaction states unchanged while making it accessible when visible

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da0440f0ac83239d83354a3b9397ec