### PR TITLE
Rebrand app with TableTorch parchment theme

### DIFF
--- a/apps/pages/src/App.tsx
+++ b/apps/pages/src/App.tsx
@@ -5,6 +5,7 @@ import { apiClient } from './api/client';
 import MapCreationWizard from './components/MapCreationWizard';
 import MapFolderList from './components/MapFolderList';
 import LandingPage from './components/LandingPage';
+import TorchLogo from './components/TorchLogo';
 import type {
   AuthResponse,
   Campaign,
@@ -63,6 +64,25 @@ const App: React.FC = () => {
   const [newCampaignPublic, setNewCampaignPublic] = useState(false);
   const [createError, setCreateError] = useState<string | null>(null);
   const [showMapWizard, setShowMapWizard] = useState(false);
+
+  const parchmentTexture = useMemo(
+    () => new URL('../../../textures/parchment-bg.jpg', import.meta.url).href,
+    []
+  );
+
+  const parchmentBackground = useMemo<React.CSSProperties>(
+    () => ({
+      backgroundColor: theme === 'dark' ? '#1a1510' : '#f5ebd3',
+      backgroundImage:
+        theme === 'dark'
+          ? `linear-gradient(rgba(10, 8, 6, 0.85), rgba(10, 8, 6, 0.9)), url(${parchmentTexture})`
+          : `url(${parchmentTexture})`,
+      backgroundSize: 'cover',
+      backgroundAttachment: 'fixed',
+      backgroundPosition: 'center',
+    }),
+    [parchmentTexture, theme]
+  );
 
   useEffect(() => {
     if (theme === 'dark') {
@@ -539,8 +559,8 @@ const App: React.FC = () => {
   const navButtonClasses = (view: 'join' | 'manage' | 'create' | 'admin') =>
     `group flex w-full items-center justify-between rounded-2xl border px-5 py-4 text-left text-sm font-semibold uppercase tracking-[0.3em] transition ${
       activeView === view
-        ? 'border-teal-400 bg-teal-400/90 text-slate-900 shadow-lg shadow-teal-500/40'
-        : 'border-slate-800/70 bg-slate-900/60 text-slate-300 hover:border-teal-400/60 hover:bg-slate-800/80'
+        ? 'border-amber-600/60 bg-amber-500/40 text-amber-900 shadow-lg shadow-amber-900/20 dark:border-amber-400/60 dark:bg-amber-500/20 dark:text-amber-100'
+        : 'border-amber-900/30 bg-amber-50/60 text-amber-900/80 hover:bg-amber-100/70 dark:border-amber-500/30 dark:bg-amber-900/30 dark:text-amber-200/80 dark:hover:bg-amber-900/50'
     }`;
 
   if (!token || !user) {
@@ -549,96 +569,106 @@ const App: React.FC = () => {
 
   if (activeSession) {
     return (
-      <div className="min-h-screen bg-slate-100 p-6 dark:bg-slate-900">
-        <div className="mb-4 flex items-center justify-between">
-          <div>
-            <h1 className="text-2xl font-bold text-primary">D&D Map Reveal</h1>
-            <p className="text-sm text-slate-500 dark:text-slate-400">Logged in as {user.displayName}</p>
-          </div>
-          <div className="flex items-center gap-2">
-            <button
-              className="rounded-full border border-slate-300 px-3 py-1 text-xs hover:bg-slate-100 dark:border-slate-600 dark:hover:bg-slate-700"
-              onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
-            >
-              {themeLabel}
-            </button>
-            <button
-              className="rounded-full border border-slate-300 px-3 py-1 text-xs hover:bg-slate-100 dark:border-slate-600 dark:hover:bg-slate-700"
-              onClick={handleLogout}
-            >
-              Logout
-            </button>
+      <div
+        className="min-h-screen px-6 py-8 text-stone-900 transition-colors dark:text-amber-100"
+        style={parchmentBackground}
+      >
+        <div className="mx-auto flex max-w-6xl flex-col gap-6">
+          <header className="flex flex-wrap items-center justify-between gap-4 rounded-3xl border border-amber-900/30 bg-amber-50/70 px-6 py-4 shadow-lg shadow-amber-900/20 backdrop-blur-sm dark:border-amber-500/30 dark:bg-amber-900/40">
+            <TorchLogo theme={theme} showTagline={false} className="gap-3" />
+            <div className="flex flex-wrap items-center gap-4">
+              <div className="text-right">
+                <p className="text-xs uppercase tracking-[0.35em] text-amber-900/70 dark:text-amber-200/70">Logged in</p>
+                <p className="text-sm font-semibold text-stone-900 dark:text-amber-100">{user.displayName}</p>
+              </div>
+              <div className="flex items-center gap-2">
+                <button
+                  className="rounded-full border border-amber-900/30 bg-amber-50/70 px-3 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-amber-900 transition hover:bg-amber-100 focus-visible:outline focus-visible:outline-amber-500 dark:border-amber-500/40 dark:bg-amber-500/20 dark:text-amber-100"
+                  onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
+                >
+                  {themeLabel}
+                </button>
+                <button
+                  className="rounded-full border border-rose-500/60 bg-rose-500/20 px-3 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-rose-900 transition hover:bg-rose-500/30 focus-visible:outline focus-visible:outline-rose-500 dark:border-rose-400/60 dark:bg-rose-500/30 dark:text-rose-100"
+                  onClick={handleLogout}
+                >
+                  Logout
+                </button>
+              </div>
+            </div>
+          </header>
+          {statusMessage && (
+            <div className="rounded-3xl border border-amber-900/30 bg-amber-50/80 px-5 py-3 text-sm text-stone-700 shadow-md shadow-amber-900/15 dark:border-amber-500/30 dark:bg-amber-900/40 dark:text-amber-200/80">
+              {statusMessage}
+            </div>
+          )}
+          <div className="rounded-3xl border border-amber-900/30 bg-amber-50/80 p-4 shadow-xl shadow-amber-900/20 backdrop-blur-sm dark:border-amber-500/30 dark:bg-amber-900/40">
+            <SessionViewer
+              session={activeSession}
+              mapImageUrl={selectedMap ? apiClient.buildMapDisplayUrl(selectedMap.id) : undefined}
+              mapWidth={selectedMap?.width}
+              mapHeight={selectedMap?.height}
+              regions={regions}
+              baseMarkers={markers}
+              mode={sessionMode}
+              user={user}
+              onLeave={handleLeaveSession}
+              onSaveSession={sessionMode === 'dm' ? handleSaveSession : undefined}
+              onEndSession={sessionMode === 'dm' ? handleEndSession : undefined}
+            />
           </div>
         </div>
-        {statusMessage && (
-          <div className="mb-4 rounded border border-slate-200 bg-white px-4 py-2 text-sm text-slate-600 shadow dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200">
-            {statusMessage}
-          </div>
-        )}
-        <SessionViewer
-          session={activeSession}
-          mapImageUrl={selectedMap ? apiClient.buildMapDisplayUrl(selectedMap.id) : undefined}
-          mapWidth={selectedMap?.width}
-          mapHeight={selectedMap?.height}
-          regions={regions}
-          baseMarkers={markers}
-          mode={sessionMode}
-          user={user}
-          onLeave={handleLeaveSession}
-          onSaveSession={sessionMode === 'dm' ? handleSaveSession : undefined}
-          onEndSession={sessionMode === 'dm' ? handleEndSession : undefined}
-        />
       </div>
     );
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 text-slate-100">
-      <div className="mx-auto flex min-h-screen max-w-6xl flex-col gap-6 px-4 py-8 md:flex-row md:py-12">
-        <aside className="flex flex-col gap-6 rounded-3xl border border-slate-800/70 bg-slate-950/70 p-6 shadow-2xl md:w-72">
-          <div>
-            <p className="text-xs uppercase tracking-[0.4em] text-slate-500">Mission Control</p>
-            <h2 className="mt-3 text-2xl font-black uppercase tracking-wide text-teal-300">Command Deck</h2>
-          </div>
-          <div className="rounded-2xl border border-slate-800/70 bg-slate-900/70 p-4">
-            <p className="text-xs uppercase tracking-[0.5em] text-slate-500">Logged in</p>
-            <p className="mt-2 text-lg font-semibold text-white">{user.displayName}</p>
-            <p className="text-xs text-slate-500">Ready for launch</p>
+    <div
+      className="min-h-screen px-4 py-8 text-stone-900 transition-colors dark:text-amber-100"
+      style={parchmentBackground}
+    >
+      <div className="mx-auto flex min-h-screen max-w-6xl flex-col gap-6 md:flex-row md:py-12">
+        <aside className="flex flex-col gap-6 rounded-3xl border border-amber-900/30 bg-amber-50/70 p-6 shadow-2xl shadow-amber-900/20 backdrop-blur-sm dark:border-amber-500/30 dark:bg-amber-900/40 md:w-72">
+          <TorchLogo theme={theme} showTagline={false} className="gap-3" />
+          <div className="rounded-2xl border border-amber-900/30 bg-amber-100/70 p-4 text-amber-900/80 dark:border-amber-500/30 dark:bg-amber-900/50 dark:text-amber-200/80">
+            <p className="text-xs uppercase tracking-[0.45em]">Torchbearer</p>
+            <p className="mt-2 text-lg font-semibold text-stone-900 dark:text-amber-100">{user.displayName}</p>
+            <p className="text-xs">Keep the story aglow.</p>
           </div>
           <nav className="space-y-3">
             <button className={navButtonClasses('join')} onClick={() => setActiveView('join')}>
               <span>Join Campaign</span>
-              <span className="text-[10px] tracking-[0.4em] text-slate-900/70 transition group-hover:text-slate-900/90">START</span>
+              <span className="text-[10px] tracking-[0.4em] text-amber-900/70 transition group-hover:text-amber-900">START</span>
             </button>
             <button className={navButtonClasses('manage')} onClick={() => setActiveView('manage')}>
               <span>Manage Campaigns</span>
-              <span className="text-[10px] tracking-[0.4em] text-slate-900/70 transition group-hover:text-slate-900/90">HANGAR</span>
+              <span className="text-[10px] tracking-[0.4em] text-amber-900/70 transition group-hover:text-amber-900">HANGAR</span>
             </button>
             <button className={navButtonClasses('create')} onClick={() => setActiveView('create')}>
               <span>Create Campaign</span>
-              <span className="text-[10px] tracking-[0.4em] text-slate-900/70 transition group-hover:text-slate-900/90">NEW</span>
+              <span className="text-[10px] tracking-[0.4em] text-amber-900/70 transition group-hover:text-amber-900">NEW</span>
             </button>
           </nav>
-          <div className="mt-auto space-y-2 text-xs text-slate-500">
-            <p>Need a room code? Ask your DM to share their campaign key.</p>
-            <p>Switch tabs to manage, create, or join adventures.</p>
+          <div className="mt-auto space-y-2 text-xs text-amber-900/70 dark:text-amber-200/70">
+            <p>Need a table key? Share the campaign code with your players.</p>
+            <p>Switch tabs to join, manage, or kindle new adventures.</p>
           </div>
         </aside>
         <section className="flex-1 space-y-6">
-          <header className="flex flex-wrap items-center justify-between gap-3 rounded-3xl border border-slate-800/70 bg-slate-950/70 px-6 py-4 shadow-xl">
+          <header className="flex flex-wrap items-center justify-between gap-3 rounded-3xl border border-amber-900/30 bg-amber-50/80 px-6 py-4 shadow-lg shadow-amber-900/20 backdrop-blur-sm dark:border-amber-500/30 dark:bg-amber-900/40">
             <div>
-              <p className="text-xs uppercase tracking-[0.5em] text-teal-300">Campaign Control</p>
-              <h1 className="text-3xl font-black uppercase tracking-wide text-white">D&D Map Reveal</h1>
+              <p className="text-xs uppercase tracking-[0.45em] text-amber-900/70 dark:text-amber-200/70">Campaign Ledger</p>
+              <h1 className="text-3xl font-black tracking-wide text-stone-900 dark:text-amber-100">TableTorch Command Board</h1>
             </div>
             <div className="flex items-center gap-3">
               <button
-                className="rounded-full border border-teal-400/60 bg-teal-400/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-teal-200 transition hover:bg-teal-400/20"
+                className="rounded-full border border-amber-900/30 bg-amber-50/70 px-4 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-amber-900 transition hover:bg-amber-100 focus-visible:outline focus-visible:outline-amber-500 dark:border-amber-500/40 dark:bg-amber-500/20 dark:text-amber-100"
                 onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
               >
                 {themeLabel}
               </button>
               <button
-                className="rounded-full border border-rose-400/60 bg-rose-500/20 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-rose-200 transition hover:bg-rose-500/30"
+                className="rounded-full border border-rose-500/60 bg-rose-500/20 px-4 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-rose-900 transition hover:bg-rose-500/30 focus-visible:outline focus-visible:outline-rose-500 dark:border-rose-400/60 dark:bg-rose-500/30 dark:text-rose-100"
                 onClick={handleLogout}
               >
                 Logout
@@ -646,43 +676,43 @@ const App: React.FC = () => {
             </div>
           </header>
           {statusMessage && (
-            <div className="rounded-3xl border border-teal-500/40 bg-teal-500/10 px-5 py-3 text-sm text-teal-200 shadow-lg shadow-teal-500/10">
+            <div className="rounded-3xl border border-amber-900/30 bg-amber-50/80 px-5 py-3 text-sm text-amber-900/80 shadow-lg shadow-amber-900/15 dark:border-amber-500/30 dark:bg-amber-900/40 dark:text-amber-200/80">
               {statusMessage}
             </div>
           )}
-          <div className="flex-1 rounded-3xl border border-slate-800/70 bg-slate-950/70 p-6 shadow-2xl">
+          <div className="flex-1 rounded-3xl border border-amber-900/30 bg-amber-50/80 p-6 shadow-2xl shadow-amber-900/20 backdrop-blur-sm dark:border-amber-500/30 dark:bg-amber-900/40">
             {activeView === 'join' && (
               <div className="space-y-6">
-                <h2 className="text-3xl font-black uppercase tracking-wide text-teal-200">Join Campaign</h2>
-                <p className="max-w-xl text-sm text-slate-300">
-                  Enter the campaign key provided by your Dungeon Master to hop into their room.
+                <h2 className="text-3xl font-black tracking-wide text-amber-900 dark:text-amber-100">Join Campaign</h2>
+                <p className="max-w-xl text-sm text-amber-900/80 dark:text-amber-200/80">
+                  Enter the campaign key provided by your storyteller to step into their illuminated view.
                 </p>
                 <form onSubmit={handleJoinByKey} className="space-y-4">
-                  <label className="block text-xs uppercase tracking-[0.4em] text-slate-400">
+                  <label className="block text-xs uppercase tracking-[0.4em] text-amber-900/70 dark:text-amber-200/70">
                     Campaign Key
                     <div className="mt-2 flex flex-col gap-3 sm:flex-row">
                       <input
                         value={joinKey}
                         onChange={(event) => setJoinKey(event.target.value)}
                         placeholder="e.g. A1B2C3"
-                        className="flex-1 rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm uppercase tracking-[0.3em] text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                        className="flex-1 rounded-xl border border-amber-900/30 bg-amber-100/70 px-4 py-3 text-sm uppercase tracking-[0.3em] text-amber-900 placeholder:text-amber-700/60 focus:border-amber-600 focus:outline-none focus:ring-2 focus:ring-amber-500/30 dark:border-amber-500/30 dark:bg-amber-900/50 dark:text-amber-100 dark:placeholder:text-amber-200/50 dark:focus:border-amber-300"
                       />
                       <button
                         type="submit"
-                        className="rounded-xl border border-teal-400/60 bg-teal-500/80 px-6 py-3 text-sm font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-teal-400/90 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                        className="rounded-xl border border-amber-900/40 bg-gradient-to-r from-amber-500 via-orange-500 to-rose-500 px-6 py-3 text-sm font-semibold uppercase tracking-[0.3em] text-amber-50 transition hover:scale-105 focus:outline-none focus:ring-2 focus:ring-amber-500/40"
                       >
                         Join Room
                       </button>
                     </div>
                   </label>
-                  {joinError && <p className="text-xs font-semibold text-rose-300">{joinError}</p>}
+                  {joinError && <p className="text-xs font-semibold text-rose-500 dark:text-rose-300">{joinError}</p>}
                 </form>
-                <div className="rounded-2xl border border-slate-800/70 bg-slate-900/70 p-4">
+                <div className="rounded-2xl border border-amber-900/30 bg-amber-100/60 p-4 dark:border-amber-500/30 dark:bg-amber-900/40">
                   <div className="mb-3 flex items-center justify-between">
-                    <h3 className="text-xs uppercase tracking-[0.4em] text-slate-400">Active Rooms</h3>
+                    <h3 className="text-xs uppercase tracking-[0.4em] text-amber-900/70 dark:text-amber-200/70">Active Rooms</h3>
                     <button
                       type="button"
-                      className="text-xs font-semibold uppercase tracking-[0.3em] text-teal-200 transition hover:text-teal-100"
+                      className="text-xs font-semibold uppercase tracking-[0.3em] text-amber-900/70 transition hover:text-amber-900 dark:text-amber-200/80 dark:hover:text-amber-100"
                       onClick={refreshLobby}
                     >
                       Refresh
@@ -690,27 +720,27 @@ const App: React.FC = () => {
                   </div>
                   <ul className="max-h-48 space-y-2 overflow-y-auto pr-1 text-sm">
                     {lobbySessions.map((session) => (
-                      <li key={session.id} className="rounded-xl border border-slate-800/70 bg-slate-950/60 p-3">
+                      <li key={session.id} className="rounded-xl border border-amber-900/30 bg-amber-50/80 p-3 dark:border-amber-500/30 dark:bg-amber-900/40">
                         <div className="flex flex-wrap items-center justify-between gap-2">
                           <div>
-                            <p className="font-semibold text-slate-100">{session.name}</p>
-                            <p className="text-[10px] uppercase tracking-[0.4em] text-slate-500">Key: {session.id}</p>
+                            <p className="font-semibold text-amber-900 dark:text-amber-100">{session.name}</p>
+                            <p className="text-[10px] uppercase tracking-[0.4em] text-amber-900/70 dark:text-amber-200/70">Key: {session.id}</p>
                           </div>
                           <button
                             type="button"
-                            className="rounded-lg border border-teal-400/60 bg-teal-500/80 px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-teal-400/90"
+                            className="rounded-lg border border-amber-900/40 bg-gradient-to-r from-amber-500 via-orange-500 to-rose-500 px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-amber-50 transition hover:scale-105"
                             onClick={() => handleJoinSession(session)}
                           >
                             Join
                           </button>
                         </div>
-                        <p className="mt-2 text-xs text-slate-400">
+                        <p className="mt-2 text-xs text-amber-900/70 dark:text-amber-200/70">
                           Campaign: {session.campaignName ?? 'Unknown'} • Map: {session.mapName ?? 'Unknown'}
                         </p>
                       </li>
                     ))}
                     {lobbySessions.length === 0 && (
-                      <li className="rounded-xl border border-dashed border-slate-700/70 px-3 py-6 text-center text-xs text-slate-500">
+                      <li className="rounded-xl border border-dashed border-amber-900/30 px-3 py-6 text-center text-xs text-amber-900/60 dark:border-amber-500/30 dark:text-amber-200/70">
                         No active rooms yet.
                       </li>
                     )}
@@ -722,12 +752,12 @@ const App: React.FC = () => {
               <div className="space-y-6">
                 <div className="flex flex-wrap items-center justify-between gap-3">
                   <div>
-                    <h2 className="text-3xl font-black uppercase tracking-wide text-teal-200">Manage Campaigns</h2>
-                    <p className="text-sm text-slate-300">Select a campaign to open the admin hangar.</p>
+                    <h2 className="text-3xl font-black tracking-wide text-amber-900 dark:text-amber-100">Manage Campaigns</h2>
+                    <p className="text-sm text-amber-900/80 dark:text-amber-200/80">Select a campaign to open the TableTorch toolkit.</p>
                   </div>
                   <button
                     type="button"
-                    className="rounded-full border border-teal-400/60 px-5 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-teal-200 transition hover:bg-teal-500/20"
+                    className="rounded-full border border-amber-900/30 bg-amber-50/70 px-5 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-amber-900 transition hover:bg-amber-100 focus-visible:outline focus-visible:outline-amber-500 dark:border-amber-500/40 dark:bg-amber-500/20 dark:text-amber-100"
                     onClick={() => refreshCampaigns()}
                   >
                     Refresh
@@ -737,22 +767,22 @@ const App: React.FC = () => {
                   {campaigns.map((campaign) => (
                     <button
                       key={campaign.id}
-                      className="group flex h-full flex-col justify-between rounded-2xl border border-slate-800/70 bg-slate-950/60 p-4 text-left transition hover:border-teal-400/60 hover:bg-slate-900/70"
+                      className="group flex h-full flex-col justify-between rounded-2xl border border-amber-900/30 bg-amber-50/80 p-4 text-left transition hover:-translate-y-1 hover:border-amber-600/50 hover:shadow-lg hover:shadow-amber-900/20 dark:border-amber-500/30 dark:bg-amber-900/40"
                       onClick={() => handleOpenCampaignAdmin(campaign)}
                     >
-                      <div>
-                        <p className="text-xs uppercase tracking-[0.4em] text-slate-500">Campaign</p>
-                        <h3 className="mt-2 text-lg font-semibold text-white">{campaign.name}</h3>
-                        <p className="mt-2 text-xs text-slate-400">{campaign.description || 'No description provided.'}</p>
+                      <div className="space-y-2">
+                        <p className="text-xs uppercase tracking-[0.4em] text-amber-900/60 dark:text-amber-200/60">Campaign</p>
+                        <h3 className="text-lg font-semibold text-amber-900 dark:text-amber-100">{campaign.name}</h3>
+                        <p className="text-sm text-amber-900/70 dark:text-amber-200/70">{campaign.description || 'No description provided.'}</p>
                       </div>
-                      <span className="mt-4 inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.3em] text-teal-200">
-                        Open Hangar <span aria-hidden>→</span>
+                      <span className="mt-4 inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.35em] text-amber-900 transition group-hover:text-amber-600 dark:text-amber-100">
+                        Open Tools <span aria-hidden>→</span>
                       </span>
                     </button>
                   ))}
                   {campaigns.length === 0 && (
-                    <div className="rounded-2xl border border-dashed border-slate-700/70 p-6 text-center text-sm text-slate-400">
-                      You haven't created any campaigns yet. Try the create tab to launch a new adventure.
+                    <div className="rounded-2xl border border-dashed border-amber-900/30 bg-amber-100/60 p-6 text-center text-sm text-amber-900/70 dark:border-amber-500/30 dark:bg-amber-900/40 dark:text-amber-200/70">
+                      You haven't created any campaigns yet. Try the create tab to kindle a new adventure.
                     </div>
                   )}
                 </div>
@@ -760,48 +790,48 @@ const App: React.FC = () => {
             )}
             {activeView === 'create' && (
               <div className="space-y-6">
-                <h2 className="text-3xl font-black uppercase tracking-wide text-teal-200">Create Campaign</h2>
-                <p className="max-w-xl text-sm text-slate-300">Set up a new campaign for your players and start building encounters.</p>
+                <h2 className="text-3xl font-black tracking-wide text-amber-900 dark:text-amber-100">Create Campaign</h2>
+                <p className="max-w-xl text-sm text-amber-900/80 dark:text-amber-200/80">Set up a new campaign for your players and keep every reveal within reach.</p>
                 <form onSubmit={handleCreateCampaign} className="space-y-5">
                   <div>
-                    <label className="text-xs uppercase tracking-[0.4em] text-slate-400">Campaign Name</label>
+                    <label className="text-xs uppercase tracking-[0.4em] text-amber-900/70 dark:text-amber-200/70">Campaign Name</label>
                     <input
                       value={newCampaignName}
                       onChange={(event) => setNewCampaignName(event.target.value)}
-                      className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                      className="mt-2 w-full rounded-xl border border-amber-900/30 bg-amber-100/70 px-4 py-3 text-sm text-amber-900 placeholder:text-amber-700/60 focus:border-amber-600 focus:outline-none focus:ring-2 focus:ring-amber-500/30 dark:border-amber-500/30 dark:bg-amber-900/50 dark:text-amber-100 dark:placeholder:text-amber-200/60 dark:focus:border-amber-300"
                       placeholder="Give your mission a title"
                     />
                   </div>
                   <div>
-                    <label className="text-xs uppercase tracking-[0.4em] text-slate-400">Description</label>
+                    <label className="text-xs uppercase tracking-[0.4em] text-amber-900/70 dark:text-amber-200/70">Description</label>
                     <textarea
                       value={newCampaignDescription}
                       onChange={(event) => setNewCampaignDescription(event.target.value)}
                       rows={4}
-                      className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                      className="mt-2 w-full rounded-xl border border-amber-900/30 bg-amber-100/70 px-4 py-3 text-sm text-amber-900 placeholder:text-amber-700/60 focus:border-amber-600 focus:outline-none focus:ring-2 focus:ring-amber-500/30 dark:border-amber-500/30 dark:bg-amber-900/50 dark:text-amber-100 dark:placeholder:text-amber-200/60 dark:focus:border-amber-300"
                       placeholder="Share a quick briefing for your players"
                     />
                   </div>
-                  <label className="flex items-center gap-3 text-xs uppercase tracking-[0.4em] text-slate-400">
+                  <label className="flex items-center gap-3 text-xs uppercase tracking-[0.4em] text-amber-900/70 dark:text-amber-200/70">
                     <input
                       type="checkbox"
                       checked={newCampaignPublic}
                       onChange={(event) => setNewCampaignPublic(event.target.checked)}
-                      className="h-4 w-4 rounded border border-slate-700 bg-slate-900 text-teal-400 focus:ring-teal-400"
+                      className="h-4 w-4 rounded border border-amber-900/40 bg-amber-100 text-amber-600 focus:ring-amber-500 dark:border-amber-500/40 dark:bg-amber-900/50 dark:text-amber-300"
                     />
-                    <span className="text-slate-300">List publicly for players to discover</span>
+                    <span className="text-amber-900/80 dark:text-amber-200/80">List publicly for players to discover</span>
                   </label>
-                  {createError && <p className="text-xs font-semibold text-rose-300">{createError}</p>}
+                  {createError && <p className="text-xs font-semibold text-rose-500 dark:text-rose-300">{createError}</p>}
                   <div className="flex flex-wrap gap-3">
                     <button
                       type="submit"
-                      className="rounded-xl border border-teal-400/60 bg-teal-500/80 px-6 py-3 text-sm font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-teal-400/90"
+                      className="rounded-xl border border-amber-900/40 bg-gradient-to-r from-amber-500 via-orange-500 to-rose-500 px-6 py-3 text-sm font-semibold uppercase tracking-[0.3em] text-amber-50 transition hover:scale-105"
                     >
                       Launch Campaign
                     </button>
                     <button
                       type="button"
-                      className="rounded-xl border border-slate-700/70 px-6 py-3 text-sm font-semibold uppercase tracking-[0.3em] text-slate-300 transition hover:border-teal-400/60 hover:text-teal-200"
+                      className="rounded-xl border border-amber-900/30 px-6 py-3 text-sm font-semibold uppercase tracking-[0.3em] text-amber-900/70 transition hover:bg-amber-100 dark:border-amber-500/30 dark:text-amber-200/80 dark:hover:bg-amber-900/50"
                       onClick={() => {
                         setNewCampaignName('');
                         setNewCampaignDescription('');
@@ -819,28 +849,28 @@ const App: React.FC = () => {
               <div className="space-y-6">
                 <div className="flex flex-wrap items-center justify-between gap-3">
                   <div>
-                    <p className="text-xs uppercase tracking-[0.4em] text-teal-300">Managing Campaign</p>
-                    <h2 className="text-3xl font-black uppercase tracking-wide text-white">{selectedCampaign.name}</h2>
-                    {selectedCampaign.description && <p className="text-sm text-slate-300">{selectedCampaign.description}</p>}
+                    <p className="text-xs uppercase tracking-[0.4em] text-amber-900/70 dark:text-amber-200/70">Managing Campaign</p>
+                    <h2 className="text-3xl font-black tracking-wide text-amber-900 dark:text-amber-100">{selectedCampaign.name}</h2>
+                    {selectedCampaign.description && <p className="text-sm text-amber-900/80 dark:text-amber-200/80">{selectedCampaign.description}</p>}
                   </div>
                   <div className="flex flex-wrap items-center gap-3">
                     <button
                       type="button"
-                      className="rounded-full border border-slate-700/70 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-300 transition hover:border-teal-400/60 hover:text-teal-200"
+                      className="rounded-full border border-amber-900/30 bg-amber-50/70 px-4 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-amber-900 transition hover:bg-amber-100 focus-visible:outline focus-visible:outline-amber-500 dark:border-amber-500/30 dark:bg-amber-500/20 dark:text-amber-100"
                       onClick={handleBackToManage}
                     >
                       Campaign List
                     </button>
                     <button
                       type="button"
-                      className="rounded-full border border-rose-400/60 bg-rose-500/20 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-rose-200 transition hover:bg-rose-500/30"
+                      className="rounded-full border border-rose-500/60 bg-rose-500/20 px-4 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-rose-900 transition hover:bg-rose-500/30 focus-visible:outline focus-visible:outline-rose-500 dark:border-rose-400/60 dark:bg-rose-500/30 dark:text-rose-100"
                       onClick={handleDeleteCampaign}
                     >
                       Delete Campaign
                     </button>
                     <button
                       type="button"
-                      className="rounded-full border border-teal-400/60 bg-teal-500/80 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-teal-400/90"
+                      className="rounded-full border border-amber-900/40 bg-gradient-to-r from-amber-500 via-orange-500 to-rose-500 px-4 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-amber-50 transition hover:scale-105"
                       onClick={handleStartSession}
                     >
                       Launch Session
@@ -859,14 +889,14 @@ const App: React.FC = () => {
                   <div className="grid gap-6 xl:grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)]">
                     <div className="space-y-6">
                       {selectedMap ? (
-                        <div className="rounded-2xl border border-slate-800/70 bg-slate-900/70 p-6">
+                        <div className="rounded-2xl border border-amber-900/30 bg-amber-100/70 p-6 shadow-md shadow-amber-900/20 dark:border-amber-500/30 dark:bg-amber-900/40">
                           <div className="mb-6 flex flex-wrap items-start justify-between gap-4">
                             <div>
-                              <h3 className="text-2xl font-semibold text-white">{selectedMap.name}</h3>
-                              {mapDescription && <p className="mt-2 text-sm text-slate-300">{mapDescription}</p>}
-                              {!mapDescription && mapNotes && <p className="mt-2 text-sm text-slate-400">{mapNotes}</p>}
+                              <h3 className="text-2xl font-semibold text-amber-900 dark:text-amber-100">{selectedMap.name}</h3>
+                              {mapDescription && <p className="mt-2 text-sm text-amber-900/80 dark:text-amber-200/80">{mapDescription}</p>}
+                              {!mapDescription && mapNotes && <p className="mt-2 text-sm text-amber-900/70 dark:text-amber-200/70">{mapNotes}</p>}
                             </div>
-                            <div className="flex flex-wrap items-center gap-4 text-xs uppercase tracking-[0.4em] text-slate-500">
+                            <div className="flex flex-wrap items-center gap-4 text-xs uppercase tracking-[0.4em] text-amber-900/60 dark:text-amber-200/60">
                               <span>Regions: {regions.length}</span>
                               <span>Markers: {markers.length}</span>
                               <span>
@@ -874,7 +904,7 @@ const App: React.FC = () => {
                               </span>
                             </div>
                           </div>
-                          <div className="overflow-hidden rounded-2xl border border-slate-800/70 bg-slate-950/70">
+                          <div className="overflow-hidden rounded-2xl border border-amber-900/30 bg-amber-200/40 dark:border-amber-500/30 dark:bg-amber-950/30">
                             <MapMaskCanvas
                               imageUrl={selectedMap ? apiClient.buildMapDisplayUrl(selectedMap.id) : undefined}
                               width={selectedMap.width}
@@ -886,72 +916,72 @@ const App: React.FC = () => {
                             />
                           </div>
                           <div className="mt-6 grid gap-4 lg:grid-cols-2">
-                            <div className="rounded-2xl border border-slate-800/70 bg-slate-950/70 p-4">
-                              <p className="text-[10px] uppercase tracking-[0.4em] text-slate-500">Grouping</p>
-                              <p className="mt-2 text-sm font-semibold text-teal-200">{mapGrouping}</p>
+                            <div className="rounded-2xl border border-amber-900/30 bg-amber-50/70 p-4 dark:border-amber-500/30 dark:bg-amber-900/40">
+                              <p className="text-[10px] uppercase tracking-[0.4em] text-amber-900/60 dark:text-amber-200/60">Grouping</p>
+                              <p className="mt-2 text-sm font-semibold text-amber-900 dark:text-amber-100">{mapGrouping}</p>
                               {mapNotes && mapDescription && (
-                                <p className="mt-3 text-xs text-slate-400">Notes: {mapNotes}</p>
+                                <p className="mt-3 text-xs text-amber-900/70 dark:text-amber-200/70">Notes: {mapNotes}</p>
                               )}
                             </div>
-                            <div className="rounded-2xl border border-slate-800/70 bg-slate-950/70 p-4">
-                              <p className="text-[10px] uppercase tracking-[0.4em] text-slate-500">Tags</p>
+                            <div className="rounded-2xl border border-amber-900/30 bg-amber-50/70 p-4 dark:border-amber-500/30 dark:bg-amber-900/40">
+                              <p className="text-[10px] uppercase tracking-[0.4em] text-amber-900/60 dark:text-amber-200/60">Tags</p>
                               {mapTags.length > 0 ? (
                                 <div className="mt-3 flex flex-wrap gap-2">
                                   {mapTags.map((tag) => (
                                     <span
                                       key={tag}
-                                      className="inline-flex items-center rounded-full border border-slate-700/70 bg-slate-900/70 px-2 py-1 text-[10px] uppercase tracking-[0.3em] text-slate-300"
+                                      className="inline-flex items-center rounded-full border border-amber-900/30 bg-amber-100/70 px-2 py-1 text-[10px] uppercase tracking-[0.3em] text-amber-900 dark:border-amber-500/30 dark:bg-amber-900/50 dark:text-amber-100"
                                     >
                                       {tag}
                                     </span>
                                   ))}
                                 </div>
                               ) : (
-                                <p className="mt-3 text-xs text-slate-500">No tags assigned yet.</p>
+                                <p className="mt-3 text-xs text-amber-900/70 dark:text-amber-200/70">No tags assigned yet.</p>
                               )}
                             </div>
                           </div>
                           {!mapDescription && !mapNotes && (
-                            <p className="mt-4 text-xs text-slate-500">
+                            <p className="mt-4 text-xs text-amber-900/70 dark:text-amber-200/70">
                               Add details and notes through the map wizard to give your players extra context.
                             </p>
                           )}
                         </div>
                       ) : (
-                        <div className="rounded-2xl border border-dashed border-slate-700/70 p-12 text-center text-sm text-slate-400">
+                        <div className="rounded-2xl border border-dashed border-amber-900/30 p-12 text-center text-sm text-amber-900/70 dark:border-amber-500/30 dark:text-amber-200/70">
                           Select or create a map to begin shaping your encounter.
                         </div>
                       )}
                     </div>
                     <div className="space-y-6">
-                      <div className="rounded-2xl border border-slate-800/70 bg-slate-900/70 p-5">
+                      <div className="rounded-2xl border border-amber-900/30 bg-amber-100/70 p-5 dark:border-amber-500/30 dark:bg-amber-900/40">
                         <div className="mb-3 flex items-center justify-between">
-                          <h3 className="text-xs uppercase tracking-[0.4em] text-slate-400">My Sessions</h3>
+                          <h3 className="text-xs uppercase tracking-[0.4em] text-amber-900/70 dark:text-amber-200/70">My Sessions</h3>
                         </div>
                         <ul className="space-y-2 text-sm">
                           {mySessions.map((session) => (
                             <li key={session.id}>
                               <button
                                 onClick={() => handleJoinSession(session)}
-                                className="w-full rounded-xl border border-slate-800/70 bg-slate-950/60 px-3 py-2 text-left text-slate-300 transition hover:border-teal-400/60 hover:text-teal-100"
+                                className="w-full rounded-xl border border-amber-900/30 bg-amber-50/80 px-3 py-2 text-left text-amber-900 transition hover:border-amber-600/50 hover:text-amber-700 dark:border-amber-500/30 dark:bg-amber-900/40 dark:text-amber-100"
                               >
                                 {session.name}
                               </button>
                             </li>
                           ))}
                           {mySessions.length === 0 && (
-                            <li className="rounded-xl border border-dashed border-slate-700/70 px-3 py-6 text-center text-xs text-slate-500">
+                            <li className="rounded-xl border border-dashed border-amber-900/30 px-3 py-6 text-center text-xs text-amber-900/60 dark:border-amber-500/30 dark:text-amber-200/70">
                               No active sessions.
                             </li>
                           )}
                         </ul>
                       </div>
-                      <div className="rounded-2xl border border-slate-800/70 bg-slate-900/70 p-5">
+                      <div className="rounded-2xl border border-amber-900/30 bg-amber-100/70 p-5 dark:border-amber-500/30 dark:bg-amber-900/40">
                         <div className="mb-3 flex items-center justify-between">
-                          <h3 className="text-xs uppercase tracking-[0.4em] text-slate-400">Lobby</h3>
+                          <h3 className="text-xs uppercase tracking-[0.4em] text-amber-900/70 dark:text-amber-200/70">Lobby</h3>
                           <button
                             type="button"
-                            className="text-xs font-semibold uppercase tracking-[0.3em] text-teal-200 transition hover:text-teal-100"
+                            className="text-xs font-semibold uppercase tracking-[0.3em] text-amber-900/70 transition hover:text-amber-900 dark:text-amber-200/80 dark:hover:text-amber-100"
                             onClick={refreshLobby}
                           >
                             Refresh
@@ -959,13 +989,13 @@ const App: React.FC = () => {
                         </div>
                         <ul className="space-y-2 text-sm">
                           {lobbySessions.map((session) => (
-                            <li key={session.id} className="rounded-xl border border-slate-800/70 bg-slate-950/60 p-3">
-                              <p className="font-semibold text-slate-100">{session.name}</p>
-                              <p className="text-[10px] uppercase tracking-[0.4em] text-slate-500">Campaign: {session.campaignName ?? 'Unknown'}</p>
-                              <p className="text-[10px] uppercase tracking-[0.4em] text-slate-500">Map: {session.mapName ?? 'Unknown'}</p>
+                            <li key={session.id} className="rounded-xl border border-amber-900/30 bg-amber-50/80 p-3 dark:border-amber-500/30 dark:bg-amber-900/40">
+                              <p className="font-semibold text-amber-900 dark:text-amber-100">{session.name}</p>
+                              <p className="text-[10px] uppercase tracking-[0.4em] text-amber-900/70 dark:text-amber-200/70">Campaign: {session.campaignName ?? 'Unknown'}</p>
+                              <p className="text-[10px] uppercase tracking-[0.4em] text-amber-900/70 dark:text-amber-200/70">Map: {session.mapName ?? 'Unknown'}</p>
                               <button
                                 type="button"
-                                className="mt-3 w-full rounded-xl border border-teal-400/60 bg-teal-500/80 px-3 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-teal-400/90"
+                                className="mt-3 w-full rounded-xl border border-amber-900/40 bg-gradient-to-r from-amber-500 via-orange-500 to-rose-500 px-3 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-amber-50 transition hover:scale-105"
                                 onClick={() => handleJoinSession(session)}
                               >
                                 Join as {session.hostId === user.id ? 'DM' : 'Player'}
@@ -973,7 +1003,7 @@ const App: React.FC = () => {
                             </li>
                           ))}
                           {lobbySessions.length === 0 && (
-                            <li className="rounded-xl border border-dashed border-slate-700/70 px-3 py-6 text-center text-xs text-slate-500">
+                            <li className="rounded-xl border border-dashed border-amber-900/30 px-3 py-6 text-center text-xs text-amber-900/60 dark:border-amber-500/30 dark:text-amber-200/70">
                               No active sessions available.
                             </li>
                           )}
@@ -985,7 +1015,7 @@ const App: React.FC = () => {
               </div>
             )}
             {activeView === 'admin' && !selectedCampaign && (
-              <div className="rounded-2xl border border-dashed border-slate-700/70 p-12 text-center text-sm text-slate-400">
+              <div className="rounded-2xl border border-dashed border-amber-900/30 p-12 text-center text-sm text-amber-900/70 dark:border-amber-500/30 dark:text-amber-200/70">
                 Choose a campaign from the manage tab to configure it here.
               </div>
             )}

--- a/apps/pages/src/components/AuthPanel.tsx
+++ b/apps/pages/src/components/AuthPanel.tsx
@@ -45,47 +45,47 @@ const AuthPanel: React.FC<AuthPanelProps> = ({ onAuthenticate, className, varian
   };
 
   const containerClasses = classNames(
-    'relative w-full overflow-hidden rounded-3xl border border-slate-200/80 bg-white/80 p-8 shadow-xl shadow-slate-200/60 backdrop-blur-sm transition-colors dark:border-slate-800/60 dark:bg-slate-900/80 dark:shadow-black/40 sm:p-10',
+    'relative w-full overflow-hidden rounded-3xl border border-amber-900/30 bg-amber-50/80 p-8 shadow-xl shadow-amber-900/10 backdrop-blur-sm transition-colors dark:border-amber-500/40 dark:bg-amber-900/60 dark:shadow-black/50 sm:p-10',
     variant === 'default' ? 'mx-auto max-w-md' : '',
     className
   );
 
-  const badgeText = mode === 'login' ? 'Return to the table' : 'Create a DM profile';
-  const headingText = mode === 'login' ? 'Sign in to D&D Map Reveal' : 'Join the D&D Map Reveal beta';
+  const badgeText = mode === 'login' ? 'Return to the glow' : 'Light a new torch';
+  const headingText = mode === 'login' ? 'Sign in to TableTorch' : 'Join the TableTorch beta';
   const submitLabel = loading ? 'Please wait…' : mode === 'login' ? 'Log in' : 'Sign up';
   const toggleLabel = mode === 'login' ? 'Need an account?' : 'Already have an account?';
-  const toggleHelper = mode === 'login' ? 'Create one instead' : 'Use your existing login';
+  const toggleHelper = mode === 'login' ? 'Kindle one instead' : 'Use your existing flame';
 
   return (
     <section className={containerClasses} aria-labelledby={`${formId}-title`}>
       <span
         aria-hidden
-        className="pointer-events-none absolute -top-28 left-1/2 h-72 w-72 -translate-x-1/2 rounded-full bg-teal-400/20 blur-3xl dark:bg-teal-500/10"
+        className="pointer-events-none absolute -top-28 left-1/2 h-72 w-72 -translate-x-1/2 rounded-full bg-amber-400/20 blur-3xl dark:bg-amber-500/15"
       />
       <div className="relative space-y-8">
         <header className="space-y-3">
-          <span className="inline-flex items-center rounded-full border border-teal-500/40 bg-teal-100/60 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.3em] text-teal-700 shadow-sm dark:border-teal-400/50 dark:bg-teal-500/10 dark:text-teal-200">
+          <span className="inline-flex items-center rounded-full border border-amber-900/30 bg-amber-100/70 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.3em] text-amber-900 shadow-sm dark:border-amber-500/40 dark:bg-amber-500/20 dark:text-amber-100">
             {badgeText}
           </span>
           <div className="flex flex-wrap items-start justify-between gap-4">
             <div className="space-y-2">
-              <h2 id={`${formId}-title`} className="text-2xl font-semibold text-slate-900 dark:text-white">
+              <h2 id={`${formId}-title`} className="text-2xl font-semibold text-stone-900 dark:text-amber-100">
                 {headingText}
               </h2>
-              <p className="text-sm text-slate-600 dark:text-slate-300">
-                Use the pre-filled demo credentials or sign up with your own details to explore the DM console.
+              <p className="text-sm text-stone-700 dark:text-amber-200/80">
+                Use the pre-filled demo credentials or sign up with your own details to explore the TableTorch command desk.
               </p>
             </div>
             <button
               type="button"
               onClick={() => setMode((current) => (current === 'login' ? 'signup' : 'login'))}
-              className="inline-flex items-center rounded-full border border-slate-300/70 bg-white/40 px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-slate-500 transition hover:border-teal-400/60 hover:text-teal-600 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-300 dark:hover:border-teal-400/50 dark:hover:text-teal-200"
+              className="inline-flex items-center rounded-full border border-amber-900/30 bg-amber-50/70 px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-amber-900 transition hover:bg-amber-100 focus-visible:outline focus-visible:outline-amber-500 dark:border-amber-500/40 dark:bg-amber-500/20 dark:text-amber-100"
               aria-pressed={mode === 'signup'}
             >
               {toggleLabel}
             </button>
           </div>
-          <p className="text-xs uppercase tracking-[0.35em] text-slate-400 dark:text-slate-500">{toggleHelper}</p>
+          <p className="text-xs uppercase tracking-[0.35em] text-amber-900/70 dark:text-amber-200/70">{toggleHelper}</p>
         </header>
         <form
           id={formId}
@@ -97,7 +97,7 @@ const AuthPanel: React.FC<AuthPanelProps> = ({ onAuthenticate, className, varian
         >
           <div className="space-y-4">
             <div className="space-y-2">
-              <label htmlFor={emailId} className="text-sm font-medium text-slate-700 dark:text-slate-200">
+              <label htmlFor={emailId} className="text-sm font-medium text-stone-800 dark:text-amber-100">
                 Email
               </label>
               <input
@@ -106,13 +106,13 @@ const AuthPanel: React.FC<AuthPanelProps> = ({ onAuthenticate, className, varian
                 value={email}
                 onChange={(event) => setEmail(event.target.value)}
                 autoComplete="email"
-                className="w-full rounded-2xl border border-slate-300/80 bg-white px-4 py-3 text-sm font-medium text-slate-900 shadow-sm transition focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-400/60 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:focus:border-teal-400"
+                className="w-full rounded-2xl border border-amber-900/20 bg-white px-4 py-3 text-sm font-medium text-stone-900 shadow-sm transition focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500/40 dark:border-amber-500/40 dark:bg-amber-950/40 dark:text-amber-100 dark:focus:border-amber-300"
                 required
               />
             </div>
             {mode === 'signup' && (
               <div className="space-y-2">
-                <label htmlFor={displayNameId} className="text-sm font-medium text-slate-700 dark:text-slate-200">
+                <label htmlFor={displayNameId} className="text-sm font-medium text-stone-800 dark:text-amber-100">
                   Display name
                 </label>
                 <input
@@ -120,13 +120,13 @@ const AuthPanel: React.FC<AuthPanelProps> = ({ onAuthenticate, className, varian
                   value={displayName}
                   onChange={(event) => setDisplayName(event.target.value)}
                   autoComplete="name"
-                  className="w-full rounded-2xl border border-slate-300/80 bg-white px-4 py-3 text-sm font-medium text-slate-900 shadow-sm transition focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-400/60 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:focus:border-teal-400"
+                  className="w-full rounded-2xl border border-amber-900/20 bg-white px-4 py-3 text-sm font-medium text-stone-900 shadow-sm transition focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500/40 dark:border-amber-500/40 dark:bg-amber-950/40 dark:text-amber-100 dark:focus:border-amber-300"
                   required
                 />
               </div>
             )}
             <div className="space-y-2">
-              <label htmlFor={passwordId} className="text-sm font-medium text-slate-700 dark:text-slate-200">
+              <label htmlFor={passwordId} className="text-sm font-medium text-stone-800 dark:text-amber-100">
                 Password
               </label>
               <input
@@ -135,25 +135,25 @@ const AuthPanel: React.FC<AuthPanelProps> = ({ onAuthenticate, className, varian
                 value={password}
                 onChange={(event) => setPassword(event.target.value)}
                 autoComplete={mode === 'login' ? 'current-password' : 'new-password'}
-                className="w-full rounded-2xl border border-slate-300/80 bg-white px-4 py-3 text-sm font-medium text-slate-900 shadow-sm transition focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-400/60 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:focus:border-teal-400"
+                className="w-full rounded-2xl border border-amber-900/20 bg-white px-4 py-3 text-sm font-medium text-stone-900 shadow-sm transition focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500/40 dark:border-amber-500/40 dark:bg-amber-950/40 dark:text-amber-100 dark:focus:border-amber-300"
                 required
               />
             </div>
           </div>
           {error && (
-            <p id={errorId} role="alert" className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-2 text-sm text-rose-600 dark:border-rose-500/50 dark:bg-rose-500/10 dark:text-rose-200">
+            <p id={errorId} role="alert" className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-2 text-sm text-rose-700 dark:border-rose-500/50 dark:bg-rose-500/20 dark:text-rose-200">
               {error}
             </p>
           )}
           <button
             type="submit"
             disabled={loading}
-            className="flex w-full items-center justify-center gap-2 rounded-2xl bg-gradient-to-r from-teal-500 via-sky-500 to-blue-500 px-5 py-3 text-sm font-semibold uppercase tracking-[0.4em] text-white shadow-lg shadow-teal-500/30 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-white/80 focus-visible:ring-offset-2 focus-visible:ring-offset-teal-500 disabled:cursor-wait disabled:opacity-80"
+            className="flex w-full items-center justify-center gap-2 rounded-2xl bg-gradient-to-r from-amber-500 via-orange-500 to-rose-500 px-5 py-3 text-sm font-semibold uppercase tracking-[0.4em] text-amber-50 shadow-lg shadow-amber-700/30 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-200/80 focus-visible:ring-offset-2 focus-visible:ring-offset-amber-600 disabled:cursor-wait disabled:opacity-80"
           >
             {submitLabel}
           </button>
         </form>
-        <p className="text-xs text-slate-500 dark:text-slate-400">
+        <p className="text-xs text-stone-600 dark:text-amber-200/70">
           We respect your table: credentials are only used to authenticate with the demo API and never stored by this client.
         </p>
       </div>

--- a/apps/pages/src/components/LandingPage.tsx
+++ b/apps/pages/src/components/LandingPage.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { AuthResponse } from '../types';
 import AuthPanel from './AuthPanel';
+import TorchLogo from './TorchLogo';
 
 interface LandingPageProps {
   theme: 'light' | 'dark';
@@ -10,24 +11,24 @@ interface LandingPageProps {
 
 const features = [
   {
-    title: 'Reveal maps live',
-    description: 'Fade in fog-of-war with precision tools built for dramatic reveals and on-the-fly adjustments.',
-    icon: '🗺️',
+    title: 'Torchlit reveals',
+    description: 'Guide your players with gentle, painterly fades that feel like candlelight washing over parchment.',
+    icon: '🕯️',
   },
   {
-    title: 'Campaign control',
-    description: 'Organise every battlemap, note and marker by campaign so your prep is ready when players arrive.',
-    icon: '🎯',
+    title: 'Campaign satchel',
+    description: 'Keep maps, lore and regions bundled by adventure so everything you prep is within arm’s reach.',
+    icon: '🎒',
   },
   {
-    title: 'Share instantly',
-    description: 'Invite players with short join codes and let them explore revealed regions from any device.',
-    icon: '⚡',
+    title: 'Instant invitations',
+    description: 'Share a single key and let the party step into your revealed view from any device at the table.',
+    icon: '📜',
   },
   {
-    title: 'Save your progress',
-    description: 'Archive live sessions and pick up where you left off without losing the dramatic tension.',
-    icon: '🛡️',
+    title: 'Session embers',
+    description: 'Save the state of every reveal so you can rekindle the exact moment you paused the story.',
+    icon: '💾',
   },
 ];
 
@@ -38,27 +39,38 @@ const LandingPage: React.FC<LandingPageProps> = ({ theme, setTheme, onAuthentica
     setTheme(theme === 'dark' ? 'light' : 'dark');
   };
 
+  const parchmentTexture = React.useMemo(
+    () => new URL('../../../../textures/parchment-bg.jpg', import.meta.url).href,
+    []
+  );
+
+  const backgroundStyle = React.useMemo<React.CSSProperties>(
+    () => ({
+      backgroundColor: theme === 'dark' ? '#1a1510' : '#f5ebd3',
+      backgroundImage:
+        theme === 'dark'
+          ? `linear-gradient(rgba(12, 10, 7, 0.8), rgba(12, 10, 7, 0.85)), url(${parchmentTexture})`
+          : `url(${parchmentTexture})`,
+      backgroundSize: 'cover',
+      backgroundAttachment: 'fixed',
+      backgroundPosition: 'center',
+    }),
+    [parchmentTexture, theme]
+  );
+
   return (
-    <div className="bg-landing relative min-h-screen overflow-hidden text-slate-900 transition-colors dark:text-slate-100">
-      <div aria-hidden className="absolute inset-0 bg-grid-mask opacity-60 mix-blend-soft-light dark:opacity-40" />
-      <div aria-hidden className="pointer-events-none absolute -top-32 right-12 h-72 w-72 rounded-full bg-sky-400/30 blur-3xl dark:bg-sky-500/20 animate-float-slow" />
-      <div aria-hidden className="pointer-events-none absolute bottom-[-10rem] left-[-6rem] h-96 w-96 rounded-full bg-teal-400/20 blur-[120px] dark:bg-teal-500/20 animate-float-slow" />
-      <div className="relative isolate">
-        <header className="mx-auto flex max-w-7xl flex-wrap items-center justify-between gap-4 px-6 py-8 sm:py-10">
-          <div className="flex items-center gap-4">
-            <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-slate-900/90 text-2xl font-black text-teal-300 shadow-2xl shadow-teal-500/20 ring-4 ring-white/50 backdrop-blur dark:bg-white/10 dark:text-teal-200 dark:ring-teal-500/30">
-              DM
-            </div>
-            <div>
-              <p className="text-xs uppercase tracking-[0.45em] text-teal-600 dark:text-teal-300">D&D Map Reveal</p>
-              <p className="text-lg font-semibold text-slate-900 dark:text-slate-100">Fog-of-war built for dramatic storytelling</p>
-            </div>
-          </div>
+    <div
+      className="relative min-h-screen overflow-hidden text-stone-900 transition-colors dark:text-amber-100"
+      style={backgroundStyle}
+    >
+      <div className="relative bg-gradient-to-b from-white/70 via-white/40 to-transparent px-6 py-10 backdrop-blur-sm dark:from-black/40 dark:via-black/30 dark:to-transparent">
+        <header className="mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-6">
+          <TorchLogo theme={theme} />
           <button
             type="button"
             onClick={handleThemeToggle}
             aria-pressed={theme === 'dark'}
-            className="inline-flex items-center gap-2 rounded-full border border-slate-300/70 bg-white/40 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-600 shadow-sm transition hover:border-teal-400/70 hover:text-teal-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-teal-400 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-200 dark:hover:border-teal-400/60 dark:hover:text-teal-200"
+            className="inline-flex items-center gap-2 rounded-full border border-amber-900/20 bg-amber-100/60 px-4 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-amber-900 shadow-sm transition hover:bg-amber-200/60 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-500 dark:border-amber-500/40 dark:bg-amber-500/20 dark:text-amber-100"
           >
             <span className="text-base" aria-hidden>
               {theme === 'dark' ? '🌙' : '🌞'}
@@ -66,28 +78,28 @@ const LandingPage: React.FC<LandingPageProps> = ({ theme, setTheme, onAuthentica
             {themeLabel}
           </button>
         </header>
-        <main className="mx-auto grid max-w-7xl gap-16 px-6 pb-24 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,0.9fr)] lg:items-center">
+        <main className="mx-auto grid max-w-6xl gap-16 pb-24 pt-12 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,0.9fr)] lg:items-start">
           <section className="space-y-10">
             <div className="space-y-6">
-              <span className="inline-flex items-center rounded-full border border-teal-400/50 bg-teal-100/60 px-4 py-1 text-[11px] font-semibold uppercase tracking-[0.35em] text-teal-700 shadow-sm dark:border-teal-500/40 dark:bg-teal-500/10 dark:text-teal-200">
-                Your new DM co-pilot
+              <span className="inline-flex items-center rounded-full border border-amber-900/20 bg-amber-100/70 px-4 py-1 text-[11px] font-semibold uppercase tracking-[0.35em] text-amber-900 shadow-sm dark:border-amber-500/40 dark:bg-amber-500/10 dark:text-amber-100">
+                TableTorch keeps the table glowing
               </span>
-              <h1 className="text-4xl font-black tracking-tight text-slate-900 sm:text-5xl dark:text-white">
-                Guide your party through unforgettable encounters with cinematic map reveals.
+              <h1 className="text-4xl font-black tracking-tight text-stone-900 sm:text-5xl dark:text-amber-100">
+                Illuminate every reveal with tools crafted for storytellers.
               </h1>
-              <p className="max-w-xl text-lg text-slate-600 dark:text-slate-300">
-                D&D Map Reveal keeps your battlemap prep organised and ready. Cue dramatic lighting, reveal regions in real time, and manage campaigns without breaking the table’s immersion.
+              <p className="max-w-xl text-lg text-stone-700 dark:text-amber-200/80">
+                TableTorch is your digital tabletop companion—blend regions smoothly, manage campaigns without rummaging through folders, and keep your party immersed in the glow of discovery.
               </p>
               <div className="flex flex-wrap items-center gap-4">
                 <a
                   href="#auth-panel"
-                  className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-teal-500 via-sky-500 to-blue-500 px-6 py-3 text-xs font-semibold uppercase tracking-[0.45em] text-white shadow-lg shadow-teal-500/30 transition hover:scale-[1.02] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-teal-400"
+                  className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-amber-500 via-orange-500 to-rose-500 px-6 py-3 text-xs font-semibold uppercase tracking-[0.45em] text-amber-50 shadow-lg shadow-amber-700/30 transition hover:scale-[1.02] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-500"
                 >
-                  Launch the demo
+                  Launch TableTorch
                 </a>
                 <a
                   href="#features"
-                  className="inline-flex items-center justify-center gap-2 rounded-full border border-slate-300/70 bg-white/60 px-6 py-3 text-xs font-semibold uppercase tracking-[0.35em] text-slate-600 transition hover:border-teal-400/60 hover:text-teal-600 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-200 dark:hover:border-teal-400/60 dark:hover:text-teal-200"
+                  className="inline-flex items-center justify-center gap-2 rounded-full border border-amber-900/30 bg-amber-50/70 px-6 py-3 text-xs font-semibold uppercase tracking-[0.35em] text-amber-900 transition hover:bg-amber-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-500 dark:border-amber-500/40 dark:bg-amber-500/20 dark:text-amber-100"
                 >
                   Explore features
                   <span aria-hidden>→</span>
@@ -98,35 +110,35 @@ const LandingPage: React.FC<LandingPageProps> = ({ theme, setTheme, onAuthentica
               {features.map((feature) => (
                 <article
                   key={feature.title}
-                  className="group relative overflow-hidden rounded-3xl border border-white/60 bg-white/80 p-6 shadow-lg shadow-slate-200/40 transition hover:-translate-y-1 hover:shadow-2xl dark:border-slate-800/70 dark:bg-slate-900/70 dark:shadow-black/40"
+                  className="group relative overflow-hidden rounded-3xl border border-amber-900/20 bg-amber-50/70 p-6 shadow-lg shadow-amber-900/10 transition hover:-translate-y-1 hover:shadow-2xl dark:border-amber-500/40 dark:bg-amber-900/30 dark:shadow-black/40"
                 >
-                  <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-teal-500/20 to-sky-500/10 text-2xl">
+                  <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-amber-500/20 to-orange-500/10 text-2xl">
                     <span aria-hidden>{feature.icon}</span>
                     <span className="sr-only">{feature.title} icon</span>
                   </div>
-                  <h3 className="mt-4 text-lg font-semibold text-slate-900 dark:text-white">{feature.title}</h3>
-                  <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">{feature.description}</p>
+                  <h3 className="mt-4 text-lg font-semibold text-stone-900 dark:text-amber-100">{feature.title}</h3>
+                  <p className="mt-2 text-sm text-stone-700 dark:text-amber-200/80">{feature.description}</p>
                   <div
                     aria-hidden
-                    className="pointer-events-none absolute inset-0 translate-y-full bg-gradient-to-t from-teal-500/10 to-transparent transition duration-500 group-hover:translate-y-0"
+                    className="pointer-events-none absolute inset-0 translate-y-full bg-gradient-to-t from-amber-500/15 to-transparent transition duration-500 group-hover:translate-y-0"
                   />
                 </article>
               ))}
             </section>
           </section>
           <aside className="relative">
-            <div aria-hidden className="absolute inset-0 -translate-y-6 rounded-[2.75rem] bg-white/50 blur-3xl dark:bg-slate-900/50" />
-            <div className="relative rounded-[2.5rem] border border-white/40 bg-white/60 p-1 shadow-2xl shadow-teal-500/10 backdrop-blur-xl dark:border-slate-800/60 dark:bg-slate-950/60">
-              <div className="absolute -top-16 right-10 h-24 w-24 rounded-full bg-gradient-to-br from-teal-400/40 to-sky-500/20 blur-3xl dark:from-teal-500/30 dark:to-sky-500/20 animate-gradient" aria-hidden />
-              <div className="absolute bottom-10 left-10 h-20 w-20 rounded-full bg-teal-400/20 blur-2xl dark:bg-teal-500/20 animate-float-slow" aria-hidden />
+            <div aria-hidden className="absolute inset-0 -translate-y-6 rounded-[2.75rem] bg-amber-100/70 blur-3xl dark:bg-amber-900/40" />
+            <div className="relative rounded-[2.5rem] border border-amber-900/20 bg-amber-50/70 p-1 shadow-2xl shadow-amber-900/30 backdrop-blur-xl dark:border-amber-500/40 dark:bg-amber-950/40">
+              <div className="absolute -top-16 right-10 h-24 w-24 rounded-full bg-gradient-to-br from-amber-400/40 to-rose-400/20 blur-3xl dark:from-amber-500/25 dark:to-rose-500/15 animate-gradient" aria-hidden />
+              <div className="absolute bottom-10 left-10 h-20 w-20 rounded-full bg-amber-400/20 blur-2xl dark:bg-amber-500/20 animate-float-slow" aria-hidden />
               <AuthPanel
                 variant="wide"
-                className="border-transparent bg-white/80 shadow-none ring-1 ring-white/60 dark:bg-slate-950/70 dark:ring-teal-500/20"
+                className="border-transparent bg-amber-50/80 shadow-none ring-1 ring-amber-900/10 dark:bg-amber-950/60 dark:ring-amber-500/30"
                 onAuthenticate={onAuthenticate}
               />
             </div>
-            <p id="auth-panel" className="mt-6 text-center text-xs text-slate-500 dark:text-slate-400">
-              No spam, no credit card – just a guided tour of the DM mission control.
+            <p id="auth-panel" className="mt-6 text-center text-xs text-stone-600 dark:text-amber-200/70">
+              No spam, no credit card – just a guided tour of the TableTorch command desk.
             </p>
           </aside>
         </main>

--- a/apps/pages/src/components/MapCreationWizard.tsx
+++ b/apps/pages/src/components/MapCreationWizard.tsx
@@ -690,18 +690,18 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex flex-col bg-slate-950/95 backdrop-blur-sm">
-      <header className="mb-0.5 border-b border-slate-800/70 px-5 py-3">
+    <div className="fixed inset-0 z-50 flex flex-col bg-stone-950/95 backdrop-blur-sm">
+      <header className="mb-0.5 border-b border-stone-800/70 px-5 py-3">
         <div className="flex flex-wrap items-center justify-between gap-4">
           <div>
-            <p className="text-xs uppercase tracking-[0.4em] text-teal-300">New Map Wizard</p>
+            <p className="text-xs uppercase tracking-[0.4em] text-amber-300">New Map Wizard</p>
             <h2 className="text-2xl font-bold text-white">{steps[step].title}</h2>
-            <p className="text-sm text-slate-400">{steps[step].description}</p>
+            <p className="text-sm text-stone-400">{steps[step].description}</p>
           </div>
           <button
             type="button"
             onClick={onClose}
-            className="rounded-full border border-slate-700/70 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-300 transition hover:border-rose-400/60 hover:text-rose-200"
+            className="rounded-full border border-stone-700/70 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-stone-300 transition hover:border-rose-400/60 hover:text-rose-200"
           >
             Exit Wizard
           </button>
@@ -715,10 +715,10 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                 key={item.title}
                 className={`flex items-center gap-3 rounded-full border px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] transition ${
                   isActive
-                    ? 'border-teal-400/70 bg-teal-500/20 text-teal-100'
+                    ? 'border-amber-400/70 bg-amber-500/20 text-amber-100'
                     : isComplete
-                    ? 'border-slate-700/70 bg-slate-800/80 text-slate-200'
-                    : 'border-slate-800/70 bg-slate-900/80 text-slate-500'
+                    ? 'border-stone-700/70 bg-stone-800/80 text-stone-200'
+                    : 'border-stone-800/70 bg-stone-900/80 text-stone-500'
                 }`}
               >
                 <span className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-current">
@@ -739,12 +739,12 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
           <div className="flex h-full flex-1 flex-col overflow-x-visible overflow-y-hidden px-[10vw]">
           {step === 0 && (
             <div className="flex flex-1 items-center justify-center">
-              <div className="w-full max-w-4xl rounded-3xl border border-slate-800/70 bg-slate-900/70 p-8 text-center">
+              <div className="w-full max-w-4xl rounded-3xl border border-stone-800/70 bg-stone-900/70 p-8 text-center">
                 <div
                   onDragEnter={(event) => event.preventDefault()}
                   onDragOver={(event) => event.preventDefault()}
                   onDrop={handleDrop}
-                  className="group relative flex min-h-[200px] flex-col items-center justify-center rounded-2xl border-2 border-dashed border-slate-700/70 bg-slate-950/70 px-6 py-8 transition hover:border-teal-400/60"
+                  className="group relative flex min-h-[200px] flex-col items-center justify-center rounded-2xl border-2 border-dashed border-stone-700/70 bg-stone-950/70 px-6 py-8 transition hover:border-amber-400/60"
                 >
                   <input
                     ref={fileInputRef}
@@ -758,23 +758,23 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                       }
                     }}
                   />
-                  <p className="text-sm uppercase tracking-[0.4em] text-slate-500">Drag &amp; Drop</p>
+                  <p className="text-sm uppercase tracking-[0.4em] text-stone-500">Drag &amp; Drop</p>
                   <h3 className="mt-3 text-2xl font-semibold text-white">Drop your map image here</h3>
-                  <p className="mt-2 max-w-xl text-sm text-slate-400">
+                  <p className="mt-2 max-w-xl text-sm text-stone-400">
                     We accept PNG, JPG, WEBP, and other common image formats. Drop the file or browse your computer to get started.
                   </p>
                   <button
                     type="button"
                     onClick={handleBrowse}
-                    className="mt-5 rounded-full border border-teal-400/60 bg-teal-500/80 px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-teal-400/90"
+                    className="mt-5 rounded-full border border-amber-400/60 bg-amber-500/80 px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-stone-900 transition hover:bg-amber-400/90"
                   >
                     Browse Files
                   </button>
                 </div>
                 {previewUrl && (
                   <div className="mt-6">
-                    <p className="text-xs uppercase tracking-[0.4em] text-teal-300">Preview</p>
-                    <div className="mt-3 overflow-hidden rounded-2xl border border-slate-800/70">
+                    <p className="text-xs uppercase tracking-[0.4em] text-amber-300">Preview</p>
+                    <div className="mt-3 overflow-hidden rounded-2xl border border-stone-800/70">
                       <img
                         src={previewUrl}
                         alt="Uploaded map preview"
@@ -782,7 +782,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                       />
                     </div>
                     {imageDimensions && (
-                      <p className="mt-2 text-xs uppercase tracking-[0.4em] text-slate-500">
+                      <p className="mt-2 text-xs uppercase tracking-[0.4em] text-stone-500">
                         {imageDimensions.width} × {imageDimensions.height} pixels
                       </p>
                     )}
@@ -793,63 +793,63 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
           )}
           {step === 1 && (
             <div className="flex flex-1 items-stretch justify-center">
-              <div className="flex h-full w-full flex-col rounded-3xl border border-slate-800/70 bg-slate-900/70 p-8">
+              <div className="flex h-full w-full flex-col rounded-3xl border border-stone-800/70 bg-stone-900/70 p-8">
                 <div className="grid flex-1 min-h-0 gap-6 md:grid-cols-[minmax(0,1fr)_260px]">
                   <div className="flex flex-col gap-5">
                     <div>
-                      <label className="block text-xs uppercase tracking-[0.4em] text-slate-400">Map Name</label>
+                      <label className="block text-xs uppercase tracking-[0.4em] text-stone-400">Map Name</label>
                       <input
                         type="text"
                         value={name}
                         onChange={(event) => setName(event.target.value)}
-                        className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                        className="mt-2 w-full rounded-xl border border-stone-800/60 bg-stone-950/70 px-4 py-3 text-sm text-stone-100 placeholder:text-stone-600 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/40"
                         placeholder="Ancient Ruins"
                       />
                     </div>
                     <div>
-                      <label className="block text-xs uppercase tracking-[0.4em] text-slate-400">Description</label>
+                      <label className="block text-xs uppercase tracking-[0.4em] text-stone-400">Description</label>
                       <textarea
                         value={description}
                         onChange={(event) => setDescription(event.target.value)}
                         rows={3}
-                        className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                        className="mt-2 w-full rounded-xl border border-stone-800/60 bg-stone-950/70 px-4 py-3 text-sm text-stone-100 placeholder:text-stone-600 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/40"
                         placeholder="Give a brief overview of the map."
                       />
                     </div>
                     <div>
-                      <label className="block text-xs uppercase tracking-[0.4em] text-slate-400">Grouping</label>
+                      <label className="block text-xs uppercase tracking-[0.4em] text-stone-400">Grouping</label>
                       <input
                         type="text"
                         value={grouping}
                         onChange={(event) => setGrouping(event.target.value)}
-                        className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                        className="mt-2 w-full rounded-xl border border-stone-800/60 bg-stone-950/70 px-4 py-3 text-sm text-stone-100 placeholder:text-stone-600 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/40"
                         placeholder="Dungeon Delves"
                       />
                     </div>
                     <div>
-                      <label className="block text-xs uppercase tracking-[0.4em] text-slate-400">Notes</label>
+                      <label className="block text-xs uppercase tracking-[0.4em] text-stone-400">Notes</label>
                       <textarea
                         value={notes}
                         onChange={(event) => setNotes(event.target.value)}
                         rows={3}
-                        className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                        className="mt-2 w-full rounded-xl border border-stone-800/60 bg-stone-950/70 px-4 py-3 text-sm text-stone-100 placeholder:text-stone-600 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/40"
                         placeholder="DM-only reminders or encounter tips"
                       />
                     </div>
                     <div>
-                      <label className="block text-xs uppercase tracking-[0.4em] text-slate-400">Tags</label>
+                      <label className="block text-xs uppercase tracking-[0.4em] text-stone-400">Tags</label>
                       <input
                         type="text"
                         value={tagsInput}
                         onChange={(event) => setTagsInput(event.target.value)}
-                        className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                        className="mt-2 w-full rounded-xl border border-stone-800/60 bg-stone-950/70 px-4 py-3 text-sm text-stone-100 placeholder:text-stone-600 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/40"
                         placeholder="forest, ruins, night"
                       />
-                      <p className="mt-2 text-xs text-slate-500">Separate tags with commas to help search and filtering.</p>
+                      <p className="mt-2 text-xs text-stone-500">Separate tags with commas to help search and filtering.</p>
                     </div>
                   </div>
                   <div className="flex h-full flex-col gap-4">
-                    <div className="flex flex-1 items-center justify-center overflow-hidden rounded-2xl border border-slate-800/70 bg-slate-950/70">
+                    <div className="flex flex-1 items-center justify-center overflow-hidden rounded-2xl border border-stone-800/70 bg-stone-950/70">
                       {previewUrl ? (
                         <img
                           src={previewUrl}
@@ -857,14 +857,14 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                           className="max-h-full w-full object-contain"
                         />
                       ) : (
-                        <p className="text-xs uppercase tracking-[0.4em] text-slate-500">
+                        <p className="text-xs uppercase tracking-[0.4em] text-stone-500">
                           Upload a map image to preview it here.
                         </p>
                       )}
                     </div>
-                    <div className="rounded-2xl border border-slate-800/70 bg-slate-950/70 p-4">
-                      <p className="text-xs uppercase tracking-[0.4em] text-slate-400">Tips</p>
-                      <ul className="mt-2 space-y-2 text-xs text-slate-400">
+                    <div className="rounded-2xl border border-stone-800/70 bg-stone-950/70 p-4">
+                      <p className="text-xs uppercase tracking-[0.4em] text-stone-400">Tips</p>
+                      <ul className="mt-2 space-y-2 text-xs text-stone-400">
                         <li>Keep names short but descriptive for quick reference during sessions.</li>
                         <li>Use notes to capture secrets, traps, or DM-only reminders.</li>
                         <li>Tags help you filter maps later in the campaign dashboard.</li>
@@ -877,11 +877,11 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
           )}
           {step === 2 && (
             <div className="flex h-full min-h-0 flex-1 justify-center">
-              <div className="flex h-full min-h-0 w-full rounded-3xl border border-slate-800/70 bg-slate-900/70 p-4">
+              <div className="flex h-full min-h-0 w-full rounded-3xl border border-stone-800/70 bg-stone-900/70 p-4">
                 <div
                   ref={defineRoomContainerRef}
-                  className={`flex h-full min-h-0 w-full flex-col overflow-visible rounded-2xl border border-slate-800/70 bg-slate-950/80 ${
-                    canLaunchRoomsEditor ? '' : 'items-center justify-center text-sm text-slate-500'
+                  className={`flex h-full min-h-0 w-full flex-col overflow-visible rounded-2xl border border-stone-800/70 bg-stone-950/80 ${
+                    canLaunchRoomsEditor ? '' : 'items-center justify-center text-sm text-stone-500'
                   }`}
                 >
                   {!canLaunchRoomsEditor && (
@@ -895,7 +895,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
             <div className="grid h-full min-h-0 gap-6 lg:grid-cols-[minmax(0,1fr)_340px]">
               <div
                 ref={mapAreaRef}
-                className="relative flex h-full min-h-0 max-h-full items-center justify-center overflow-hidden rounded-3xl border border-slate-800/70 bg-slate-900/70"
+                className="relative flex h-full min-h-0 max-h-full items-center justify-center overflow-hidden rounded-3xl border border-stone-800/70 bg-stone-900/70"
               >
                 {previewUrl ? (
                   <>
@@ -918,39 +918,39 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                             markerDisplayMetrics,
                           ),
                         )}
-                        className="group absolute -translate-x-1/2 -translate-y-1/2 rounded-full border border-white/40 bg-slate-950/80 px-3 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-white shadow-lg transition hover:border-teal-300/80 hover:text-teal-100"
+                        className="group absolute -transtone-x-1/2 -transtone-y-1/2 rounded-full border border-white/40 bg-stone-950/80 px-3 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-white shadow-lg transition hover:border-amber-300/80 hover:text-amber-100"
                       >
                         {marker.label || 'Marker'}
                       </button>
                     ))}
                     {markers.length === 0 && (
-                      <div className="absolute inset-0 flex items-center justify-center text-sm text-slate-400">
+                      <div className="absolute inset-0 flex items-center justify-center text-sm text-stone-400">
                         Add markers from the panel to start placing points of interest.
                       </div>
                     )}
                   </>
                 ) : (
-                  <div className="flex h-full w-full items-center justify-center text-sm text-slate-400">
+                  <div className="flex h-full w-full items-center justify-center text-sm text-stone-400">
                     Upload a map image to place markers.
                   </div>
                 )}
               </div>
-              <div className="flex h-full min-h-0 flex-col rounded-3xl border border-slate-800/70 bg-slate-900/70">
-                <div className="border-b border-slate-800/70 p-4">
+              <div className="flex h-full min-h-0 flex-col rounded-3xl border border-stone-800/70 bg-stone-900/70">
+                <div className="border-b border-stone-800/70 p-4">
                   <div className="flex items-center justify-between gap-3">
                     <div>
-                      <p className="text-xs uppercase tracking-[0.4em] text-slate-400">Markers</p>
+                      <p className="text-xs uppercase tracking-[0.4em] text-stone-400">Markers</p>
                       <h3 className="text-lg font-semibold text-white">Drag &amp; Drop Points</h3>
                     </div>
                     <button
                       type="button"
                       onClick={handleAddMarker}
-                      className="rounded-full border border-teal-400/60 bg-teal-500/80 px-4 py-2 text-[10px] font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-teal-400/90"
+                      className="rounded-full border border-amber-400/60 bg-amber-500/80 px-4 py-2 text-[10px] font-semibold uppercase tracking-[0.3em] text-stone-900 transition hover:bg-amber-400/90"
                     >
                       Add Marker
                     </button>
                   </div>
-                  <p className="mt-2 text-xs text-slate-500">
+                  <p className="mt-2 text-xs text-stone-500">
                     Create markers and drag them directly onto the map. Use notes to capture quick reminders.
                   </p>
                 </div>
@@ -962,8 +962,8 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                         key={marker.id}
                         className={`rounded-2xl border px-4 py-3 transition ${
                           isExpanded
-                            ? 'border-teal-400/60 bg-slate-950/80'
-                            : 'border-slate-800/70 bg-slate-950/70'
+                            ? 'border-amber-400/60 bg-stone-950/80'
+                            : 'border-stone-800/70 bg-stone-950/70'
                         }`}
                       >
                         <button
@@ -976,13 +976,13 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                         >
                           <div>
                             <p className="text-sm font-semibold text-white">{marker.label || 'Marker'}</p>
-                            <div className="mt-1 flex flex-wrap items-center gap-3 text-[10px] uppercase tracking-[0.35em] text-slate-500">
+                            <div className="mt-1 flex flex-wrap items-center gap-3 text-[10px] uppercase tracking-[0.35em] text-stone-500">
                               <span>
                                 Position: {Math.round(marker.x * 100)}% × {Math.round(marker.y * 100)}%
                               </span>
                               <span className="flex items-center gap-2">
                                 <span
-                                  className="h-3 w-3 rounded-full border border-slate-700/70"
+                                  className="h-3 w-3 rounded-full border border-stone-700/70"
                                   style={{ backgroundColor: marker.color || '#facc15' }}
                                 />
                                 <span>{marker.color}</span>
@@ -991,7 +991,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                           </div>
                           <span
                             className={`text-[10px] uppercase tracking-[0.35em] ${
-                              isExpanded ? 'text-teal-200' : 'text-slate-400'
+                              isExpanded ? 'text-amber-200' : 'text-stone-400'
                             }`}
                           >
                             {isExpanded ? 'Hide' : 'Edit'}
@@ -999,7 +999,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                         </button>
                         {isExpanded && (
                           <div className="mt-3 space-y-3">
-                            <label className="block text-[10px] uppercase tracking-[0.4em] text-slate-500">
+                            <label className="block text-[10px] uppercase tracking-[0.4em] text-stone-500">
                               Label
                               <input
                                 type="text"
@@ -1007,12 +1007,12 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                                 onChange={(event) =>
                                   handleMarkerChange(marker.id, 'label', event.target.value)
                                 }
-                                className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-3 py-2 text-xs text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                                className="mt-2 w-full rounded-xl border border-stone-800/60 bg-stone-950/70 px-3 py-2 text-xs text-stone-100 placeholder:text-stone-600 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/40"
                                 placeholder="Secret Door"
                               />
                             </label>
                             <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_140px]">
-                              <label className="block text-[10px] uppercase tracking-[0.4em] text-slate-500">
+                              <label className="block text-[10px] uppercase tracking-[0.4em] text-stone-500">
                                 Notes
                                 <textarea
                                   value={marker.notes}
@@ -1020,11 +1020,11 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                                     handleMarkerChange(marker.id, 'notes', event.target.value)
                                   }
                                   rows={2}
-                                  className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-3 py-2 text-xs text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                                  className="mt-2 w-full rounded-xl border border-stone-800/60 bg-stone-950/70 px-3 py-2 text-xs text-stone-100 placeholder:text-stone-600 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/40"
                                   placeholder="Trap trigger, treasure cache, etc."
                                 />
                               </label>
-                              <label className="block text-[10px] uppercase tracking-[0.4em] text-slate-500">
+                              <label className="block text-[10px] uppercase tracking-[0.4em] text-stone-500">
                                 Color
                                 <input
                                   type="text"
@@ -1032,7 +1032,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                                   onChange={(event) =>
                                     handleMarkerChange(marker.id, 'color', event.target.value)
                                   }
-                                  className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-3 py-2 text-xs text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                                  className="mt-2 w-full rounded-xl border border-stone-800/60 bg-stone-950/70 px-3 py-2 text-xs text-stone-100 placeholder:text-stone-600 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/40"
                                   placeholder="#facc15"
                                 />
                               </label>
@@ -1052,7 +1052,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                     );
                   })}
                   {markers.length === 0 && (
-                    <div className="rounded-2xl border border-dashed border-slate-700/70 px-4 py-8 text-center text-xs text-slate-500">
+                    <div className="rounded-2xl border border-dashed border-stone-700/70 px-4 py-8 text-center text-xs text-stone-500">
                       No markers yet. Add a marker to start placing points of interest.
                     </div>
                   )}
@@ -1063,12 +1063,12 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
           </div>
         </div>
       </main>
-      <footer className="mt-0.5 border-t border-slate-800/70 px-5 py-1.5">
+      <footer className="mt-0.5 border-t border-stone-800/70 px-5 py-1.5">
         <div className="flex flex-wrap items-center justify-between gap-2">
           <button
             type="button"
             onClick={handleBack}
-            className="rounded-full border border-slate-700/70 px-4 py-1.5 text-[11px] font-semibold uppercase tracking-[0.3em] text-slate-300 transition hover:border-teal-400/60 hover:text-teal-200"
+            className="rounded-full border border-stone-700/70 px-4 py-1.5 text-[11px] font-semibold uppercase tracking-[0.3em] text-stone-300 transition hover:border-amber-400/60 hover:text-amber-200"
           >
             {step === 0 ? 'Cancel' : 'Back'}
           </button>
@@ -1081,8 +1081,8 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                 onClick={handleContinue}
                 className={`rounded-full border px-5 py-1.5 text-[11px] font-semibold uppercase tracking-[0.3em] transition ${
                   allowNext
-                    ? 'border-teal-400/60 bg-teal-500/80 text-slate-900 hover:bg-teal-400/90'
-                    : 'cursor-not-allowed border-slate-800/70 bg-slate-900/70 text-slate-500'
+                    ? 'border-amber-400/60 bg-amber-500/80 text-stone-900 hover:bg-amber-400/90'
+                    : 'cursor-not-allowed border-stone-800/70 bg-stone-900/70 text-stone-500'
                 }`}
               >
                 Next
@@ -1094,8 +1094,8 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                 disabled={creating}
                 className={`rounded-full border px-5 py-1.5 text-[11px] font-semibold uppercase tracking-[0.3em] transition ${
                   creating
-                    ? 'cursor-wait border-slate-800/70 bg-slate-900/70 text-slate-500'
-                    : 'border-teal-400/60 bg-teal-500/80 text-slate-900 hover:bg-teal-400/90'
+                    ? 'cursor-wait border-stone-800/70 bg-stone-900/70 text-stone-500'
+                    : 'border-amber-400/60 bg-amber-500/80 text-stone-900 hover:bg-amber-400/90'
                 }`}
               >
                 {creating ? 'Creating…' : 'Create Map'}

--- a/apps/pages/src/components/MapFolderList.tsx
+++ b/apps/pages/src/components/MapFolderList.tsx
@@ -77,23 +77,23 @@ const MapFolderList: React.FC<MapFolderListProps> = ({
   };
 
   return (
-    <div className="rounded-2xl border border-slate-800/70 bg-slate-900/70 p-5">
+    <div className="rounded-2xl border border-amber-900/30 bg-amber-100/70 p-5 shadow-md shadow-amber-900/20 dark:border-amber-500/30 dark:bg-amber-900/40">
       <div className="mb-6 flex flex-wrap items-center justify-between gap-4">
         <div>
-          <p className="text-xs uppercase tracking-[0.4em] text-slate-400">Maps</p>
-          <h3 className="text-2xl font-bold text-white">Campaign Atlas</h3>
-          <p className="text-sm text-slate-400">Organize maps into folders to keep your encounters tidy.</p>
+          <p className="text-xs uppercase tracking-[0.4em] text-amber-900/70 dark:text-amber-200/70">Maps</p>
+          <h3 className="text-2xl font-bold text-amber-900 dark:text-amber-100">Campaign Atlas</h3>
+          <p className="text-sm text-amber-900/70 dark:text-amber-200/70">Organize maps into folders to keep your encounters tidy.</p>
         </div>
         <button
           type="button"
           onClick={onCreateMap}
-          className="rounded-xl border border-teal-400/60 bg-teal-500/80 px-5 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-teal-400/90"
+          className="rounded-xl border border-amber-900/40 bg-gradient-to-r from-amber-500 via-orange-500 to-rose-500 px-5 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-amber-50 transition hover:scale-105"
         >
           New Map
         </button>
       </div>
       {grouped.length === 0 ? (
-        <div className="rounded-xl border border-dashed border-slate-700/70 px-6 py-12 text-center text-sm text-slate-400">
+        <div className="rounded-xl border border-dashed border-amber-900/30 px-6 py-12 text-center text-sm text-amber-900/70 dark:border-amber-500/30 dark:text-amber-200/70">
           No maps yet. Create a map to start building your world.
         </div>
       ) : (
@@ -101,7 +101,7 @@ const MapFolderList: React.FC<MapFolderListProps> = ({
           {grouped.map((group) => {
             const expanded = expandedGroups[group.name];
             return (
-              <div key={group.name} className="rounded-2xl border border-slate-800/70 bg-slate-950/70 shadow-lg">
+              <div key={group.name} className="rounded-2xl border border-amber-900/30 bg-amber-50/80 shadow-lg shadow-amber-900/15 dark:border-amber-500/30 dark:bg-amber-900/40">
                 <div className="flex items-start justify-between gap-3 px-5 py-4 sm:items-center">
                   <button
                     type="button"
@@ -109,12 +109,12 @@ const MapFolderList: React.FC<MapFolderListProps> = ({
                     className="flex w-full flex-1 items-center justify-between gap-4 text-left"
                   >
                     <div>
-                      <p className="text-lg font-semibold text-white">{group.name}</p>
-                      <p className="text-[10px] uppercase tracking-[0.4em] text-slate-500">{group.maps.length} Maps</p>
+                      <p className="text-lg font-semibold text-amber-900 dark:text-amber-100">{group.name}</p>
+                      <p className="text-[10px] uppercase tracking-[0.4em] text-amber-900/70 dark:text-amber-200/70">{group.maps.length} Maps</p>
                     </div>
                     <span
-                      className={`inline-flex h-8 w-8 items-center justify-center rounded-full border border-slate-700/70 text-xs font-bold text-slate-300 transition ${
-                        expanded ? 'bg-teal-500/10 text-teal-200' : 'bg-slate-900'
+                      className={`inline-flex h-8 w-8 items-center justify-center rounded-full border border-amber-900/30 text-xs font-bold text-amber-900 transition dark:border-amber-500/30 dark:text-amber-100 ${
+                        expanded ? 'bg-amber-200/70 dark:bg-amber-900/60' : 'bg-amber-100/60 dark:bg-amber-950/40'
                       }`}
                       aria-hidden="true"
                     >
@@ -123,7 +123,7 @@ const MapFolderList: React.FC<MapFolderListProps> = ({
                   </button>
                   <button
                     type="button"
-                    className="rounded-full border border-rose-400/60 bg-rose-500/20 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.3em] text-rose-200 transition hover:bg-rose-500/30"
+                    className="rounded-full border border-rose-500/60 bg-rose-500/20 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.3em] text-rose-900 transition hover:bg-rose-500/30 focus-visible:outline focus-visible:outline-rose-500 dark:border-rose-400/60 dark:bg-rose-500/30 dark:text-rose-100"
                     onClick={(event) => {
                       event.stopPropagation();
                       onDeleteGroup(group.name, group.maps);
@@ -135,7 +135,7 @@ const MapFolderList: React.FC<MapFolderListProps> = ({
                   </button>
                 </div>
                 {expanded && (
-                  <div className="grid gap-4 border-t border-slate-800/60 px-5 py-5 sm:grid-cols-2 xl:grid-cols-3">
+                  <div className="grid gap-4 border-t border-amber-900/30 px-5 py-5 sm:grid-cols-2 xl:grid-cols-3 dark:border-amber-500/30">
                     {group.maps.map((map) => {
                       const description = getMetadataString(map.metadata, 'description');
                       const notes = getMetadataString(map.metadata, 'notes');
@@ -153,16 +153,16 @@ const MapFolderList: React.FC<MapFolderListProps> = ({
                               onSelect(map);
                             }
                           }}
-                          className={`group relative overflow-hidden rounded-2xl border px-5 py-6 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-teal-400/60 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 ${
+                          className={`group relative overflow-hidden rounded-2xl border px-5 py-6 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/40 focus-visible:ring-offset-2 focus-visible:ring-offset-amber-100 dark:focus-visible:ring-offset-amber-900 ${
                             selectedMapId === map.id
-                              ? 'border-teal-400 bg-teal-500/10 shadow-[0_0_0_1px_rgba(45,212,191,0.4)]'
-                              : 'border-slate-800/60 bg-slate-950/60 hover:border-teal-400/60 hover:shadow-[0_0_0_1px_rgba(45,212,191,0.3)]'
+                              ? 'border-amber-600 bg-amber-200/60 shadow-[0_0_0_1px_rgba(217,119,6,0.4)] dark:bg-amber-900/50'
+                              : 'border-amber-900/30 bg-amber-50/80 hover:border-amber-600/50 hover:shadow-[0_0_0_1px_rgba(217,119,6,0.35)] dark:border-amber-500/30 dark:bg-amber-900/40'
                           }`}
                         >
                           <div className="absolute right-4 top-4 flex items-center gap-2">
                             <button
                               type="button"
-                              className="rounded-full border border-rose-400/60 bg-rose-500/20 px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.3em] text-rose-200 transition hover:bg-rose-500/30"
+                              className="rounded-full border border-rose-500/60 bg-rose-500/20 px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.3em] text-rose-900 transition hover:bg-rose-500/30 focus-visible:outline focus-visible:outline-rose-500 dark:border-rose-400/60 dark:bg-rose-500/30 dark:text-rose-100"
                               onClick={(event) => {
                                 event.stopPropagation();
                                 onDeleteMap(map);
@@ -174,34 +174,31 @@ const MapFolderList: React.FC<MapFolderListProps> = ({
                               ✕
                             </button>
                           </div>
-                          <div className="mb-4 flex items-center justify-between text-xs uppercase tracking-[0.4em] text-slate-500">
+                          <div className="mb-4 flex items-center justify-between text-xs uppercase tracking-[0.4em] text-amber-900/60 dark:text-amber-200/60">
                             <span>Map</span>
                             <span>
                               {map.width ?? '—'} × {map.height ?? '—'}
                             </span>
                           </div>
-                          <h4 className="text-lg font-semibold text-white">{map.name}</h4>
-                          {description && <p className="mt-2 text-sm text-slate-300">{description}</p>}
-                          {notes && !description && <p className="mt-2 text-sm text-slate-400">{notes}</p>}
+                          <h4 className="text-lg font-semibold text-amber-900 dark:text-amber-100">{map.name}</h4>
+                          {description && <p className="mt-2 text-sm text-amber-900/80 dark:text-amber-200/80">{description}</p>}
+                          {notes && !description && <p className="mt-2 text-sm text-amber-900/70 dark:text-amber-200/70">{notes}</p>}
                           {tags.length > 0 && (
                             <div className="mt-4 flex flex-wrap gap-2">
                               {tags.map((tag) => (
                                 <span
                                   key={tag}
-                                  className="inline-flex items-center rounded-full border border-slate-700/70 bg-slate-900/70 px-2 py-1 text-[10px] uppercase tracking-[0.3em] text-slate-300"
+                                  className="inline-flex items-center rounded-full border border-amber-900/30 bg-amber-100/70 px-2 py-1 text-[10px] uppercase tracking-[0.3em] text-amber-900 dark:border-amber-500/30 dark:bg-amber-900/50 dark:text-amber-100"
                                 >
                                   {tag}
                                 </span>
                               ))}
                             </div>
                           )}
-                          <div className="pointer-events-none absolute inset-0 rounded-2xl border border-white/5 transition group-hover:border-white/10" />
+                          <div className="pointer-events-none absolute inset-0 rounded-2xl border border-white/10 transition group-hover:border-white/20" />
                           <div className="pointer-events-none absolute inset-0 opacity-0 transition group-hover:opacity-100">
-                            <div
-                              className="absolute inset-0 bg-cover bg-center opacity-20"
-                              style={{ backgroundImage: `url(${apiClient.buildMapDisplayUrl(map.id)})` }}
-                            />
-                            <div className="absolute inset-0 bg-gradient-to-t from-slate-950 via-transparent to-transparent" />
+                            <div className="absolute inset-0 bg-cover bg-center opacity-20" style={{ backgroundImage: `url(${apiClient.buildMapDisplayUrl(map.id)})` }} />
+                            <div className="absolute inset-0 bg-gradient-to-t from-amber-900/60 via-transparent to-transparent" />
                           </div>
                         </div>
                       );

--- a/apps/pages/src/components/TorchLogo.tsx
+++ b/apps/pages/src/components/TorchLogo.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+
+interface TorchLogoProps {
+  theme: 'light' | 'dark';
+  label?: string;
+  className?: string;
+  showTagline?: boolean;
+  tagline?: string;
+}
+
+const combineClasses = (...classes: Array<string | undefined | false | null>) =>
+  classes.filter(Boolean).join(' ');
+
+const TorchLogo: React.FC<TorchLogoProps> = ({
+  theme,
+  label = 'TableTorch',
+  className,
+  showTagline = true,
+  tagline = 'Ignite every tabletop reveal.',
+}) => {
+  const haloStyles: React.CSSProperties | undefined =
+    theme === 'dark'
+      ? {
+          background: 'radial-gradient(circle, rgba(253, 230, 138, 0.55) 0%, rgba(253, 230, 138, 0) 70%)',
+        }
+      : undefined;
+
+  return (
+    <div className={combineClasses('relative flex items-center gap-4', className)}>
+      <div className="relative">
+        {theme === 'dark' && (
+          <span
+            aria-hidden
+            className="pointer-events-none absolute -inset-3 rounded-full opacity-80"
+            style={haloStyles}
+          />
+        )}
+        <div className="relative flex h-14 w-14 items-center justify-center rounded-full bg-amber-200/80 text-2xl shadow-inner shadow-amber-900/30 ring-2 ring-amber-900/20 dark:bg-amber-300/30 dark:text-amber-100 dark:shadow-amber-900/70 dark:ring-amber-500/30">
+          <span aria-hidden role="img">
+            🔥
+          </span>
+          <span className="sr-only">{label}</span>
+        </div>
+      </div>
+      <div className="space-y-1">
+        <p className="text-xs font-semibold uppercase tracking-[0.45em] text-amber-800/80 dark:text-amber-200/70">{label}</p>
+        {showTagline && <p className="text-lg font-semibold text-stone-900 dark:text-amber-100">{tagline}</p>}
+      </div>
+    </div>
+  );
+};
+
+export default TorchLogo;


### PR DESCRIPTION
## Summary
- replace Fog of War copy with TableTorch messaging and parchment visuals on the landing page
- introduce a reusable TorchLogo component and parchment backgrounds across authenticated views
- retheme campaign management, session tools, and wizards to the warm TableTorch palette and imagery

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dafbf9ba008323aae9b6bb3d80768a