### PR TITLE
Retheme TableTorch surfaces with parchment styling

### DIFF
--- a/apps/pages/src/App.tsx
+++ b/apps/pages/src/App.tsx
@@ -539,8 +539,8 @@ const App: React.FC = () => {
   const navButtonClasses = (view: 'join' | 'manage' | 'create' | 'admin') =>
     `group flex w-full items-center justify-between rounded-2xl border px-5 py-4 text-left text-sm font-semibold uppercase tracking-[0.3em] transition ${
       activeView === view
-        ? 'border-teal-400 bg-teal-400/90 text-slate-900 shadow-lg shadow-teal-500/40'
-        : 'border-slate-800/70 bg-slate-900/60 text-slate-300 hover:border-teal-400/60 hover:bg-slate-800/80'
+        ? 'border-amber-400 bg-amber-400/90 text-slate-900 shadow-lg shadow-amber-500/40'
+        : 'border-slate-800/70 bg-slate-900/60 text-slate-300 hover:border-amber-400/60 hover:bg-slate-800/80 hover:text-amber-200'
     }`;
 
   if (!token || !user) {
@@ -549,21 +549,21 @@ const App: React.FC = () => {
 
   if (activeSession) {
     return (
-      <div className="min-h-screen bg-slate-100 p-6 dark:bg-slate-900">
+      <div className="min-h-screen bg-amber-50 p-6 dark:bg-slate-900">
         <div className="mb-4 flex items-center justify-between">
           <div>
-            <h1 className="text-2xl font-bold text-primary">D&D Map Reveal</h1>
+            <h1 className="text-2xl font-bold text-amber-700 dark:text-amber-300">TableTorch</h1>
             <p className="text-sm text-slate-500 dark:text-slate-400">Logged in as {user.displayName}</p>
           </div>
           <div className="flex items-center gap-2">
             <button
-              className="rounded-full border border-slate-300 px-3 py-1 text-xs hover:bg-slate-100 dark:border-slate-600 dark:hover:bg-slate-700"
+              className="rounded-full border border-amber-300 px-3 py-1 text-xs text-amber-700 transition hover:bg-amber-100 dark:border-amber-500/40 dark:text-amber-200 dark:hover:bg-slate-800"
               onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
             >
               {themeLabel}
             </button>
             <button
-              className="rounded-full border border-slate-300 px-3 py-1 text-xs hover:bg-slate-100 dark:border-slate-600 dark:hover:bg-slate-700"
+              className="rounded-full border border-amber-300 px-3 py-1 text-xs text-amber-700 transition hover:bg-amber-100 dark:border-amber-500/40 dark:text-amber-200 dark:hover:bg-slate-800"
               onClick={handleLogout}
             >
               Logout
@@ -571,7 +571,7 @@ const App: React.FC = () => {
           </div>
         </div>
         {statusMessage && (
-          <div className="mb-4 rounded border border-slate-200 bg-white px-4 py-2 text-sm text-slate-600 shadow dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200">
+          <div className="mb-4 rounded border border-amber-200 bg-white px-4 py-2 text-sm text-slate-600 shadow dark:border-amber-500/40 dark:bg-slate-800 dark:text-slate-200">
             {statusMessage}
           </div>
         )}
@@ -593,46 +593,46 @@ const App: React.FC = () => {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 text-slate-100">
+    <div className="min-h-screen bg-gradient-to-br from-[#150d06] via-slate-950 to-[#090807] text-slate-100">
       <div className="mx-auto flex min-h-screen max-w-6xl flex-col gap-6 px-4 py-8 md:flex-row md:py-12">
-        <aside className="flex flex-col gap-6 rounded-3xl border border-slate-800/70 bg-slate-950/70 p-6 shadow-2xl md:w-72">
+        <aside className="flex flex-col gap-6 rounded-3xl border border-amber-500/30 bg-slate-950/70 p-6 shadow-2xl shadow-amber-500/10 md:w-72">
           <div>
-            <p className="text-xs uppercase tracking-[0.4em] text-slate-500">Mission Control</p>
-            <h2 className="mt-3 text-2xl font-black uppercase tracking-wide text-teal-300">Command Deck</h2>
+            <p className="text-xs uppercase tracking-[0.4em] text-amber-300/80">Torchlight Hub</p>
+            <h2 className="mt-3 text-2xl font-black uppercase tracking-wide text-amber-300">Keeper's Desk</h2>
           </div>
-          <div className="rounded-2xl border border-slate-800/70 bg-slate-900/70 p-4">
+          <div className="rounded-2xl border border-amber-500/20 bg-slate-900/70 p-4">
             <p className="text-xs uppercase tracking-[0.5em] text-slate-500">Logged in</p>
             <p className="mt-2 text-lg font-semibold text-white">{user.displayName}</p>
-            <p className="text-xs text-slate-500">Ready for launch</p>
+            <p className="text-xs text-slate-500">Lantern lit</p>
           </div>
           <nav className="space-y-3">
             <button className={navButtonClasses('join')} onClick={() => setActiveView('join')}>
               <span>Join Campaign</span>
-              <span className="text-[10px] tracking-[0.4em] text-slate-900/70 transition group-hover:text-slate-900/90">START</span>
+              <span className="text-[10px] tracking-[0.4em] text-slate-900/70 transition group-hover:text-slate-900/90">GLOW</span>
             </button>
             <button className={navButtonClasses('manage')} onClick={() => setActiveView('manage')}>
               <span>Manage Campaigns</span>
-              <span className="text-[10px] tracking-[0.4em] text-slate-900/70 transition group-hover:text-slate-900/90">HANGAR</span>
+              <span className="text-[10px] tracking-[0.4em] text-slate-900/70 transition group-hover:text-slate-900/90">TEND</span>
             </button>
             <button className={navButtonClasses('create')} onClick={() => setActiveView('create')}>
               <span>Create Campaign</span>
-              <span className="text-[10px] tracking-[0.4em] text-slate-900/70 transition group-hover:text-slate-900/90">NEW</span>
+              <span className="text-[10px] tracking-[0.4em] text-slate-900/70 transition group-hover:text-slate-900/90">SPARK</span>
             </button>
           </nav>
           <div className="mt-auto space-y-2 text-xs text-slate-500">
-            <p>Need a room code? Ask your DM to share their campaign key.</p>
-            <p>Switch tabs to manage, create, or join adventures.</p>
+            <p>Need a room code? Ask your DM to pass along their TableTorch key.</p>
+            <p>Use the tabs to tend the flame, prepare new scenes, or join the glow.</p>
           </div>
         </aside>
         <section className="flex-1 space-y-6">
-          <header className="flex flex-wrap items-center justify-between gap-3 rounded-3xl border border-slate-800/70 bg-slate-950/70 px-6 py-4 shadow-xl">
+          <header className="flex flex-wrap items-center justify-between gap-3 rounded-3xl border border-amber-500/30 bg-slate-950/70 px-6 py-4 shadow-xl shadow-amber-500/10">
             <div>
-              <p className="text-xs uppercase tracking-[0.5em] text-teal-300">Campaign Control</p>
-              <h1 className="text-3xl font-black uppercase tracking-wide text-white">D&D Map Reveal</h1>
+              <p className="text-xs uppercase tracking-[0.5em] text-amber-300">Lantern Control</p>
+              <h1 className="text-3xl font-black uppercase tracking-wide text-white">TableTorch</h1>
             </div>
             <div className="flex items-center gap-3">
               <button
-                className="rounded-full border border-teal-400/60 bg-teal-400/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-teal-200 transition hover:bg-teal-400/20"
+                className="rounded-full border border-amber-400/60 bg-amber-400/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-amber-200 transition hover:bg-amber-400/20"
                 onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
               >
                 {themeLabel}
@@ -646,14 +646,14 @@ const App: React.FC = () => {
             </div>
           </header>
           {statusMessage && (
-            <div className="rounded-3xl border border-teal-500/40 bg-teal-500/10 px-5 py-3 text-sm text-teal-200 shadow-lg shadow-teal-500/10">
+            <div className="rounded-3xl border border-amber-500/40 bg-amber-500/10 px-5 py-3 text-sm text-amber-200 shadow-lg shadow-amber-500/10">
               {statusMessage}
             </div>
           )}
           <div className="flex-1 rounded-3xl border border-slate-800/70 bg-slate-950/70 p-6 shadow-2xl">
             {activeView === 'join' && (
               <div className="space-y-6">
-                <h2 className="text-3xl font-black uppercase tracking-wide text-teal-200">Join Campaign</h2>
+                <h2 className="text-3xl font-black uppercase tracking-wide text-amber-200">Join Campaign</h2>
                 <p className="max-w-xl text-sm text-slate-300">
                   Enter the campaign key provided by your Dungeon Master to hop into their room.
                 </p>
@@ -665,11 +665,11 @@ const App: React.FC = () => {
                         value={joinKey}
                         onChange={(event) => setJoinKey(event.target.value)}
                         placeholder="e.g. A1B2C3"
-                        className="flex-1 rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm uppercase tracking-[0.3em] text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                        className="flex-1 rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm uppercase tracking-[0.3em] text-slate-100 placeholder:text-slate-600 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/40"
                       />
                       <button
                         type="submit"
-                        className="rounded-xl border border-teal-400/60 bg-teal-500/80 px-6 py-3 text-sm font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-teal-400/90 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                        className="rounded-xl border border-amber-400/60 bg-amber-500/80 px-6 py-3 text-sm font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-amber-400/90 focus:outline-none focus:ring-2 focus:ring-amber-400/40"
                       >
                         Join Room
                       </button>
@@ -682,7 +682,7 @@ const App: React.FC = () => {
                     <h3 className="text-xs uppercase tracking-[0.4em] text-slate-400">Active Rooms</h3>
                     <button
                       type="button"
-                      className="text-xs font-semibold uppercase tracking-[0.3em] text-teal-200 transition hover:text-teal-100"
+                      className="text-xs font-semibold uppercase tracking-[0.3em] text-amber-200 transition hover:text-amber-100"
                       onClick={refreshLobby}
                     >
                       Refresh
@@ -698,7 +698,7 @@ const App: React.FC = () => {
                           </div>
                           <button
                             type="button"
-                            className="rounded-lg border border-teal-400/60 bg-teal-500/80 px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-teal-400/90"
+                            className="rounded-lg border border-amber-400/60 bg-amber-500/80 px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-amber-400/90"
                             onClick={() => handleJoinSession(session)}
                           >
                             Join
@@ -722,12 +722,12 @@ const App: React.FC = () => {
               <div className="space-y-6">
                 <div className="flex flex-wrap items-center justify-between gap-3">
                   <div>
-                    <h2 className="text-3xl font-black uppercase tracking-wide text-teal-200">Manage Campaigns</h2>
-                    <p className="text-sm text-slate-300">Select a campaign to open the admin hangar.</p>
+                    <h2 className="text-3xl font-black uppercase tracking-wide text-amber-200">Manage Campaigns</h2>
+                    <p className="text-sm text-slate-300">Select a campaign to open the keeper's vault.</p>
                   </div>
                   <button
                     type="button"
-                    className="rounded-full border border-teal-400/60 px-5 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-teal-200 transition hover:bg-teal-500/20"
+                    className="rounded-full border border-amber-400/60 px-5 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-amber-200 transition hover:bg-amber-500/20"
                     onClick={() => refreshCampaigns()}
                   >
                     Refresh
@@ -737,7 +737,7 @@ const App: React.FC = () => {
                   {campaigns.map((campaign) => (
                     <button
                       key={campaign.id}
-                      className="group flex h-full flex-col justify-between rounded-2xl border border-slate-800/70 bg-slate-950/60 p-4 text-left transition hover:border-teal-400/60 hover:bg-slate-900/70"
+                      className="group flex h-full flex-col justify-between rounded-2xl border border-slate-800/70 bg-slate-950/60 p-4 text-left transition hover:border-amber-400/60 hover:bg-slate-900/70"
                       onClick={() => handleOpenCampaignAdmin(campaign)}
                     >
                       <div>
@@ -745,8 +745,8 @@ const App: React.FC = () => {
                         <h3 className="mt-2 text-lg font-semibold text-white">{campaign.name}</h3>
                         <p className="mt-2 text-xs text-slate-400">{campaign.description || 'No description provided.'}</p>
                       </div>
-                      <span className="mt-4 inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.3em] text-teal-200">
-                        Open Hangar <span aria-hidden>→</span>
+                      <span className="mt-4 inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.3em] text-amber-200">
+                        Open Vault <span aria-hidden>→</span>
                       </span>
                     </button>
                   ))}
@@ -760,7 +760,7 @@ const App: React.FC = () => {
             )}
             {activeView === 'create' && (
               <div className="space-y-6">
-                <h2 className="text-3xl font-black uppercase tracking-wide text-teal-200">Create Campaign</h2>
+                <h2 className="text-3xl font-black uppercase tracking-wide text-amber-200">Create Campaign</h2>
                 <p className="max-w-xl text-sm text-slate-300">Set up a new campaign for your players and start building encounters.</p>
                 <form onSubmit={handleCreateCampaign} className="space-y-5">
                   <div>
@@ -768,7 +768,7 @@ const App: React.FC = () => {
                     <input
                       value={newCampaignName}
                       onChange={(event) => setNewCampaignName(event.target.value)}
-                      className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                      className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/40"
                       placeholder="Give your mission a title"
                     />
                   </div>
@@ -778,7 +778,7 @@ const App: React.FC = () => {
                       value={newCampaignDescription}
                       onChange={(event) => setNewCampaignDescription(event.target.value)}
                       rows={4}
-                      className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                      className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/40"
                       placeholder="Share a quick briefing for your players"
                     />
                   </div>
@@ -787,7 +787,7 @@ const App: React.FC = () => {
                       type="checkbox"
                       checked={newCampaignPublic}
                       onChange={(event) => setNewCampaignPublic(event.target.checked)}
-                      className="h-4 w-4 rounded border border-slate-700 bg-slate-900 text-teal-400 focus:ring-teal-400"
+                      className="h-4 w-4 rounded border border-slate-700 bg-slate-900 text-amber-400 focus:ring-amber-400"
                     />
                     <span className="text-slate-300">List publicly for players to discover</span>
                   </label>
@@ -795,13 +795,13 @@ const App: React.FC = () => {
                   <div className="flex flex-wrap gap-3">
                     <button
                       type="submit"
-                      className="rounded-xl border border-teal-400/60 bg-teal-500/80 px-6 py-3 text-sm font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-teal-400/90"
+                      className="rounded-xl border border-amber-400/60 bg-amber-500/80 px-6 py-3 text-sm font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-amber-400/90"
                     >
-                      Launch Campaign
+                      Ignite Campaign
                     </button>
                     <button
                       type="button"
-                      className="rounded-xl border border-slate-700/70 px-6 py-3 text-sm font-semibold uppercase tracking-[0.3em] text-slate-300 transition hover:border-teal-400/60 hover:text-teal-200"
+                      className="rounded-xl border border-slate-700/70 px-6 py-3 text-sm font-semibold uppercase tracking-[0.3em] text-slate-300 transition hover:border-amber-400/60 hover:text-amber-200"
                       onClick={() => {
                         setNewCampaignName('');
                         setNewCampaignDescription('');
@@ -819,14 +819,14 @@ const App: React.FC = () => {
               <div className="space-y-6">
                 <div className="flex flex-wrap items-center justify-between gap-3">
                   <div>
-                    <p className="text-xs uppercase tracking-[0.4em] text-teal-300">Managing Campaign</p>
+                    <p className="text-xs uppercase tracking-[0.4em] text-amber-300">Managing Campaign</p>
                     <h2 className="text-3xl font-black uppercase tracking-wide text-white">{selectedCampaign.name}</h2>
                     {selectedCampaign.description && <p className="text-sm text-slate-300">{selectedCampaign.description}</p>}
                   </div>
                   <div className="flex flex-wrap items-center gap-3">
                     <button
                       type="button"
-                      className="rounded-full border border-slate-700/70 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-300 transition hover:border-teal-400/60 hover:text-teal-200"
+                      className="rounded-full border border-slate-700/70 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-300 transition hover:border-amber-400/60 hover:text-amber-200"
                       onClick={handleBackToManage}
                     >
                       Campaign List
@@ -840,10 +840,10 @@ const App: React.FC = () => {
                     </button>
                     <button
                       type="button"
-                      className="rounded-full border border-teal-400/60 bg-teal-500/80 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-teal-400/90"
+                      className="rounded-full border border-amber-400/60 bg-amber-500/80 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-amber-400/90"
                       onClick={handleStartSession}
                     >
-                      Launch Session
+                      Ignite Session
                     </button>
                   </div>
                 </div>
@@ -888,7 +888,7 @@ const App: React.FC = () => {
                           <div className="mt-6 grid gap-4 lg:grid-cols-2">
                             <div className="rounded-2xl border border-slate-800/70 bg-slate-950/70 p-4">
                               <p className="text-[10px] uppercase tracking-[0.4em] text-slate-500">Grouping</p>
-                              <p className="mt-2 text-sm font-semibold text-teal-200">{mapGrouping}</p>
+                              <p className="mt-2 text-sm font-semibold text-amber-200">{mapGrouping}</p>
                               {mapNotes && mapDescription && (
                                 <p className="mt-3 text-xs text-slate-400">Notes: {mapNotes}</p>
                               )}
@@ -933,7 +933,7 @@ const App: React.FC = () => {
                             <li key={session.id}>
                               <button
                                 onClick={() => handleJoinSession(session)}
-                                className="w-full rounded-xl border border-slate-800/70 bg-slate-950/60 px-3 py-2 text-left text-slate-300 transition hover:border-teal-400/60 hover:text-teal-100"
+                                className="w-full rounded-xl border border-slate-800/70 bg-slate-950/60 px-3 py-2 text-left text-slate-300 transition hover:border-amber-400/60 hover:text-amber-100"
                               >
                                 {session.name}
                               </button>
@@ -951,7 +951,7 @@ const App: React.FC = () => {
                           <h3 className="text-xs uppercase tracking-[0.4em] text-slate-400">Lobby</h3>
                           <button
                             type="button"
-                            className="text-xs font-semibold uppercase tracking-[0.3em] text-teal-200 transition hover:text-teal-100"
+                            className="text-xs font-semibold uppercase tracking-[0.3em] text-amber-200 transition hover:text-amber-100"
                             onClick={refreshLobby}
                           >
                             Refresh
@@ -965,7 +965,7 @@ const App: React.FC = () => {
                               <p className="text-[10px] uppercase tracking-[0.4em] text-slate-500">Map: {session.mapName ?? 'Unknown'}</p>
                               <button
                                 type="button"
-                                className="mt-3 w-full rounded-xl border border-teal-400/60 bg-teal-500/80 px-3 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-teal-400/90"
+                                className="mt-3 w-full rounded-xl border border-amber-400/60 bg-amber-500/80 px-3 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-amber-400/90"
                                 onClick={() => handleJoinSession(session)}
                               >
                                 Join as {session.hostId === user.id ? 'DM' : 'Player'}

--- a/apps/pages/src/components/AuthPanel.tsx
+++ b/apps/pages/src/components/AuthPanel.tsx
@@ -50,21 +50,21 @@ const AuthPanel: React.FC<AuthPanelProps> = ({ onAuthenticate, className, varian
     className
   );
 
-  const badgeText = mode === 'login' ? 'Return to the table' : 'Create a DM profile';
-  const headingText = mode === 'login' ? 'Sign in to D&D Map Reveal' : 'Join the D&D Map Reveal beta';
+  const badgeText = mode === 'login' ? 'Return to the light' : 'Kindle a DM profile';
+  const headingText = mode === 'login' ? 'Sign in to TableTorch' : 'Join the TableTorch beta';
   const submitLabel = loading ? 'Please wait…' : mode === 'login' ? 'Log in' : 'Sign up';
   const toggleLabel = mode === 'login' ? 'Need an account?' : 'Already have an account?';
-  const toggleHelper = mode === 'login' ? 'Create one instead' : 'Use your existing login';
+  const toggleHelper = mode === 'login' ? 'Kindle one instead' : 'Use your existing login';
 
   return (
     <section className={containerClasses} aria-labelledby={`${formId}-title`}>
       <span
         aria-hidden
-        className="pointer-events-none absolute -top-28 left-1/2 h-72 w-72 -translate-x-1/2 rounded-full bg-teal-400/20 blur-3xl dark:bg-teal-500/10"
+        className="pointer-events-none absolute -top-28 left-1/2 h-72 w-72 -translate-x-1/2 rounded-full bg-amber-400/20 blur-3xl dark:bg-amber-500/10"
       />
       <div className="relative space-y-8">
         <header className="space-y-3">
-          <span className="inline-flex items-center rounded-full border border-teal-500/40 bg-teal-100/60 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.3em] text-teal-700 shadow-sm dark:border-teal-400/50 dark:bg-teal-500/10 dark:text-teal-200">
+          <span className="inline-flex items-center rounded-full border border-amber-500/40 bg-amber-100/60 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.3em] text-amber-700 shadow-sm dark:border-amber-400/50 dark:bg-amber-500/10 dark:text-amber-200">
             {badgeText}
           </span>
           <div className="flex flex-wrap items-start justify-between gap-4">
@@ -73,13 +73,13 @@ const AuthPanel: React.FC<AuthPanelProps> = ({ onAuthenticate, className, varian
                 {headingText}
               </h2>
               <p className="text-sm text-slate-600 dark:text-slate-300">
-                Use the pre-filled demo credentials or sign up with your own details to explore the DM console.
+                Use the pre-filled demo credentials or sign up with your own details to explore the TableTorch console.
               </p>
             </div>
             <button
               type="button"
               onClick={() => setMode((current) => (current === 'login' ? 'signup' : 'login'))}
-              className="inline-flex items-center rounded-full border border-slate-300/70 bg-white/40 px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-slate-500 transition hover:border-teal-400/60 hover:text-teal-600 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-300 dark:hover:border-teal-400/50 dark:hover:text-teal-200"
+              className="inline-flex items-center rounded-full border border-slate-300/70 bg-white/40 px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-slate-500 transition hover:border-amber-400/60 hover:text-amber-600 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-300 dark:hover:border-amber-400/50 dark:hover:text-amber-200"
               aria-pressed={mode === 'signup'}
             >
               {toggleLabel}
@@ -106,7 +106,7 @@ const AuthPanel: React.FC<AuthPanelProps> = ({ onAuthenticate, className, varian
                 value={email}
                 onChange={(event) => setEmail(event.target.value)}
                 autoComplete="email"
-                className="w-full rounded-2xl border border-slate-300/80 bg-white px-4 py-3 text-sm font-medium text-slate-900 shadow-sm transition focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-400/60 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:focus:border-teal-400"
+                className="w-full rounded-2xl border border-slate-300/80 bg-white px-4 py-3 text-sm font-medium text-slate-900 shadow-sm transition focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-400/60 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:focus:border-amber-400"
                 required
               />
             </div>
@@ -120,7 +120,7 @@ const AuthPanel: React.FC<AuthPanelProps> = ({ onAuthenticate, className, varian
                   value={displayName}
                   onChange={(event) => setDisplayName(event.target.value)}
                   autoComplete="name"
-                  className="w-full rounded-2xl border border-slate-300/80 bg-white px-4 py-3 text-sm font-medium text-slate-900 shadow-sm transition focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-400/60 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:focus:border-teal-400"
+                  className="w-full rounded-2xl border border-slate-300/80 bg-white px-4 py-3 text-sm font-medium text-slate-900 shadow-sm transition focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-400/60 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:focus:border-amber-400"
                   required
                 />
               </div>
@@ -135,7 +135,7 @@ const AuthPanel: React.FC<AuthPanelProps> = ({ onAuthenticate, className, varian
                 value={password}
                 onChange={(event) => setPassword(event.target.value)}
                 autoComplete={mode === 'login' ? 'current-password' : 'new-password'}
-                className="w-full rounded-2xl border border-slate-300/80 bg-white px-4 py-3 text-sm font-medium text-slate-900 shadow-sm transition focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-400/60 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:focus:border-teal-400"
+                className="w-full rounded-2xl border border-slate-300/80 bg-white px-4 py-3 text-sm font-medium text-slate-900 shadow-sm transition focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-400/60 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:focus:border-amber-400"
                 required
               />
             </div>
@@ -148,7 +148,7 @@ const AuthPanel: React.FC<AuthPanelProps> = ({ onAuthenticate, className, varian
           <button
             type="submit"
             disabled={loading}
-            className="flex w-full items-center justify-center gap-2 rounded-2xl bg-gradient-to-r from-teal-500 via-sky-500 to-blue-500 px-5 py-3 text-sm font-semibold uppercase tracking-[0.4em] text-white shadow-lg shadow-teal-500/30 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-white/80 focus-visible:ring-offset-2 focus-visible:ring-offset-teal-500 disabled:cursor-wait disabled:opacity-80"
+            className="flex w-full items-center justify-center gap-2 rounded-2xl bg-gradient-to-r from-amber-500 via-orange-500 to-rose-500 px-5 py-3 text-sm font-semibold uppercase tracking-[0.4em] text-white shadow-lg shadow-amber-500/30 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-white/80 focus-visible:ring-offset-2 focus-visible:ring-offset-amber-500 disabled:cursor-wait disabled:opacity-80"
           >
             {submitLabel}
           </button>

--- a/apps/pages/src/components/LandingPage.tsx
+++ b/apps/pages/src/components/LandingPage.tsx
@@ -10,24 +10,24 @@ interface LandingPageProps {
 
 const features = [
   {
-    title: 'Reveal maps live',
-    description: 'Fade in fog-of-war with precision tools built for dramatic reveals and on-the-fly adjustments.',
-    icon: '🗺️',
+    title: 'Torchlit reveals',
+    description: 'Sweep warm light across battlemaps with layered masks that echo flickering torchlight.',
+    icon: '🔥',
   },
   {
-    title: 'Campaign control',
-    description: 'Organise every battlemap, note and marker by campaign so your prep is ready when players arrive.',
-    icon: '🎯',
+    title: 'Campaign vault',
+    description: 'Keep maps, notes, and tokens organised by campaign so every adventure is ready to ignite.',
+    icon: '📜',
   },
   {
-    title: 'Share instantly',
-    description: 'Invite players with short join codes and let them explore revealed regions from any device.',
-    icon: '⚡',
+    title: 'Table-ready sharing',
+    description: 'Share illuminated views instantly with invite links or join codes that work on any device.',
+    icon: '🪔',
   },
   {
-    title: 'Save your progress',
-    description: 'Archive live sessions and pick up where you left off without losing the dramatic tension.',
-    icon: '🛡️',
+    title: 'Session embers',
+    description: 'Resume past encounters without losing the glow—every reveal is saved right where you paused.',
+    icon: '🕯️',
   },
 ];
 
@@ -42,23 +42,24 @@ const LandingPage: React.FC<LandingPageProps> = ({ theme, setTheme, onAuthentica
     <div className="bg-landing relative min-h-screen overflow-hidden text-slate-900 transition-colors dark:text-slate-100">
       <div aria-hidden className="absolute inset-0 bg-grid-mask opacity-60 mix-blend-soft-light dark:opacity-40" />
       <div aria-hidden className="pointer-events-none absolute -top-32 right-12 h-72 w-72 rounded-full bg-sky-400/30 blur-3xl dark:bg-sky-500/20 animate-float-slow" />
-      <div aria-hidden className="pointer-events-none absolute bottom-[-10rem] left-[-6rem] h-96 w-96 rounded-full bg-teal-400/20 blur-[120px] dark:bg-teal-500/20 animate-float-slow" />
+      <div aria-hidden className="pointer-events-none absolute bottom-[-10rem] left-[-6rem] h-96 w-96 rounded-full bg-amber-400/20 blur-[120px] dark:bg-amber-500/20 animate-float-slow" />
       <div className="relative isolate">
         <header className="mx-auto flex max-w-7xl flex-wrap items-center justify-between gap-4 px-6 py-8 sm:py-10">
           <div className="flex items-center gap-4">
-            <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-slate-900/90 text-2xl font-black text-teal-300 shadow-2xl shadow-teal-500/20 ring-4 ring-white/50 backdrop-blur dark:bg-white/10 dark:text-teal-200 dark:ring-teal-500/30">
-              DM
+            <div className="torch-logo flex h-16 w-16 items-center justify-center rounded-2xl bg-amber-50/80 text-3xl text-amber-700 shadow-lg shadow-amber-500/30 ring-2 ring-amber-200/80 backdrop-blur-sm dark:bg-slate-900/70 dark:text-amber-200 dark:ring-amber-500/40">
+              <span aria-hidden>🔥</span>
+              <span className="sr-only">TableTorch placeholder logo</span>
             </div>
             <div>
-              <p className="text-xs uppercase tracking-[0.45em] text-teal-600 dark:text-teal-300">D&D Map Reveal</p>
-              <p className="text-lg font-semibold text-slate-900 dark:text-slate-100">Fog-of-war built for dramatic storytelling</p>
+              <p className="text-xs uppercase tracking-[0.45em] text-amber-700 dark:text-amber-200">TableTorch</p>
+              <p className="text-lg font-semibold text-slate-900 dark:text-slate-100">Bring every tabletop to life with warm, dramatic reveals.</p>
             </div>
           </div>
           <button
             type="button"
             onClick={handleThemeToggle}
             aria-pressed={theme === 'dark'}
-            className="inline-flex items-center gap-2 rounded-full border border-slate-300/70 bg-white/40 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-600 shadow-sm transition hover:border-teal-400/70 hover:text-teal-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-teal-400 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-200 dark:hover:border-teal-400/60 dark:hover:text-teal-200"
+            className="inline-flex items-center gap-2 rounded-full border border-amber-500/40 bg-white/40 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-amber-700 shadow-sm transition hover:border-amber-500/70 hover:text-amber-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-500 dark:border-amber-500/30 dark:bg-slate-900/60 dark:text-amber-200 dark:hover:border-amber-400/60 dark:hover:text-amber-200"
           >
             <span className="text-base" aria-hidden>
               {theme === 'dark' ? '🌙' : '🌞'}
@@ -69,25 +70,25 @@ const LandingPage: React.FC<LandingPageProps> = ({ theme, setTheme, onAuthentica
         <main className="mx-auto grid max-w-7xl gap-16 px-6 pb-24 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,0.9fr)] lg:items-center">
           <section className="space-y-10">
             <div className="space-y-6">
-              <span className="inline-flex items-center rounded-full border border-teal-400/50 bg-teal-100/60 px-4 py-1 text-[11px] font-semibold uppercase tracking-[0.35em] text-teal-700 shadow-sm dark:border-teal-500/40 dark:bg-teal-500/10 dark:text-teal-200">
-                Your new DM co-pilot
+              <span className="inline-flex items-center rounded-full border border-amber-500/40 bg-amber-100/70 px-4 py-1 text-[11px] font-semibold uppercase tracking-[0.35em] text-amber-700 shadow-sm dark:border-amber-500/40 dark:bg-amber-500/10 dark:text-amber-200">
+                Illuminate your table
               </span>
               <h1 className="text-4xl font-black tracking-tight text-slate-900 sm:text-5xl dark:text-white">
-                Guide your party through unforgettable encounters with cinematic map reveals.
+                Light the way for unforgettable encounters with TableTorch.
               </h1>
               <p className="max-w-xl text-lg text-slate-600 dark:text-slate-300">
-                D&D Map Reveal keeps your battlemap prep organised and ready. Cue dramatic lighting, reveal regions in real time, and manage campaigns without breaking the table’s immersion.
+                TableTorch keeps your battlemap prep organised and ready. Paint scenes with living light, reveal regions in real time, and manage every campaign without breaking immersion.
               </p>
               <div className="flex flex-wrap items-center gap-4">
                 <a
                   href="#auth-panel"
-                  className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-teal-500 via-sky-500 to-blue-500 px-6 py-3 text-xs font-semibold uppercase tracking-[0.45em] text-white shadow-lg shadow-teal-500/30 transition hover:scale-[1.02] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-teal-400"
+                  className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-amber-500 via-orange-500 to-rose-500 px-6 py-3 text-xs font-semibold uppercase tracking-[0.45em] text-white shadow-lg shadow-amber-500/30 transition hover:scale-[1.02] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-500"
                 >
                   Launch the demo
                 </a>
                 <a
                   href="#features"
-                  className="inline-flex items-center justify-center gap-2 rounded-full border border-slate-300/70 bg-white/60 px-6 py-3 text-xs font-semibold uppercase tracking-[0.35em] text-slate-600 transition hover:border-teal-400/60 hover:text-teal-600 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-200 dark:hover:border-teal-400/60 dark:hover:text-teal-200"
+                  className="inline-flex items-center justify-center gap-2 rounded-full border border-amber-500/30 bg-white/60 px-6 py-3 text-xs font-semibold uppercase tracking-[0.35em] text-amber-700 transition hover:border-amber-500/60 hover:text-amber-700 dark:border-amber-500/40 dark:bg-slate-900/60 dark:text-amber-200 dark:hover:border-amber-400/60 dark:hover:text-amber-200"
                 >
                   Explore features
                   <span aria-hidden>→</span>
@@ -98,9 +99,9 @@ const LandingPage: React.FC<LandingPageProps> = ({ theme, setTheme, onAuthentica
               {features.map((feature) => (
                 <article
                   key={feature.title}
-                  className="group relative overflow-hidden rounded-3xl border border-white/60 bg-white/80 p-6 shadow-lg shadow-slate-200/40 transition hover:-translate-y-1 hover:shadow-2xl dark:border-slate-800/70 dark:bg-slate-900/70 dark:shadow-black/40"
+                  className="group relative overflow-hidden rounded-3xl border border-amber-500/40 bg-amber-50/80 p-6 shadow-lg shadow-amber-500/20 transition hover:-translate-y-1 hover:shadow-2xl dark:border-amber-500/30 dark:bg-slate-900/70 dark:shadow-black/40"
                 >
-                  <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-teal-500/20 to-sky-500/10 text-2xl">
+                  <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-amber-500/25 to-rose-400/15 text-2xl">
                     <span aria-hidden>{feature.icon}</span>
                     <span className="sr-only">{feature.title} icon</span>
                   </div>
@@ -108,7 +109,7 @@ const LandingPage: React.FC<LandingPageProps> = ({ theme, setTheme, onAuthentica
                   <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">{feature.description}</p>
                   <div
                     aria-hidden
-                    className="pointer-events-none absolute inset-0 translate-y-full bg-gradient-to-t from-teal-500/10 to-transparent transition duration-500 group-hover:translate-y-0"
+                    className="pointer-events-none absolute inset-0 translate-y-full bg-gradient-to-t from-amber-500/15 to-transparent transition duration-500 group-hover:translate-y-0"
                   />
                 </article>
               ))}
@@ -116,17 +117,17 @@ const LandingPage: React.FC<LandingPageProps> = ({ theme, setTheme, onAuthentica
           </section>
           <aside className="relative">
             <div aria-hidden className="absolute inset-0 -translate-y-6 rounded-[2.75rem] bg-white/50 blur-3xl dark:bg-slate-900/50" />
-            <div className="relative rounded-[2.5rem] border border-white/40 bg-white/60 p-1 shadow-2xl shadow-teal-500/10 backdrop-blur-xl dark:border-slate-800/60 dark:bg-slate-950/60">
-              <div className="absolute -top-16 right-10 h-24 w-24 rounded-full bg-gradient-to-br from-teal-400/40 to-sky-500/20 blur-3xl dark:from-teal-500/30 dark:to-sky-500/20 animate-gradient" aria-hidden />
-              <div className="absolute bottom-10 left-10 h-20 w-20 rounded-full bg-teal-400/20 blur-2xl dark:bg-teal-500/20 animate-float-slow" aria-hidden />
+            <div className="relative rounded-[2.5rem] border border-amber-500/30 bg-amber-50/70 p-1 shadow-2xl shadow-amber-500/20 backdrop-blur-xl dark:border-amber-500/30 dark:bg-slate-950/70">
+              <div className="absolute -top-16 right-10 h-24 w-24 rounded-full bg-gradient-to-br from-amber-300/40 to-rose-400/20 blur-3xl dark:from-amber-400/30 dark:to-rose-500/20 animate-gradient" aria-hidden />
+              <div className="absolute bottom-10 left-10 h-20 w-20 rounded-full bg-amber-300/25 blur-2xl dark:bg-amber-400/20 animate-float-slow" aria-hidden />
               <AuthPanel
                 variant="wide"
-                className="border-transparent bg-white/80 shadow-none ring-1 ring-white/60 dark:bg-slate-950/70 dark:ring-teal-500/20"
+                className="border-transparent bg-white/[0.85] shadow-none ring-1 ring-amber-500/20 dark:bg-slate-950/70 dark:ring-amber-500/20"
                 onAuthenticate={onAuthenticate}
               />
             </div>
             <p id="auth-panel" className="mt-6 text-center text-xs text-slate-500 dark:text-slate-400">
-              No spam, no credit card – just a guided tour of the DM mission control.
+              No spam, no credit card – just a guided tour of the TableTorch experience.
             </p>
           </aside>
         </main>

--- a/apps/pages/src/components/MapCreationWizard.tsx
+++ b/apps/pages/src/components/MapCreationWizard.tsx
@@ -694,7 +694,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
       <header className="mb-0.5 border-b border-slate-800/70 px-5 py-3">
         <div className="flex flex-wrap items-center justify-between gap-4">
           <div>
-            <p className="text-xs uppercase tracking-[0.4em] text-teal-300">New Map Wizard</p>
+            <p className="text-xs uppercase tracking-[0.4em] text-amber-300">New Map Wizard</p>
             <h2 className="text-2xl font-bold text-white">{steps[step].title}</h2>
             <p className="text-sm text-slate-400">{steps[step].description}</p>
           </div>
@@ -715,7 +715,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                 key={item.title}
                 className={`flex items-center gap-3 rounded-full border px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] transition ${
                   isActive
-                    ? 'border-teal-400/70 bg-teal-500/20 text-teal-100'
+                    ? 'border-amber-400/70 bg-amber-500/20 text-amber-100'
                     : isComplete
                     ? 'border-slate-700/70 bg-slate-800/80 text-slate-200'
                     : 'border-slate-800/70 bg-slate-900/80 text-slate-500'
@@ -744,7 +744,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                   onDragEnter={(event) => event.preventDefault()}
                   onDragOver={(event) => event.preventDefault()}
                   onDrop={handleDrop}
-                  className="group relative flex min-h-[200px] flex-col items-center justify-center rounded-2xl border-2 border-dashed border-slate-700/70 bg-slate-950/70 px-6 py-8 transition hover:border-teal-400/60"
+                  className="group relative flex min-h-[200px] flex-col items-center justify-center rounded-2xl border-2 border-dashed border-slate-700/70 bg-slate-950/70 px-6 py-8 transition hover:border-amber-400/60"
                 >
                   <input
                     ref={fileInputRef}
@@ -766,14 +766,14 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                   <button
                     type="button"
                     onClick={handleBrowse}
-                    className="mt-5 rounded-full border border-teal-400/60 bg-teal-500/80 px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-teal-400/90"
+                    className="mt-5 rounded-full border border-amber-400/60 bg-amber-500/80 px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-amber-400/90"
                   >
                     Browse Files
                   </button>
                 </div>
                 {previewUrl && (
                   <div className="mt-6">
-                    <p className="text-xs uppercase tracking-[0.4em] text-teal-300">Preview</p>
+                    <p className="text-xs uppercase tracking-[0.4em] text-amber-300">Preview</p>
                     <div className="mt-3 overflow-hidden rounded-2xl border border-slate-800/70">
                       <img
                         src={previewUrl}
@@ -802,7 +802,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                         type="text"
                         value={name}
                         onChange={(event) => setName(event.target.value)}
-                        className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                        className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/40"
                         placeholder="Ancient Ruins"
                       />
                     </div>
@@ -812,7 +812,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                         value={description}
                         onChange={(event) => setDescription(event.target.value)}
                         rows={3}
-                        className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                        className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/40"
                         placeholder="Give a brief overview of the map."
                       />
                     </div>
@@ -822,7 +822,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                         type="text"
                         value={grouping}
                         onChange={(event) => setGrouping(event.target.value)}
-                        className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                        className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/40"
                         placeholder="Dungeon Delves"
                       />
                     </div>
@@ -832,7 +832,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                         value={notes}
                         onChange={(event) => setNotes(event.target.value)}
                         rows={3}
-                        className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                        className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/40"
                         placeholder="DM-only reminders or encounter tips"
                       />
                     </div>
@@ -842,7 +842,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                         type="text"
                         value={tagsInput}
                         onChange={(event) => setTagsInput(event.target.value)}
-                        className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                        className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/40"
                         placeholder="forest, ruins, night"
                       />
                       <p className="mt-2 text-xs text-slate-500">Separate tags with commas to help search and filtering.</p>
@@ -918,7 +918,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                             markerDisplayMetrics,
                           ),
                         )}
-                        className="group absolute -translate-x-1/2 -translate-y-1/2 rounded-full border border-white/40 bg-slate-950/80 px-3 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-white shadow-lg transition hover:border-teal-300/80 hover:text-teal-100"
+                        className="group absolute -translate-x-1/2 -translate-y-1/2 rounded-full border border-white/40 bg-slate-950/80 px-3 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-white shadow-lg transition hover:border-amber-300/80 hover:text-amber-100"
                       >
                         {marker.label || 'Marker'}
                       </button>
@@ -945,7 +945,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                     <button
                       type="button"
                       onClick={handleAddMarker}
-                      className="rounded-full border border-teal-400/60 bg-teal-500/80 px-4 py-2 text-[10px] font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-teal-400/90"
+                      className="rounded-full border border-amber-400/60 bg-amber-500/80 px-4 py-2 text-[10px] font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-amber-400/90"
                     >
                       Add Marker
                     </button>
@@ -962,7 +962,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                         key={marker.id}
                         className={`rounded-2xl border px-4 py-3 transition ${
                           isExpanded
-                            ? 'border-teal-400/60 bg-slate-950/80'
+                            ? 'border-amber-400/60 bg-slate-950/80'
                             : 'border-slate-800/70 bg-slate-950/70'
                         }`}
                       >
@@ -991,7 +991,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                           </div>
                           <span
                             className={`text-[10px] uppercase tracking-[0.35em] ${
-                              isExpanded ? 'text-teal-200' : 'text-slate-400'
+                              isExpanded ? 'text-amber-200' : 'text-slate-400'
                             }`}
                           >
                             {isExpanded ? 'Hide' : 'Edit'}
@@ -1007,7 +1007,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                                 onChange={(event) =>
                                   handleMarkerChange(marker.id, 'label', event.target.value)
                                 }
-                                className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-3 py-2 text-xs text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                                className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-3 py-2 text-xs text-slate-100 placeholder:text-slate-600 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/40"
                                 placeholder="Secret Door"
                               />
                             </label>
@@ -1020,7 +1020,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                                     handleMarkerChange(marker.id, 'notes', event.target.value)
                                   }
                                   rows={2}
-                                  className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-3 py-2 text-xs text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                                  className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-3 py-2 text-xs text-slate-100 placeholder:text-slate-600 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/40"
                                   placeholder="Trap trigger, treasure cache, etc."
                                 />
                               </label>
@@ -1032,7 +1032,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                                   onChange={(event) =>
                                     handleMarkerChange(marker.id, 'color', event.target.value)
                                   }
-                                  className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-3 py-2 text-xs text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                                  className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-3 py-2 text-xs text-slate-100 placeholder:text-slate-600 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/40"
                                   placeholder="#facc15"
                                 />
                               </label>
@@ -1068,7 +1068,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
           <button
             type="button"
             onClick={handleBack}
-            className="rounded-full border border-slate-700/70 px-4 py-1.5 text-[11px] font-semibold uppercase tracking-[0.3em] text-slate-300 transition hover:border-teal-400/60 hover:text-teal-200"
+            className="rounded-full border border-slate-700/70 px-4 py-1.5 text-[11px] font-semibold uppercase tracking-[0.3em] text-slate-300 transition hover:border-amber-400/60 hover:text-amber-200"
           >
             {step === 0 ? 'Cancel' : 'Back'}
           </button>
@@ -1081,7 +1081,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                 onClick={handleContinue}
                 className={`rounded-full border px-5 py-1.5 text-[11px] font-semibold uppercase tracking-[0.3em] transition ${
                   allowNext
-                    ? 'border-teal-400/60 bg-teal-500/80 text-slate-900 hover:bg-teal-400/90'
+                    ? 'border-amber-400/60 bg-amber-500/80 text-slate-900 hover:bg-amber-400/90'
                     : 'cursor-not-allowed border-slate-800/70 bg-slate-900/70 text-slate-500'
                 }`}
               >
@@ -1095,7 +1095,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                 className={`rounded-full border px-5 py-1.5 text-[11px] font-semibold uppercase tracking-[0.3em] transition ${
                   creating
                     ? 'cursor-wait border-slate-800/70 bg-slate-900/70 text-slate-500'
-                    : 'border-teal-400/60 bg-teal-500/80 text-slate-900 hover:bg-teal-400/90'
+                    : 'border-amber-400/60 bg-amber-500/80 text-slate-900 hover:bg-amber-400/90'
                 }`}
               >
                 {creating ? 'Creating…' : 'Create Map'}

--- a/apps/pages/src/components/MapFolderList.tsx
+++ b/apps/pages/src/components/MapFolderList.tsx
@@ -87,7 +87,7 @@ const MapFolderList: React.FC<MapFolderListProps> = ({
         <button
           type="button"
           onClick={onCreateMap}
-          className="rounded-xl border border-teal-400/60 bg-teal-500/80 px-5 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-teal-400/90"
+          className="rounded-xl border border-amber-400/60 bg-amber-500/80 px-5 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-amber-400/90"
         >
           New Map
         </button>
@@ -114,7 +114,7 @@ const MapFolderList: React.FC<MapFolderListProps> = ({
                     </div>
                     <span
                       className={`inline-flex h-8 w-8 items-center justify-center rounded-full border border-slate-700/70 text-xs font-bold text-slate-300 transition ${
-                        expanded ? 'bg-teal-500/10 text-teal-200' : 'bg-slate-900'
+                        expanded ? 'bg-amber-500/10 text-amber-200' : 'bg-slate-900'
                       }`}
                       aria-hidden="true"
                     >
@@ -153,10 +153,10 @@ const MapFolderList: React.FC<MapFolderListProps> = ({
                               onSelect(map);
                             }
                           }}
-                          className={`group relative overflow-hidden rounded-2xl border px-5 py-6 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-teal-400/60 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 ${
+                          className={`group relative overflow-hidden rounded-2xl border px-5 py-6 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400/60 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 ${
                             selectedMapId === map.id
-                              ? 'border-teal-400 bg-teal-500/10 shadow-[0_0_0_1px_rgba(45,212,191,0.4)]'
-                              : 'border-slate-800/60 bg-slate-950/60 hover:border-teal-400/60 hover:shadow-[0_0_0_1px_rgba(45,212,191,0.3)]'
+                              ? 'border-amber-400 bg-amber-500/10 shadow-[0_0_0_1px_rgba(251,191,36,0.4)]'
+                              : 'border-slate-800/60 bg-slate-950/60 hover:border-amber-400/60 hover:shadow-[0_0_0_1px_rgba(251,191,36,0.3)]'
                           }`}
                         >
                           <div className="absolute right-4 top-4 flex items-center gap-2">

--- a/apps/pages/src/index.css
+++ b/apps/pages/src/index.css
@@ -20,23 +20,33 @@ body.dark {
 
 @layer utilities {
   .bg-landing {
+    background-color: #f3ede0;
     background-image:
-      radial-gradient(circle at 10% -10%, rgba(56, 189, 248, 0.35), transparent 45%),
-      radial-gradient(circle at 80% 10%, rgba(20, 184, 166, 0.25), transparent 40%),
-      radial-gradient(circle at 0% 80%, rgba(14, 165, 233, 0.2), transparent 45%),
-      linear-gradient(135deg, #f8fafc 0%, #f1f5f9 50%, #e2e8f0 100%);
+      radial-gradient(circle at 20% -10%, rgba(252, 211, 77, 0.35), transparent 55%),
+      radial-gradient(circle at 85% 15%, rgba(248, 113, 113, 0.25), transparent 60%),
+      linear-gradient(120deg, rgba(255, 255, 255, 0.85), rgba(253, 244, 215, 0.75)),
+      url('/parchment-bg.jpg');
+    background-blend-mode: screen, screen, multiply, normal;
+    background-size: 1200px 1200px, 1200px 1200px, cover, 900px auto;
+    background-repeat: no-repeat, no-repeat, no-repeat, repeat;
+    background-position: left top, right 10% top, center, center;
   }
 
   .dark .bg-landing {
+    background-color: #0f172a;
     background-image:
-      radial-gradient(circle at 15% -10%, rgba(56, 189, 248, 0.2), transparent 45%),
-      radial-gradient(circle at 85% 15%, rgba(37, 99, 235, 0.18), transparent 45%),
-      radial-gradient(circle at 10% 85%, rgba(45, 212, 191, 0.18), transparent 45%),
-      linear-gradient(135deg, #020617 0%, #0f172a 55%, #020617 100%);
+      radial-gradient(circle at 20% -5%, rgba(252, 211, 77, 0.18), transparent 55%),
+      radial-gradient(circle at 85% 20%, rgba(248, 113, 113, 0.15), transparent 60%),
+      linear-gradient(140deg, rgba(13, 18, 29, 0.95), rgba(36, 24, 14, 0.92)),
+      url('/parchment-bg.jpg');
+    background-blend-mode: screen, screen, multiply, normal;
+    background-size: 1200px 1200px, 1200px 1200px, cover, 900px auto;
+    background-repeat: no-repeat, no-repeat, no-repeat, repeat;
+    background-position: left top, right 10% top, center, center;
   }
 
   .bg-grid-mask {
-    --grid-color: rgba(15, 23, 42, 0.08);
+    --grid-color: rgba(146, 64, 14, 0.08);
     background-image:
       linear-gradient(var(--grid-color) 1px, transparent 1px),
       linear-gradient(90deg, var(--grid-color) 1px, transparent 1px);
@@ -44,7 +54,8 @@ body.dark {
   }
 
   .dark .bg-grid-mask {
-    --grid-color: rgba(148, 163, 184, 0.1);
+    --grid-color: rgba(248, 191, 72, 0.12);
+    mix-blend-mode: screen;
   }
 
   .animate-gradient {
@@ -54,6 +65,27 @@ body.dark {
 
   .animate-float-slow {
     animation: floatSlow 14s ease-in-out infinite;
+  }
+
+  .torch-logo {
+    position: relative;
+    isolation: isolate;
+  }
+
+  .torch-logo::after {
+    content: '';
+    position: absolute;
+    inset: -1.75rem;
+    border-radius: 9999px;
+    opacity: 0;
+    background: radial-gradient(circle, rgba(252, 211, 77, 0.35) 0%, rgba(252, 211, 77, 0.1) 45%, transparent 70%);
+    pointer-events: none;
+    transition: opacity 400ms ease;
+    z-index: -1;
+  }
+
+  .dark .torch-logo::after {
+    opacity: 1;
   }
 }
 

--- a/apps/pages/vite.config.ts
+++ b/apps/pages/vite.config.ts
@@ -31,6 +31,7 @@ export default defineConfig({
   resolve: {
     alias,
   },
+  publicDir: resolvePath('../../textures'),
   server: {
     port: 5173,
   },


### PR DESCRIPTION
## Summary
- replace the landing page hero with TableTorch-focused copy, a placeholder torch logo, and warm accent colors
- serve the shared parchment background texture and apply it to both light and dark modes with matching halo effects
- update authenticated dashboards, auth forms, and creation flows to use the TableTorch palette and language throughout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db02b751e48323ad773c6dc5fc3857