### PR TITLE
Rehost embedded brush slider outside wizard content

### DIFF
--- a/apps/pages/src/components/MapCreationWizard.tsx
+++ b/apps/pages/src/components/MapCreationWizard.tsx
@@ -286,6 +286,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
   const [draggingId, setDraggingId] = useState<string | null>(null);
   const [definedRooms, setDefinedRooms] = useState<DraftRoom[]>([]);
   const [defineRoomContainer, setDefineRoomContainer] = useState<HTMLDivElement | null>(null);
+  const [brushSliderPortal, setBrushSliderPortal] = useState<HTMLDivElement | null>(null);
   const mapAreaRef = useRef<HTMLDivElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const defineRoomRef = useRef<DefineRoom | null>(null);
@@ -293,6 +294,9 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
   const [defineRoomReady, setDefineRoomReady] = useState(false);
   const defineRoomContainerRef = useCallback((node: HTMLDivElement | null) => {
     setDefineRoomContainer(node);
+  }, []);
+  const brushSliderPortalRef = useCallback((node: HTMLDivElement | null) => {
+    setBrushSliderPortal(node);
   }, []);
 
   const syncRoomsFromEditor = useCallback(() => {
@@ -422,6 +426,18 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
       editor.close();
     }
   }, [defineRoomReady, step]);
+
+  useEffect(() => {
+    const editor = defineRoomRef.current;
+    if (!editor) {
+      return;
+    }
+    if (!defineRoomReady) {
+      editor.attachBrushSliderTo(null);
+      return;
+    }
+    editor.attachBrushSliderTo(step === 2 ? brushSliderPortal : null);
+  }, [brushSliderPortal, defineRoomReady, step]);
 
   const markerDisplayMetrics = useImageDisplayMetrics(mapAreaRef, imageDimensions);
 
@@ -696,8 +712,9 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
           })}
         </div>
       </header>
-      <main className="flex-1 overflow-hidden px-[10vw] py-4">
-        <div className="flex h-full flex-col overflow-hidden">
+      <main className="flex-1 overflow-x-visible overflow-y-auto py-4">
+        <div className="flex h-full">
+          <div className="flex h-full flex-1 flex-col overflow-x-visible overflow-y-hidden px-[10vw]">
           {step === 0 && (
             <div className="flex flex-1 items-center justify-center">
               <div className="w-full max-w-4xl rounded-3xl border border-slate-800/70 bg-slate-900/70 p-8 text-center">
@@ -841,7 +858,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
               <div className="flex h-full min-h-0 w-full rounded-3xl border border-slate-800/70 bg-slate-900/70 p-4">
                 <div
                   ref={defineRoomContainerRef}
-                  className={`flex h-full min-h-0 w-full flex-col overflow-hidden rounded-2xl border border-slate-800/70 bg-slate-950/80 ${
+                  className={`flex h-full min-h-0 w-full flex-col overflow-visible rounded-2xl border border-slate-800/70 bg-slate-950/80 ${
                     canLaunchRoomsEditor ? '' : 'items-center justify-center text-sm text-slate-500'
                   }`}
                 >
@@ -1021,6 +1038,14 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
               </div>
             </div>
           )}
+          </div>
+          <div
+            ref={brushSliderPortalRef}
+            className={`relative overflow-visible transition-[width] duration-200 ${
+              step === 2 ? 'ml-6 w-[120px] flex-shrink-0' : 'w-0 flex-shrink-0'
+            }`}
+            aria-hidden={step !== 2}
+          ></div>
         </div>
       </main>
       <footer className="mt-0.5 border-t border-slate-800/70 px-5 py-1.5">

--- a/apps/pages/src/define-rooms/DefineRoom.tsx
+++ b/apps/pages/src/define-rooms/DefineRoom.tsx
@@ -518,6 +518,10 @@ export class DefineRoom {
 
   private brushSliderCaptureElement: HTMLElement | null = null;
 
+  private brushSliderOriginalParent: HTMLElement | null = null;
+
+  private brushSliderPortal: HTMLElement | null = null;
+
   private imageCanvas!: HTMLCanvasElement;
 
   private overlayCanvas!: HTMLCanvasElement;
@@ -806,6 +810,7 @@ export class DefineRoom {
   }
 
   public destroy(): void {
+    this.attachBrushSliderTo(null);
     this.close();
     document.removeEventListener("click", this.handleColorMenuOutsideClick);
     this.root.remove();
@@ -815,6 +820,44 @@ export class DefineRoom {
     return this.root;
   }
 
+  public attachBrushSliderTo(container: HTMLElement | null): void {
+    if (!this.brushSliderContainer) {
+      return;
+    }
+
+    if (!this.brushSliderOriginalParent) {
+      this.brushSliderOriginalParent = this.brushSliderContainer.parentElement;
+    }
+
+    if (container === this.brushSliderPortal) {
+      return;
+    }
+
+    if (container) {
+      if (this.brushSliderPortal?.contains(this.brushSliderContainer)) {
+        this.brushSliderPortal.removeChild(this.brushSliderContainer);
+      } else if (this.brushSliderOriginalParent?.contains(this.brushSliderContainer)) {
+        this.brushSliderOriginalParent.removeChild(this.brushSliderContainer);
+      }
+
+      container.appendChild(this.brushSliderContainer);
+      this.brushSliderContainer.classList.add("external-hosted");
+      this.brushSliderPortal = container;
+      return;
+    }
+
+    if (this.brushSliderPortal?.contains(this.brushSliderContainer)) {
+      this.brushSliderPortal.removeChild(this.brushSliderContainer);
+    }
+
+    if (this.brushSliderOriginalParent) {
+      this.brushSliderOriginalParent.appendChild(this.brushSliderContainer);
+    }
+
+    this.brushSliderContainer.classList.remove("external-hosted");
+    this.brushSliderPortal = null;
+  }
+
   private initializeDomReferences(): void {
     this.toolbarPrimaryButton = this.root.querySelector(".toolbar-primary") as HTMLButtonElement;
     this.toolbarConfirmGroup = this.root.querySelector(".toolbar-confirm-group") as HTMLElement;
@@ -822,6 +865,7 @@ export class DefineRoom {
     this.toolbarCancelButton = this.root.querySelector(".toolbar-cancel") as HTMLButtonElement;
     this.undoButton = this.root.querySelector(".toolbar-undo") as HTMLButtonElement;
     this.redoButton = this.root.querySelector(".toolbar-redo") as HTMLButtonElement;
+    this.brushSliderOriginalParent = this.brushSliderContainer?.parentElement ?? null;
     this.roomsList = this.roomsPanel.querySelector(".rooms-list") as HTMLElement;
     this.colorMenu = this.roomsPanel.querySelector(".room-color-menu") as HTMLElement;
     this.deleteBackdrop = this.root.querySelector(".room-delete-backdrop") as HTMLElement;

--- a/apps/pages/src/define-rooms/styles.css
+++ b/apps/pages/src/define-rooms/styles.css
@@ -565,6 +565,15 @@
   pointer-events: auto;
 }
 
+.brush-slider-container.external-hosted {
+  left: 0;
+  transform: translateY(-50%);
+}
+
+.brush-slider-container.external-hosted.visible {
+  transform: translateY(-50%);
+}
+
 .brush-slider-container.dragging {
   box-shadow: 0 24px 70px rgba(56, 189, 248, 0.35);
 }


### PR DESCRIPTION
## Summary
- move the wizard layout padding to the primary content column and add a sibling portal for the brush slider
- expose a DefineRoom API to relocate the brush slider container and use it when the embedded editor is visible
- adjust brush slider styling for external hosting so it remains aligned while visible

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da085ed7e88323862fa840a1d4d966