### PR TITLE
Allow embedded room editor slider to overflow

### DIFF
--- a/apps/pages/src/components/MapCreationWizard.tsx
+++ b/apps/pages/src/components/MapCreationWizard.tsx
@@ -696,8 +696,8 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
           })}
         </div>
       </header>
-      <main className="flex-1 overflow-hidden px-[10vw] py-4">
-        <div className="flex h-full flex-col overflow-hidden">
+      <main className="flex-1 overflow-visible px-[10vw] py-4">
+        <div className="flex h-full flex-col overflow-visible">
           {step === 0 && (
             <div className="flex flex-1 items-center justify-center">
               <div className="w-full max-w-4xl rounded-3xl border border-slate-800/70 bg-slate-900/70 p-8 text-center">
@@ -841,7 +841,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
               <div className="flex h-full min-h-0 w-full rounded-3xl border border-slate-800/70 bg-slate-900/70 p-4">
                 <div
                   ref={defineRoomContainerRef}
-                  className={`flex h-full min-h-0 w-full flex-col overflow-hidden rounded-2xl border border-slate-800/70 bg-slate-950/80 ${
+                  className={`flex h-full min-h-0 w-full flex-col overflow-visible rounded-2xl border border-slate-800/70 bg-slate-950/80 ${
                     canLaunchRoomsEditor ? '' : 'items-center justify-center text-sm text-slate-500'
                   }`}
                 >


### PR DESCRIPTION
## Summary
- allow the wizard content area to use overflow-visible so the brush slider can render outside its parent
- let the embedded room editor container opt into overflow-visible to prevent clipping of the brush slider

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da085ed7e88323862fa840a1d4d966