### PR TITLE
Retheme TableTorch landing experience

### DIFF
--- a/apps/pages/src/App.tsx
+++ b/apps/pages/src/App.tsx
@@ -552,7 +552,7 @@ const App: React.FC = () => {
       <div className="min-h-screen bg-slate-100 p-6 dark:bg-slate-900">
         <div className="mb-4 flex items-center justify-between">
           <div>
-            <h1 className="text-2xl font-bold text-primary">D&D Map Reveal</h1>
+            <h1 className="text-2xl font-bold text-primary">TableTorch</h1>
             <p className="text-sm text-slate-500 dark:text-slate-400">Logged in as {user.displayName}</p>
           </div>
           <div className="flex items-center gap-2">
@@ -628,7 +628,7 @@ const App: React.FC = () => {
           <header className="flex flex-wrap items-center justify-between gap-3 rounded-3xl border border-slate-800/70 bg-slate-950/70 px-6 py-4 shadow-xl">
             <div>
               <p className="text-xs uppercase tracking-[0.5em] text-teal-300">Campaign Control</p>
-              <h1 className="text-3xl font-black uppercase tracking-wide text-white">D&D Map Reveal</h1>
+              <h1 className="text-3xl font-black uppercase tracking-wide text-white">TableTorch</h1>
             </div>
             <div className="flex items-center gap-3">
               <button

--- a/apps/pages/src/components/AuthPanel.tsx
+++ b/apps/pages/src/components/AuthPanel.tsx
@@ -16,7 +16,7 @@ const AuthPanel: React.FC<AuthPanelProps> = ({ onAuthenticate, className, varian
   const [mode, setMode] = useState<'login' | 'signup'>('login');
   const [email, setEmail] = useState('demo@dandmaps.example');
   const [password, setPassword] = useState('demo-password');
-  const [displayName, setDisplayName] = useState('Demo DM');
+  const [displayName, setDisplayName] = useState('Torchbearer Demo');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -50,8 +50,8 @@ const AuthPanel: React.FC<AuthPanelProps> = ({ onAuthenticate, className, varian
     className
   );
 
-  const badgeText = mode === 'login' ? 'Return to the table' : 'Create a DM profile';
-  const headingText = mode === 'login' ? 'Sign in to D&D Map Reveal' : 'Join the D&D Map Reveal beta';
+  const badgeText = mode === 'login' ? 'Return to the torchlight' : 'Light a new profile';
+  const headingText = mode === 'login' ? 'Sign in to TableTorch' : 'Join the TableTorch beta';
   const submitLabel = loading ? 'Please wait…' : mode === 'login' ? 'Log in' : 'Sign up';
   const toggleLabel = mode === 'login' ? 'Need an account?' : 'Already have an account?';
   const toggleHelper = mode === 'login' ? 'Create one instead' : 'Use your existing login';
@@ -73,7 +73,7 @@ const AuthPanel: React.FC<AuthPanelProps> = ({ onAuthenticate, className, varian
                 {headingText}
               </h2>
               <p className="text-sm text-slate-600 dark:text-slate-300">
-                Use the pre-filled demo credentials or sign up with your own details to explore the DM console.
+                Use the pre-filled demo credentials or sign up with your own details to explore the TableTorch console.
               </p>
             </div>
             <button

--- a/apps/pages/src/components/LandingPage.tsx
+++ b/apps/pages/src/components/LandingPage.tsx
@@ -10,26 +10,60 @@ interface LandingPageProps {
 
 const features = [
   {
-    title: 'Reveal maps live',
-    description: 'Fade in fog-of-war with precision tools built for dramatic reveals and on-the-fly adjustments.',
-    icon: '🗺️',
+    title: 'Ignite your reveals',
+    description:
+      'Sweep light across battlemaps with layered masks and brush tools that feel like guiding a real torch.',
+    icon: '🔥',
   },
   {
-    title: 'Campaign control',
-    description: 'Organise every battlemap, note and marker by campaign so your prep is ready when players arrive.',
-    icon: '🎯',
+    title: 'Curate every campaign',
+    description: 'Sort maps, notes and tokens by world so your stories stay organised between adventures.',
+    icon: '🗂️',
   },
   {
-    title: 'Share instantly',
-    description: 'Invite players with short join codes and let them explore revealed regions from any device.',
-    icon: '⚡',
+    title: 'Share the glow',
+    description: 'Send players a join code and let them follow the light from any device without extra installs.',
+    icon: '✨',
   },
   {
-    title: 'Save your progress',
-    description: 'Archive live sessions and pick up where you left off without losing the dramatic tension.',
-    icon: '🛡️',
+    title: 'Preserve the embers',
+    description: 'Save session states so you can rekindle encounters exactly where the party left off.',
+    icon: '🕯️',
   },
 ];
+
+const parchmentTexture = new URL('../../../../textures/parchment-bg.jpg', import.meta.url).href;
+
+const TorchLogo: React.FC = () => (
+  <div className="relative">
+    <div
+      aria-hidden
+      className="absolute -inset-5 rounded-full bg-amber-300/0 blur-2xl transition dark:bg-amber-200/20"
+    />
+    <div className="relative flex h-14 w-14 items-center justify-center rounded-3xl bg-gradient-to-br from-amber-200 via-amber-100 to-amber-300 shadow-lg shadow-amber-500/30 ring-2 ring-amber-900/10 dark:from-amber-500/20 dark:via-amber-500/10 dark:to-amber-400/20 dark:shadow-amber-500/40 dark:ring-amber-300/30">
+      <svg
+        aria-hidden
+        viewBox="0 0 64 64"
+        className="h-10 w-10 drop-shadow-[0_0_6px_rgba(251,191,36,0.45)] text-amber-700 dark:text-amber-200"
+      >
+        <path
+          d="M28 6c5 4 10 7 11 13 1 6-3 11-7 14h10c0 5-3 14-10 19-7-5-10-14-10-19h8c-5-5-7-13-2-22z"
+          fill="currentColor"
+        />
+        <path
+          d="M26 37h12l-2 16h-8z"
+          fill="url(#flame-handle)"
+        />
+        <defs>
+          <linearGradient id="flame-handle" x1="26" y1="37" x2="38" y2="53" gradientUnits="userSpaceOnUse">
+            <stop stopColor="#78350f" />
+            <stop offset="1" stopColor="#451a03" />
+          </linearGradient>
+        </defs>
+      </svg>
+    </div>
+  </div>
+);
 
 const LandingPage: React.FC<LandingPageProps> = ({ theme, setTheme, onAuthenticate }) => {
   const themeLabel = theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode';
@@ -38,27 +72,32 @@ const LandingPage: React.FC<LandingPageProps> = ({ theme, setTheme, onAuthentica
     setTheme(theme === 'dark' ? 'light' : 'dark');
   };
 
+  const backgroundStyle = {
+    ['--parchment-texture' as const]: `url(${parchmentTexture})`,
+  } as React.CSSProperties;
+
   return (
-    <div className="bg-landing relative min-h-screen overflow-hidden text-slate-900 transition-colors dark:text-slate-100">
-      <div aria-hidden className="absolute inset-0 bg-grid-mask opacity-60 mix-blend-soft-light dark:opacity-40" />
-      <div aria-hidden className="pointer-events-none absolute -top-32 right-12 h-72 w-72 rounded-full bg-sky-400/30 blur-3xl dark:bg-sky-500/20 animate-float-slow" />
-      <div aria-hidden className="pointer-events-none absolute bottom-[-10rem] left-[-6rem] h-96 w-96 rounded-full bg-teal-400/20 blur-[120px] dark:bg-teal-500/20 animate-float-slow" />
+    <div
+      className="bg-landing relative min-h-screen overflow-hidden text-slate-900 transition-colors dark:text-amber-50"
+      style={backgroundStyle}
+    >
+      <div aria-hidden className="absolute inset-0 bg-grid-mask opacity-60 mix-blend-multiply dark:mix-blend-normal dark:opacity-50" />
+      <div aria-hidden className="pointer-events-none absolute -top-32 right-12 h-72 w-72 rounded-full bg-amber-300/40 blur-3xl dark:bg-amber-500/20 animate-float-slow" />
+      <div aria-hidden className="pointer-events-none absolute bottom-[-10rem] left-[-6rem] h-96 w-96 rounded-full bg-orange-200/30 blur-[140px] dark:bg-orange-500/20 animate-float-slow" />
       <div className="relative isolate">
         <header className="mx-auto flex max-w-7xl flex-wrap items-center justify-between gap-4 px-6 py-8 sm:py-10">
           <div className="flex items-center gap-4">
-            <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-slate-900/90 text-2xl font-black text-teal-300 shadow-2xl shadow-teal-500/20 ring-4 ring-white/50 backdrop-blur dark:bg-white/10 dark:text-teal-200 dark:ring-teal-500/30">
-              DM
-            </div>
+            <TorchLogo />
             <div>
-              <p className="text-xs uppercase tracking-[0.45em] text-teal-600 dark:text-teal-300">D&D Map Reveal</p>
-              <p className="text-lg font-semibold text-slate-900 dark:text-slate-100">Fog-of-war built for dramatic storytelling</p>
+              <p className="text-xs uppercase tracking-[0.45em] text-amber-700 dark:text-amber-200">TableTorch</p>
+              <p className="text-lg font-semibold text-slate-900 dark:text-amber-50">Light every encounter with warm, cinematic reveals</p>
             </div>
           </div>
           <button
             type="button"
             onClick={handleThemeToggle}
             aria-pressed={theme === 'dark'}
-            className="inline-flex items-center gap-2 rounded-full border border-slate-300/70 bg-white/40 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-600 shadow-sm transition hover:border-teal-400/70 hover:text-teal-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-teal-400 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-200 dark:hover:border-teal-400/60 dark:hover:text-teal-200"
+            className="inline-flex items-center gap-2 rounded-full border border-amber-900/20 bg-amber-50/80 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-amber-800 shadow-sm transition hover:border-amber-500/60 hover:text-amber-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-500 dark:border-amber-300/40 dark:bg-amber-500/10 dark:text-amber-100 dark:hover:border-amber-200/60 dark:hover:text-amber-200"
           >
             <span className="text-base" aria-hidden>
               {theme === 'dark' ? '🌙' : '🌞'}
@@ -69,25 +108,25 @@ const LandingPage: React.FC<LandingPageProps> = ({ theme, setTheme, onAuthentica
         <main className="mx-auto grid max-w-7xl gap-16 px-6 pb-24 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,0.9fr)] lg:items-center">
           <section className="space-y-10">
             <div className="space-y-6">
-              <span className="inline-flex items-center rounded-full border border-teal-400/50 bg-teal-100/60 px-4 py-1 text-[11px] font-semibold uppercase tracking-[0.35em] text-teal-700 shadow-sm dark:border-teal-500/40 dark:bg-teal-500/10 dark:text-teal-200">
-                Your new DM co-pilot
+              <span className="inline-flex items-center rounded-full border border-amber-900/30 bg-amber-100/70 px-4 py-1 text-[11px] font-semibold uppercase tracking-[0.35em] text-amber-800 shadow-sm dark:border-amber-200/40 dark:bg-amber-500/20 dark:text-amber-100">
+                Illuminate every session
               </span>
-              <h1 className="text-4xl font-black tracking-tight text-slate-900 sm:text-5xl dark:text-white">
-                Guide your party through unforgettable encounters with cinematic map reveals.
+              <h1 className="text-4xl font-black tracking-tight text-slate-900 sm:text-5xl dark:text-amber-50">
+                Guide your party with the glow of TableTorch.
               </h1>
-              <p className="max-w-xl text-lg text-slate-600 dark:text-slate-300">
-                D&D Map Reveal keeps your battlemap prep organised and ready. Cue dramatic lighting, reveal regions in real time, and manage campaigns without breaking the table’s immersion.
+              <p className="max-w-xl text-lg text-slate-700 dark:text-amber-200/80">
+                TableTorch keeps your battlemap prep organised and ready. Douse the table in warm light, reveal regions in real time, and keep the suspense alive without breaking immersion.
               </p>
               <div className="flex flex-wrap items-center gap-4">
                 <a
                   href="#auth-panel"
-                  className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-teal-500 via-sky-500 to-blue-500 px-6 py-3 text-xs font-semibold uppercase tracking-[0.45em] text-white shadow-lg shadow-teal-500/30 transition hover:scale-[1.02] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-teal-400"
+                  className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-amber-500 via-orange-500 to-rose-500 px-6 py-3 text-xs font-semibold uppercase tracking-[0.45em] text-white shadow-lg shadow-amber-500/30 transition hover:scale-[1.02] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-400"
                 >
-                  Launch the demo
+                  Light the demo
                 </a>
                 <a
                   href="#features"
-                  className="inline-flex items-center justify-center gap-2 rounded-full border border-slate-300/70 bg-white/60 px-6 py-3 text-xs font-semibold uppercase tracking-[0.35em] text-slate-600 transition hover:border-teal-400/60 hover:text-teal-600 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-200 dark:hover:border-teal-400/60 dark:hover:text-teal-200"
+                  className="inline-flex items-center justify-center gap-2 rounded-full border border-amber-900/30 bg-amber-50/70 px-6 py-3 text-xs font-semibold uppercase tracking-[0.35em] text-amber-800 transition hover:border-amber-500/60 hover:text-amber-600 dark:border-amber-200/40 dark:bg-amber-500/10 dark:text-amber-100 dark:hover:border-amber-200/60 dark:hover:text-amber-200"
                 >
                   Explore features
                   <span aria-hidden>→</span>
@@ -98,35 +137,35 @@ const LandingPage: React.FC<LandingPageProps> = ({ theme, setTheme, onAuthentica
               {features.map((feature) => (
                 <article
                   key={feature.title}
-                  className="group relative overflow-hidden rounded-3xl border border-white/60 bg-white/80 p-6 shadow-lg shadow-slate-200/40 transition hover:-translate-y-1 hover:shadow-2xl dark:border-slate-800/70 dark:bg-slate-900/70 dark:shadow-black/40"
+                  className="group relative overflow-hidden rounded-3xl border border-amber-900/20 bg-amber-50/70 p-6 shadow-lg shadow-amber-900/10 transition hover:-translate-y-1 hover:shadow-2xl dark:border-amber-200/30 dark:bg-slate-950/60 dark:shadow-black/50"
                 >
-                  <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-teal-500/20 to-sky-500/10 text-2xl">
+                  <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-amber-500/30 to-orange-500/20 text-2xl text-white shadow-inner shadow-amber-900/20">
                     <span aria-hidden>{feature.icon}</span>
                     <span className="sr-only">{feature.title} icon</span>
                   </div>
-                  <h3 className="mt-4 text-lg font-semibold text-slate-900 dark:text-white">{feature.title}</h3>
-                  <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">{feature.description}</p>
+                  <h3 className="mt-4 text-lg font-semibold text-slate-900 dark:text-amber-50">{feature.title}</h3>
+                  <p className="mt-2 text-sm text-slate-700 dark:text-amber-200/80">{feature.description}</p>
                   <div
                     aria-hidden
-                    className="pointer-events-none absolute inset-0 translate-y-full bg-gradient-to-t from-teal-500/10 to-transparent transition duration-500 group-hover:translate-y-0"
+                    className="pointer-events-none absolute inset-0 translate-y-full bg-gradient-to-t from-amber-500/10 via-orange-500/5 to-transparent transition duration-500 group-hover:translate-y-0"
                   />
                 </article>
               ))}
             </section>
           </section>
           <aside className="relative">
-            <div aria-hidden className="absolute inset-0 -translate-y-6 rounded-[2.75rem] bg-white/50 blur-3xl dark:bg-slate-900/50" />
-            <div className="relative rounded-[2.5rem] border border-white/40 bg-white/60 p-1 shadow-2xl shadow-teal-500/10 backdrop-blur-xl dark:border-slate-800/60 dark:bg-slate-950/60">
-              <div className="absolute -top-16 right-10 h-24 w-24 rounded-full bg-gradient-to-br from-teal-400/40 to-sky-500/20 blur-3xl dark:from-teal-500/30 dark:to-sky-500/20 animate-gradient" aria-hidden />
-              <div className="absolute bottom-10 left-10 h-20 w-20 rounded-full bg-teal-400/20 blur-2xl dark:bg-teal-500/20 animate-float-slow" aria-hidden />
+            <div aria-hidden className="absolute inset-0 -translate-y-6 rounded-[2.75rem] bg-amber-100/70 blur-3xl dark:bg-amber-900/40" />
+            <div className="relative rounded-[2.5rem] border border-amber-900/20 bg-amber-50/70 p-1 shadow-2xl shadow-amber-900/20 backdrop-blur-xl dark:border-amber-200/20 dark:bg-slate-950/60">
+              <div className="absolute -top-16 right-10 h-24 w-24 rounded-full bg-gradient-to-br from-amber-400/50 to-orange-500/20 blur-3xl dark:from-amber-500/30 dark:to-orange-500/20 animate-gradient" aria-hidden />
+              <div className="absolute bottom-10 left-10 h-20 w-20 rounded-full bg-orange-400/20 blur-2xl dark:bg-amber-500/20 animate-float-slow" aria-hidden />
               <AuthPanel
                 variant="wide"
-                className="border-transparent bg-white/80 shadow-none ring-1 ring-white/60 dark:bg-slate-950/70 dark:ring-teal-500/20"
+                className="border-transparent bg-amber-50/70 shadow-none ring-1 ring-amber-900/10 dark:bg-slate-950/70 dark:ring-amber-200/30"
                 onAuthenticate={onAuthenticate}
               />
             </div>
-            <p id="auth-panel" className="mt-6 text-center text-xs text-slate-500 dark:text-slate-400">
-              No spam, no credit card – just a guided tour of the DM mission control.
+            <p id="auth-panel" className="mt-6 text-center text-xs text-slate-600 dark:text-amber-200/70">
+              No spam, no credit card – just a guided tour of the TableTorch command lantern.
             </p>
           </aside>
         </main>

--- a/apps/pages/src/index.css
+++ b/apps/pages/src/index.css
@@ -20,23 +20,32 @@ body.dark {
 
 @layer utilities {
   .bg-landing {
+    background-color: #f8e9cc;
     background-image:
-      radial-gradient(circle at 10% -10%, rgba(56, 189, 248, 0.35), transparent 45%),
-      radial-gradient(circle at 80% 10%, rgba(20, 184, 166, 0.25), transparent 40%),
-      radial-gradient(circle at 0% 80%, rgba(14, 165, 233, 0.2), transparent 45%),
-      linear-gradient(135deg, #f8fafc 0%, #f1f5f9 50%, #e2e8f0 100%);
+      radial-gradient(circle at 12% -8%, rgba(249, 115, 22, 0.18), transparent 45%),
+      radial-gradient(circle at 82% 12%, rgba(217, 119, 6, 0.16), transparent 48%),
+      linear-gradient(135deg, rgba(248, 250, 229, 0.75), rgba(250, 240, 200, 0.6)),
+      var(--parchment-texture);
+    background-size: 1200px 1200px, 900px 900px, cover, cover;
+    background-position: center, center, center, center;
+    background-repeat: no-repeat, no-repeat, no-repeat, repeat;
+    background-blend-mode: soft-light, soft-light, normal, normal;
   }
 
   .dark .bg-landing {
+    background-color: #0c0906;
     background-image:
-      radial-gradient(circle at 15% -10%, rgba(56, 189, 248, 0.2), transparent 45%),
-      radial-gradient(circle at 85% 15%, rgba(37, 99, 235, 0.18), transparent 45%),
-      radial-gradient(circle at 10% 85%, rgba(45, 212, 191, 0.18), transparent 45%),
-      linear-gradient(135deg, #020617 0%, #0f172a 55%, #020617 100%);
+      radial-gradient(circle at 14% -10%, rgba(251, 191, 36, 0.18), transparent 45%),
+      radial-gradient(circle at 88% 18%, rgba(249, 115, 22, 0.14), transparent 50%),
+      linear-gradient(140deg, rgba(9, 6, 3, 0.9), rgba(17, 12, 8, 0.92)),
+      var(--parchment-texture);
+    background-blend-mode: screen, screen, normal, multiply;
+    background-size: 1100px 1100px, 900px 900px, cover, cover;
+    background-position: center, center, center, center;
   }
 
   .bg-grid-mask {
-    --grid-color: rgba(15, 23, 42, 0.08);
+    --grid-color: rgba(120, 72, 24, 0.1);
     background-image:
       linear-gradient(var(--grid-color) 1px, transparent 1px),
       linear-gradient(90deg, var(--grid-color) 1px, transparent 1px);
@@ -44,7 +53,7 @@ body.dark {
   }
 
   .dark .bg-grid-mask {
-    --grid-color: rgba(148, 163, 184, 0.1);
+    --grid-color: rgba(248, 191, 88, 0.08);
   }
 
   .animate-gradient {


### PR DESCRIPTION
## Summary
- rebrand the marketing landing page around TableTorch with parchment-inspired styling and placeholder torch logo
- update background utilities to use the parchment texture with warm and dark overlays
- rename authentication messaging and in-app headings from D&D Map Reveal to TableTorch

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dafbf9ba008323aae9b6bb3d80768a