### PR TITLE
Ensure TableTorch parchment texture and light mode styling

### DIFF
--- a/apps/pages/src/App.tsx
+++ b/apps/pages/src/App.tsx
@@ -5,6 +5,7 @@ import { apiClient } from './api/client';
 import MapCreationWizard from './components/MapCreationWizard';
 import MapFolderList from './components/MapFolderList';
 import LandingPage from './components/LandingPage';
+import parchmentTextureUrl from '@textures/parchment-bg.jpg';
 import type {
   AuthResponse,
   Campaign,
@@ -63,6 +64,26 @@ const App: React.FC = () => {
   const [newCampaignPublic, setNewCampaignPublic] = useState(false);
   const [createError, setCreateError] = useState<string | null>(null);
   const [showMapWizard, setShowMapWizard] = useState(false);
+
+  const parchmentTextureStyles = useMemo(
+    () => ({ '--parchment-texture': `url(${parchmentTextureUrl})` }) as React.CSSProperties,
+    []
+  );
+
+  const renderWithinParchment = useCallback(
+    (content: React.ReactNode) => (
+      <div
+        style={parchmentTextureStyles}
+        className="bg-landing relative min-h-screen overflow-hidden text-slate-900 transition-colors dark:text-slate-100"
+      >
+        <div aria-hidden className="absolute inset-0 bg-grid-mask opacity-60 mix-blend-multiply dark:mix-blend-soft-light dark:opacity-40" />
+        <div aria-hidden className="pointer-events-none absolute -top-40 right-10 h-72 w-72 rounded-full bg-amber-200/30 blur-3xl dark:bg-amber-500/25" />
+        <div aria-hidden className="pointer-events-none absolute bottom-[-8rem] left-[-4rem] h-80 w-80 rounded-full bg-rose-200/25 blur-[120px] dark:bg-rose-500/20" />
+        <div className="relative isolate">{content}</div>
+      </div>
+    ),
+    [parchmentTextureStyles]
+  );
 
   useEffect(() => {
     if (theme === 'dark') {
@@ -537,10 +558,10 @@ const App: React.FC = () => {
   const themeLabel = theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode';
 
   const navButtonClasses = (view: 'join' | 'manage' | 'create' | 'admin') =>
-    `group flex w-full items-center justify-between rounded-2xl border px-5 py-4 text-left text-sm font-semibold uppercase tracking-[0.3em] transition ${
+    `group flex w-full items-center justify-between rounded-2xl border px-5 py-4 text-left text-sm font-semibold uppercase tracking-[0.3em] transition backdrop-blur ${
       activeView === view
-        ? 'border-teal-400 bg-teal-400/90 text-slate-900 shadow-lg shadow-teal-500/40'
-        : 'border-slate-800/70 bg-slate-900/60 text-slate-300 hover:border-teal-400/60 hover:bg-slate-800/80'
+        ? 'border-amber-500/70 bg-amber-400/90 text-slate-900 shadow-lg shadow-amber-500/40 dark:border-amber-400/80 dark:bg-amber-500/80 dark:text-slate-900'
+        : 'border-amber-900/20 bg-white/70 text-slate-700 hover:border-amber-400/60 hover:bg-amber-100/50 dark:border-slate-800/70 dark:bg-slate-900/60 dark:text-slate-300 dark:hover:border-amber-400/60 dark:hover:bg-slate-800/80'
     }`;
 
   if (!token || !user) {
@@ -548,22 +569,25 @@ const App: React.FC = () => {
   }
 
   if (activeSession) {
-    return (
-      <div className="min-h-screen bg-slate-100 p-6 dark:bg-slate-900">
-        <div className="mb-4 flex items-center justify-between">
+    return renderWithinParchment(
+      <div className="mx-auto flex min-h-screen max-w-6xl flex-col gap-6 px-4 py-8 lg:px-8">
+        <div className="flex flex-wrap items-center justify-between gap-4 rounded-3xl border border-amber-900/20 bg-white/80 px-6 py-5 shadow-lg shadow-amber-900/15 backdrop-blur dark:border-slate-800/70 dark:bg-slate-950/70 dark:shadow-black/40">
           <div>
-            <h1 className="text-2xl font-bold text-primary">D&D Map Reveal</h1>
-            <p className="text-sm text-slate-500 dark:text-slate-400">Logged in as {user.displayName}</p>
+            <h1 className="text-2xl font-bold text-amber-600 dark:text-amber-300">TableTorch</h1>
+            <p className="text-sm text-slate-600 dark:text-slate-300">Logged in as {user.displayName}</p>
           </div>
           <div className="flex items-center gap-2">
             <button
-              className="rounded-full border border-slate-300 px-3 py-1 text-xs hover:bg-slate-100 dark:border-slate-600 dark:hover:bg-slate-700"
+              className="inline-flex items-center gap-2 rounded-full border border-amber-900/30 bg-white/70 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-700 shadow-sm transition hover:border-amber-400/60 hover:text-amber-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-400 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-200 dark:hover:border-amber-400/60 dark:hover:text-amber-200"
               onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
             >
+              <span className="text-base" aria-hidden>
+                {theme === 'dark' ? '🌙' : '🌞'}
+              </span>
               {themeLabel}
             </button>
             <button
-              className="rounded-full border border-slate-300 px-3 py-1 text-xs hover:bg-slate-100 dark:border-slate-600 dark:hover:bg-slate-700"
+              className="rounded-full border border-rose-400/60 bg-rose-100/70 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-rose-700 shadow-sm transition hover:bg-rose-200/80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-400 dark:border-rose-400/60 dark:bg-rose-500/30 dark:text-rose-100 dark:hover:bg-rose-500/40"
               onClick={handleLogout}
             >
               Logout
@@ -571,434 +595,449 @@ const App: React.FC = () => {
           </div>
         </div>
         {statusMessage && (
-          <div className="mb-4 rounded border border-slate-200 bg-white px-4 py-2 text-sm text-slate-600 shadow dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200">
+          <div className="rounded-3xl border border-amber-900/25 bg-amber-50/80 px-5 py-3 text-sm text-amber-700 shadow-md shadow-amber-900/10 backdrop-blur dark:border-amber-400/40 dark:bg-amber-500/10 dark:text-amber-200 dark:shadow-amber-500/10">
             {statusMessage}
           </div>
         )}
-        <SessionViewer
-          session={activeSession}
-          mapImageUrl={selectedMap ? apiClient.buildMapDisplayUrl(selectedMap.id) : undefined}
-          mapWidth={selectedMap?.width}
-          mapHeight={selectedMap?.height}
-          regions={regions}
-          baseMarkers={markers}
-          mode={sessionMode}
-          user={user}
-          onLeave={handleLeaveSession}
-          onSaveSession={sessionMode === 'dm' ? handleSaveSession : undefined}
-          onEndSession={sessionMode === 'dm' ? handleEndSession : undefined}
-        />
+        <div className="flex-1 overflow-hidden rounded-3xl border border-amber-900/25 bg-white/85 p-4 shadow-2xl shadow-amber-900/15 backdrop-blur dark:border-slate-800/70 dark:bg-slate-950/70 dark:shadow-black/40">
+          <SessionViewer
+            session={activeSession}
+            mapImageUrl={selectedMap ? apiClient.buildMapDisplayUrl(selectedMap.id) : undefined}
+            mapWidth={selectedMap?.width}
+            mapHeight={selectedMap?.height}
+            regions={regions}
+            baseMarkers={markers}
+            mode={sessionMode}
+            user={user}
+            onLeave={handleLeaveSession}
+            onSaveSession={sessionMode === 'dm' ? handleSaveSession : undefined}
+            onEndSession={sessionMode === 'dm' ? handleEndSession : undefined}
+          />
+        </div>
       </div>
     );
   }
 
-  return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 text-slate-100">
-      <div className="mx-auto flex min-h-screen max-w-6xl flex-col gap-6 px-4 py-8 md:flex-row md:py-12">
-        <aside className="flex flex-col gap-6 rounded-3xl border border-slate-800/70 bg-slate-950/70 p-6 shadow-2xl md:w-72">
+  return renderWithinParchment(
+    <div className="mx-auto flex min-h-screen max-w-6xl flex-col gap-6 px-4 py-8 md:flex-row md:py-12 lg:px-10">
+      <aside className="flex flex-col gap-6 rounded-3xl border border-amber-900/20 bg-white/80 p-6 shadow-2xl shadow-amber-900/15 backdrop-blur md:w-72 dark:border-slate-800/70 dark:bg-slate-950/70 dark:shadow-black/40">
+        <div>
+          <p className="text-xs uppercase tracking-[0.4em] text-amber-700 dark:text-amber-300">Mission Control</p>
+          <h2 className="mt-3 text-2xl font-black uppercase tracking-wide text-amber-600 dark:text-amber-200">Command Deck</h2>
+        </div>
+        <div className="rounded-2xl border border-amber-900/20 bg-white/80 p-4 shadow-md shadow-amber-900/10 backdrop-blur dark:border-slate-800/70 dark:bg-slate-900/70 dark:shadow-black/30">
+          <p className="text-xs uppercase tracking-[0.5em] text-amber-800/70 dark:text-amber-300">Logged in</p>
+          <p className="mt-2 text-lg font-semibold text-slate-800 dark:text-white">{user.displayName}</p>
+          <p className="text-xs text-slate-600 dark:text-slate-400">Ready for launch</p>
+        </div>
+        <nav className="space-y-3">
+          <button className={navButtonClasses('join')} onClick={() => setActiveView('join')}>
+            <span>Join Campaign</span>
+            <span className="text-[10px] tracking-[0.4em] text-amber-700/70 transition group-hover:text-amber-900 dark:text-amber-200/70 dark:group-hover:text-amber-100">
+              START
+            </span>
+          </button>
+          <button className={navButtonClasses('manage')} onClick={() => setActiveView('manage')}>
+            <span>Manage Campaigns</span>
+            <span className="text-[10px] tracking-[0.4em] text-amber-700/70 transition group-hover:text-amber-900 dark:text-amber-200/70 dark:group-hover:text-amber-100">
+              HANGAR
+            </span>
+          </button>
+          <button className={navButtonClasses('create')} onClick={() => setActiveView('create')}>
+            <span>Create Campaign</span>
+            <span className="text-[10px] tracking-[0.4em] text-amber-700/70 transition group-hover:text-amber-900 dark:text-amber-200/70 dark:group-hover:text-amber-100">
+              NEW
+            </span>
+          </button>
+        </nav>
+        <div className="mt-auto space-y-2 text-xs text-slate-600 dark:text-slate-400">
+          <p>Need a room code? Ask your DM to share their campaign key.</p>
+          <p>Switch tabs to manage, create, or join adventures.</p>
+        </div>
+      </aside>
+      <section className="flex-1 space-y-6">
+        <header className="flex flex-wrap items-center justify-between gap-3 rounded-3xl border border-amber-900/20 bg-white/80 px-6 py-4 shadow-xl shadow-amber-900/15 backdrop-blur dark:border-slate-800/70 dark:bg-slate-950/70 dark:shadow-black/40">
           <div>
-            <p className="text-xs uppercase tracking-[0.4em] text-slate-500">Mission Control</p>
-            <h2 className="mt-3 text-2xl font-black uppercase tracking-wide text-teal-300">Command Deck</h2>
+            <p className="text-xs uppercase tracking-[0.5em] text-amber-700 dark:text-amber-300">Campaign Control</p>
+            <h1 className="text-3xl font-black uppercase tracking-wide text-slate-900 dark:text-white">TableTorch</h1>
           </div>
-          <div className="rounded-2xl border border-slate-800/70 bg-slate-900/70 p-4">
-            <p className="text-xs uppercase tracking-[0.5em] text-slate-500">Logged in</p>
-            <p className="mt-2 text-lg font-semibold text-white">{user.displayName}</p>
-            <p className="text-xs text-slate-500">Ready for launch</p>
+          <div className="flex items-center gap-3">
+            <button
+              className="inline-flex items-center gap-2 rounded-full border border-amber-900/30 bg-white/70 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-700 shadow-sm transition hover:border-amber-400/60 hover:text-amber-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-400 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-200 dark:hover:border-amber-400/60 dark:hover:text-amber-200"
+              onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
+            >
+              <span className="text-base" aria-hidden>
+                {theme === 'dark' ? '🌙' : '🌞'}
+              </span>
+              {themeLabel}
+            </button>
+            <button
+              className="rounded-full border border-rose-400/60 bg-rose-100/70 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-rose-700 shadow-sm transition hover:bg-rose-200/80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-400 dark:border-rose-400/60 dark:bg-rose-500/30 dark:text-rose-100 dark:hover:bg-rose-500/40"
+              onClick={handleLogout}
+            >
+              Logout
+            </button>
           </div>
-          <nav className="space-y-3">
-            <button className={navButtonClasses('join')} onClick={() => setActiveView('join')}>
-              <span>Join Campaign</span>
-              <span className="text-[10px] tracking-[0.4em] text-slate-900/70 transition group-hover:text-slate-900/90">START</span>
-            </button>
-            <button className={navButtonClasses('manage')} onClick={() => setActiveView('manage')}>
-              <span>Manage Campaigns</span>
-              <span className="text-[10px] tracking-[0.4em] text-slate-900/70 transition group-hover:text-slate-900/90">HANGAR</span>
-            </button>
-            <button className={navButtonClasses('create')} onClick={() => setActiveView('create')}>
-              <span>Create Campaign</span>
-              <span className="text-[10px] tracking-[0.4em] text-slate-900/70 transition group-hover:text-slate-900/90">NEW</span>
-            </button>
-          </nav>
-          <div className="mt-auto space-y-2 text-xs text-slate-500">
-            <p>Need a room code? Ask your DM to share their campaign key.</p>
-            <p>Switch tabs to manage, create, or join adventures.</p>
+        </header>
+        {statusMessage && (
+          <div className="rounded-3xl border border-amber-900/25 bg-amber-50/80 px-5 py-3 text-sm text-amber-700 shadow-md shadow-amber-900/10 backdrop-blur dark:border-amber-400/40 dark:bg-amber-500/10 dark:text-amber-200 dark:shadow-amber-500/10">
+            {statusMessage}
           </div>
-        </aside>
-        <section className="flex-1 space-y-6">
-          <header className="flex flex-wrap items-center justify-between gap-3 rounded-3xl border border-slate-800/70 bg-slate-950/70 px-6 py-4 shadow-xl">
-            <div>
-              <p className="text-xs uppercase tracking-[0.5em] text-teal-300">Campaign Control</p>
-              <h1 className="text-3xl font-black uppercase tracking-wide text-white">D&D Map Reveal</h1>
-            </div>
-            <div className="flex items-center gap-3">
-              <button
-                className="rounded-full border border-teal-400/60 bg-teal-400/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-teal-200 transition hover:bg-teal-400/20"
-                onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
-              >
-                {themeLabel}
-              </button>
-              <button
-                className="rounded-full border border-rose-400/60 bg-rose-500/20 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-rose-200 transition hover:bg-rose-500/30"
-                onClick={handleLogout}
-              >
-                Logout
-              </button>
-            </div>
-          </header>
-          {statusMessage && (
-            <div className="rounded-3xl border border-teal-500/40 bg-teal-500/10 px-5 py-3 text-sm text-teal-200 shadow-lg shadow-teal-500/10">
-              {statusMessage}
-            </div>
-          )}
-          <div className="flex-1 rounded-3xl border border-slate-800/70 bg-slate-950/70 p-6 shadow-2xl">
-            {activeView === 'join' && (
-              <div className="space-y-6">
-                <h2 className="text-3xl font-black uppercase tracking-wide text-teal-200">Join Campaign</h2>
-                <p className="max-w-xl text-sm text-slate-300">
-                  Enter the campaign key provided by your Dungeon Master to hop into their room.
-                </p>
-                <form onSubmit={handleJoinByKey} className="space-y-4">
-                  <label className="block text-xs uppercase tracking-[0.4em] text-slate-400">
-                    Campaign Key
-                    <div className="mt-2 flex flex-col gap-3 sm:flex-row">
-                      <input
-                        value={joinKey}
-                        onChange={(event) => setJoinKey(event.target.value)}
-                        placeholder="e.g. A1B2C3"
-                        className="flex-1 rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm uppercase tracking-[0.3em] text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
-                      />
-                      <button
-                        type="submit"
-                        className="rounded-xl border border-teal-400/60 bg-teal-500/80 px-6 py-3 text-sm font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-teal-400/90 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
-                      >
-                        Join Room
-                      </button>
-                    </div>
-                  </label>
-                  {joinError && <p className="text-xs font-semibold text-rose-300">{joinError}</p>}
-                </form>
-                <div className="rounded-2xl border border-slate-800/70 bg-slate-900/70 p-4">
-                  <div className="mb-3 flex items-center justify-between">
-                    <h3 className="text-xs uppercase tracking-[0.4em] text-slate-400">Active Rooms</h3>
+        )}
+        <div className="flex-1 rounded-3xl border border-amber-900/20 bg-white/85 p-6 shadow-2xl shadow-amber-900/15 backdrop-blur dark:border-slate-800/70 dark:bg-slate-950/70 dark:shadow-black/40">
+          {activeView === 'join' && (
+            <div className="space-y-6">
+              <h2 className="text-3xl font-black uppercase tracking-wide text-amber-700 dark:text-amber-200">Join Campaign</h2>
+              <p className="max-w-xl text-sm text-slate-600 dark:text-slate-300">
+                Enter the campaign key provided by your Dungeon Master to hop into their room.
+              </p>
+              <form onSubmit={handleJoinByKey} className="space-y-4">
+                <label className="block text-xs uppercase tracking-[0.4em] text-amber-800/80 dark:text-amber-200/80">
+                  Campaign Key
+                  <div className="mt-2 flex flex-col gap-3 sm:flex-row">
+                    <input
+                      value={joinKey}
+                      onChange={(event) => setJoinKey(event.target.value)}
+                      placeholder="e.g. A1B2C3"
+                      className="flex-1 rounded-xl border border-amber-900/25 bg-white/85 px-4 py-3 text-sm uppercase tracking-[0.3em] text-slate-800 shadow-sm placeholder:text-slate-500 focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-400/40 dark:border-slate-800/60 dark:bg-slate-950/70 dark:text-slate-100 dark:placeholder:text-slate-500"
+                    />
                     <button
-                      type="button"
-                      className="text-xs font-semibold uppercase tracking-[0.3em] text-teal-200 transition hover:text-teal-100"
-                      onClick={refreshLobby}
+                      type="submit"
+                      className="rounded-xl bg-gradient-to-r from-amber-500 via-orange-500 to-rose-500 px-6 py-3 text-sm font-semibold uppercase tracking-[0.3em] text-white shadow-lg shadow-amber-500/30 transition hover:scale-[1.02] focus:outline-none focus:ring-2 focus:ring-amber-400/40"
                     >
-                      Refresh
+                      Join Room
                     </button>
                   </div>
-                  <ul className="max-h-48 space-y-2 overflow-y-auto pr-1 text-sm">
-                    {lobbySessions.map((session) => (
-                      <li key={session.id} className="rounded-xl border border-slate-800/70 bg-slate-950/60 p-3">
-                        <div className="flex flex-wrap items-center justify-between gap-2">
-                          <div>
-                            <p className="font-semibold text-slate-100">{session.name}</p>
-                            <p className="text-[10px] uppercase tracking-[0.4em] text-slate-500">Key: {session.id}</p>
-                          </div>
-                          <button
-                            type="button"
-                            className="rounded-lg border border-teal-400/60 bg-teal-500/80 px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-teal-400/90"
-                            onClick={() => handleJoinSession(session)}
-                          >
-                            Join
-                          </button>
-                        </div>
-                        <p className="mt-2 text-xs text-slate-400">
-                          Campaign: {session.campaignName ?? 'Unknown'} • Map: {session.mapName ?? 'Unknown'}
-                        </p>
-                      </li>
-                    ))}
-                    {lobbySessions.length === 0 && (
-                      <li className="rounded-xl border border-dashed border-slate-700/70 px-3 py-6 text-center text-xs text-slate-500">
-                        No active rooms yet.
-                      </li>
-                    )}
-                  </ul>
-                </div>
-              </div>
-            )}
-            {activeView === 'manage' && (
-              <div className="space-y-6">
-                <div className="flex flex-wrap items-center justify-between gap-3">
-                  <div>
-                    <h2 className="text-3xl font-black uppercase tracking-wide text-teal-200">Manage Campaigns</h2>
-                    <p className="text-sm text-slate-300">Select a campaign to open the admin hangar.</p>
-                  </div>
+                </label>
+                {joinError && <p className="text-xs font-semibold text-rose-500 dark:text-rose-300">{joinError}</p>}
+              </form>
+              <div className="rounded-2xl border border-amber-900/25 bg-white/80 p-4 shadow-md shadow-amber-900/10 backdrop-blur dark:border-slate-800/70 dark:bg-slate-900/70 dark:shadow-black/30">
+                <div className="mb-3 flex items-center justify-between">
+                  <h3 className="text-xs uppercase tracking-[0.4em] text-amber-800/80 dark:text-amber-200/80">Active Rooms</h3>
                   <button
                     type="button"
-                    className="rounded-full border border-teal-400/60 px-5 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-teal-200 transition hover:bg-teal-500/20"
-                    onClick={() => refreshCampaigns()}
+                    className="text-xs font-semibold uppercase tracking-[0.3em] text-amber-700 transition hover:text-amber-900 dark:text-amber-200 dark:hover:text-amber-100"
+                    onClick={refreshLobby}
                   >
                     Refresh
                   </button>
                 </div>
-                <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
-                  {campaigns.map((campaign) => (
-                    <button
-                      key={campaign.id}
-                      className="group flex h-full flex-col justify-between rounded-2xl border border-slate-800/70 bg-slate-950/60 p-4 text-left transition hover:border-teal-400/60 hover:bg-slate-900/70"
-                      onClick={() => handleOpenCampaignAdmin(campaign)}
+                <ul className="max-h-48 space-y-2 overflow-y-auto pr-1 text-sm">
+                  {lobbySessions.map((session) => (
+                    <li
+                      key={session.id}
+                      className="rounded-xl border border-amber-900/25 bg-white/90 p-3 shadow-sm shadow-amber-900/10 backdrop-blur dark:border-slate-800/70 dark:bg-slate-950/60 dark:shadow-black/30"
                     >
-                      <div>
-                        <p className="text-xs uppercase tracking-[0.4em] text-slate-500">Campaign</p>
-                        <h3 className="mt-2 text-lg font-semibold text-white">{campaign.name}</h3>
-                        <p className="mt-2 text-xs text-slate-400">{campaign.description || 'No description provided.'}</p>
+                      <div className="flex flex-wrap items-center justify-between gap-2">
+                        <div>
+                          <p className="font-semibold text-slate-800 dark:text-slate-100">{session.name}</p>
+                          <p className="text-[10px] uppercase tracking-[0.4em] text-slate-500 dark:text-slate-400">Key: {session.id}</p>
+                        </div>
+                        <button
+                          type="button"
+                          className="rounded-lg border border-amber-400/60 bg-amber-500/80 px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-amber-400/90"
+                          onClick={() => handleJoinSession(session)}
+                        >
+                          Join
+                        </button>
                       </div>
-                      <span className="mt-4 inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.3em] text-teal-200">
-                        Open Hangar <span aria-hidden>→</span>
-                      </span>
-                    </button>
+                      <p className="mt-2 text-xs text-slate-500 dark:text-slate-400">
+                        Campaign: {session.campaignName ?? 'Unknown'} • Map: {session.mapName ?? 'Unknown'}
+                      </p>
+                    </li>
                   ))}
-                  {campaigns.length === 0 && (
-                    <div className="rounded-2xl border border-dashed border-slate-700/70 p-6 text-center text-sm text-slate-400">
-                      You haven't created any campaigns yet. Try the create tab to launch a new adventure.
-                    </div>
+                  {lobbySessions.length === 0 && (
+                    <li className="rounded-xl border border-dashed border-amber-900/25 px-3 py-6 text-center text-xs text-slate-500 dark:border-slate-700/70 dark:text-slate-400">
+                      No active rooms yet.
+                    </li>
                   )}
-                </div>
+                </ul>
               </div>
-            )}
-            {activeView === 'create' && (
-              <div className="space-y-6">
-                <h2 className="text-3xl font-black uppercase tracking-wide text-teal-200">Create Campaign</h2>
-                <p className="max-w-xl text-sm text-slate-300">Set up a new campaign for your players and start building encounters.</p>
-                <form onSubmit={handleCreateCampaign} className="space-y-5">
-                  <div>
-                    <label className="text-xs uppercase tracking-[0.4em] text-slate-400">Campaign Name</label>
-                    <input
-                      value={newCampaignName}
-                      onChange={(event) => setNewCampaignName(event.target.value)}
-                      className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
-                      placeholder="Give your mission a title"
-                    />
-                  </div>
-                  <div>
-                    <label className="text-xs uppercase tracking-[0.4em] text-slate-400">Description</label>
-                    <textarea
-                      value={newCampaignDescription}
-                      onChange={(event) => setNewCampaignDescription(event.target.value)}
-                      rows={4}
-                      className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
-                      placeholder="Share a quick briefing for your players"
-                    />
-                  </div>
-                  <label className="flex items-center gap-3 text-xs uppercase tracking-[0.4em] text-slate-400">
-                    <input
-                      type="checkbox"
-                      checked={newCampaignPublic}
-                      onChange={(event) => setNewCampaignPublic(event.target.checked)}
-                      className="h-4 w-4 rounded border border-slate-700 bg-slate-900 text-teal-400 focus:ring-teal-400"
-                    />
-                    <span className="text-slate-300">List publicly for players to discover</span>
-                  </label>
-                  {createError && <p className="text-xs font-semibold text-rose-300">{createError}</p>}
-                  <div className="flex flex-wrap gap-3">
-                    <button
-                      type="submit"
-                      className="rounded-xl border border-teal-400/60 bg-teal-500/80 px-6 py-3 text-sm font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-teal-400/90"
-                    >
-                      Launch Campaign
-                    </button>
-                    <button
-                      type="button"
-                      className="rounded-xl border border-slate-700/70 px-6 py-3 text-sm font-semibold uppercase tracking-[0.3em] text-slate-300 transition hover:border-teal-400/60 hover:text-teal-200"
-                      onClick={() => {
-                        setNewCampaignName('');
-                        setNewCampaignDescription('');
-                        setNewCampaignPublic(false);
-                        setCreateError(null);
-                      }}
-                    >
-                      Reset
-                    </button>
-                  </div>
-                </form>
-              </div>
-            )}
-            {activeView === 'admin' && selectedCampaign && (
-              <div className="space-y-6">
-                <div className="flex flex-wrap items-center justify-between gap-3">
-                  <div>
-                    <p className="text-xs uppercase tracking-[0.4em] text-teal-300">Managing Campaign</p>
-                    <h2 className="text-3xl font-black uppercase tracking-wide text-white">{selectedCampaign.name}</h2>
-                    {selectedCampaign.description && <p className="text-sm text-slate-300">{selectedCampaign.description}</p>}
-                  </div>
-                  <div className="flex flex-wrap items-center gap-3">
-                    <button
-                      type="button"
-                      className="rounded-full border border-slate-700/70 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-300 transition hover:border-teal-400/60 hover:text-teal-200"
-                      onClick={handleBackToManage}
-                    >
-                      Campaign List
-                    </button>
-                    <button
-                      type="button"
-                      className="rounded-full border border-rose-400/60 bg-rose-500/20 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-rose-200 transition hover:bg-rose-500/30"
-                      onClick={handleDeleteCampaign}
-                    >
-                      Delete Campaign
-                    </button>
-                    <button
-                      type="button"
-                      className="rounded-full border border-teal-400/60 bg-teal-500/80 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-teal-400/90"
-                      onClick={handleStartSession}
-                    >
-                      Launch Session
-                    </button>
-                  </div>
+            </div>
+          )}
+          {activeView === 'manage' && (
+            <div className="space-y-6">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <h2 className="text-3xl font-black uppercase tracking-wide text-amber-700 dark:text-amber-200">Manage Campaigns</h2>
+                  <p className="text-sm text-slate-600 dark:text-slate-300">Select a campaign to open the admin hangar.</p>
                 </div>
-                <div className="space-y-6">
-                  <MapFolderList
-                    maps={maps}
-                    selectedMapId={selectedMap?.id ?? null}
-                    onSelect={(map) => setSelectedMap(map)}
-                    onCreateMap={handleOpenMapWizard}
-                    onDeleteMap={handleDeleteMap}
-                    onDeleteGroup={handleDeleteGroup}
+                <button
+                  type="button"
+                  className="rounded-full border border-amber-900/30 px-5 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-amber-700 transition hover:border-amber-500/60 hover:text-amber-900 dark:border-amber-400/60 dark:text-amber-200 dark:hover:text-amber-100"
+                  onClick={() => refreshCampaigns()}
+                >
+                  Refresh
+                </button>
+              </div>
+              <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+                {campaigns.map((campaign) => (
+                  <button
+                    key={campaign.id}
+                    className="group flex h-full flex-col justify-between rounded-2xl border border-amber-900/25 bg-white/85 p-4 text-left shadow-sm shadow-amber-900/10 transition hover:-translate-y-1 hover:border-amber-500/60 hover:shadow-xl dark:border-slate-800/70 dark:bg-slate-900/70 dark:shadow-black/30"
+                    onClick={() => handleOpenCampaignAdmin(campaign)}
+                  >
+                    <div>
+                      <p className="text-xs uppercase tracking-[0.4em] text-amber-800/70 dark:text-amber-200/80">Campaign</p>
+                      <h3 className="mt-2 text-lg font-semibold text-slate-800 dark:text-white">{campaign.name}</h3>
+                      <p className="mt-2 text-xs text-slate-600 dark:text-slate-400">{campaign.description || 'No description provided.'}</p>
+                    </div>
+                    <span className="mt-4 inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.3em] text-amber-700 transition group-hover:text-amber-900 dark:text-amber-200 dark:group-hover:text-amber-100">
+                      Open Hangar <span aria-hidden>→</span>
+                    </span>
+                  </button>
+                ))}
+                {campaigns.length === 0 && (
+                  <div className="rounded-2xl border border-dashed border-amber-900/25 p-6 text-center text-sm text-slate-500 dark:border-slate-700/70 dark:text-slate-400">
+                    You haven't created any campaigns yet. Try the create tab to launch a new adventure.
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+          {activeView === 'create' && (
+            <div className="space-y-6">
+              <h2 className="text-3xl font-black uppercase tracking-wide text-amber-700 dark:text-amber-200">Create Campaign</h2>
+              <p className="max-w-xl text-sm text-slate-600 dark:text-slate-300">Set up a new campaign for your players and start building encounters.</p>
+              <form onSubmit={handleCreateCampaign} className="space-y-5">
+                <div>
+                  <label className="text-xs uppercase tracking-[0.4em] text-amber-800/80 dark:text-amber-200/80">Campaign Name</label>
+                  <input
+                    value={newCampaignName}
+                    onChange={(event) => setNewCampaignName(event.target.value)}
+                    className="mt-2 w-full rounded-xl border border-amber-900/25 bg-white/85 px-4 py-3 text-sm text-slate-800 shadow-sm placeholder:text-slate-500 focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-400/40 dark:border-slate-800/60 dark:bg-slate-950/70 dark:text-slate-100 dark:placeholder:text-slate-500"
+                    placeholder="Give your mission a title"
                   />
-                  <div className="grid gap-6 xl:grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)]">
-                    <div className="space-y-6">
-                      {selectedMap ? (
-                        <div className="rounded-2xl border border-slate-800/70 bg-slate-900/70 p-6">
-                          <div className="mb-6 flex flex-wrap items-start justify-between gap-4">
-                            <div>
-                              <h3 className="text-2xl font-semibold text-white">{selectedMap.name}</h3>
-                              {mapDescription && <p className="mt-2 text-sm text-slate-300">{mapDescription}</p>}
-                              {!mapDescription && mapNotes && <p className="mt-2 text-sm text-slate-400">{mapNotes}</p>}
-                            </div>
-                            <div className="flex flex-wrap items-center gap-4 text-xs uppercase tracking-[0.4em] text-slate-500">
-                              <span>Regions: {regions.length}</span>
-                              <span>Markers: {markers.length}</span>
-                              <span>
-                                Size: {selectedMap.width ?? '—'} × {selectedMap.height ?? '—'}
-                              </span>
-                            </div>
+                </div>
+                <div>
+                  <label className="text-xs uppercase tracking-[0.4em] text-amber-800/80 dark:text-amber-200/80">Description</label>
+                  <textarea
+                    value={newCampaignDescription}
+                    onChange={(event) => setNewCampaignDescription(event.target.value)}
+                    rows={4}
+                    className="mt-2 w-full rounded-xl border border-amber-900/25 bg-white/85 px-4 py-3 text-sm text-slate-800 shadow-sm placeholder:text-slate-500 focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-400/40 dark:border-slate-800/60 dark:bg-slate-950/70 dark:text-slate-100 dark:placeholder:text-slate-500"
+                    placeholder="Share a quick briefing for your players"
+                  />
+                </div>
+                <label className="flex items-center gap-3 text-xs uppercase tracking-[0.4em] text-amber-800/80 dark:text-amber-200/80">
+                  <input
+                    type="checkbox"
+                    checked={newCampaignPublic}
+                    onChange={(event) => setNewCampaignPublic(event.target.checked)}
+                    className="h-4 w-4 rounded border border-amber-900/30 bg-white text-amber-600 focus:ring-amber-400 dark:border-slate-700 dark:bg-slate-900 dark:text-amber-400"
+                  />
+                  <span className="text-slate-600 dark:text-slate-300">List publicly for players to discover</span>
+                </label>
+                {createError && <p className="text-xs font-semibold text-rose-500 dark:text-rose-300">{createError}</p>}
+                <div className="flex flex-wrap gap-3">
+                  <button
+                    type="submit"
+                    className="rounded-xl bg-gradient-to-r from-amber-500 via-orange-500 to-rose-500 px-6 py-3 text-sm font-semibold uppercase tracking-[0.3em] text-white shadow-lg shadow-amber-500/30 transition hover:scale-[1.02] focus:outline-none focus:ring-2 focus:ring-amber-400/40"
+                  >
+                    Launch Campaign
+                  </button>
+                  <button
+                    type="button"
+                    className="rounded-xl border border-amber-900/30 bg-white/70 px-6 py-3 text-sm font-semibold uppercase tracking-[0.3em] text-amber-700 transition hover:border-amber-500/60 hover:text-amber-900 dark:border-amber-400/60 dark:bg-slate-900/60 dark:text-amber-200 dark:hover:text-amber-100"
+                    onClick={() => {
+                      setNewCampaignName('');
+                      setNewCampaignDescription('');
+                      setNewCampaignPublic(false);
+                      setCreateError(null);
+                    }}
+                  >
+                    Reset
+                  </button>
+                </div>
+              </form>
+            </div>
+          )}
+          {activeView === 'admin' && selectedCampaign && (
+            <div className="space-y-6">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <p className="text-xs uppercase tracking-[0.4em] text-amber-700 dark:text-amber-300">Managing Campaign</p>
+                  <h2 className="text-3xl font-black uppercase tracking-wide text-slate-900 dark:text-white">{selectedCampaign.name}</h2>
+                  {selectedCampaign.description && <p className="text-sm text-slate-600 dark:text-slate-300">{selectedCampaign.description}</p>}
+                </div>
+                <div className="flex flex-wrap items-center gap-3">
+                  <button
+                    type="button"
+                    className="rounded-full border border-amber-900/30 bg-white/70 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-700 transition hover:border-amber-500/60 hover:text-amber-800 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-200 dark:hover:text-amber-200"
+                    onClick={handleBackToManage}
+                  >
+                    Campaign List
+                  </button>
+                  <button
+                    type="button"
+                    className="rounded-full border border-rose-400/60 bg-rose-100/70 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-rose-700 transition hover:bg-rose-200/80 dark:border-rose-400/60 dark:bg-rose-500/30 dark:text-rose-100 dark:hover:bg-rose-500/40"
+                    onClick={handleDeleteCampaign}
+                  >
+                    Delete Campaign
+                  </button>
+                  <button
+                    type="button"
+                    className="rounded-full bg-gradient-to-r from-amber-500 via-orange-500 to-rose-500 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-white shadow-lg shadow-amber-500/30 transition hover:scale-[1.02]"
+                    onClick={handleStartSession}
+                  >
+                    Launch Session
+                  </button>
+                </div>
+              </div>
+              <div className="space-y-6">
+                <MapFolderList
+                  maps={maps}
+                  selectedMapId={selectedMap?.id ?? null}
+                  onSelect={(map) => setSelectedMap(map)}
+                  onCreateMap={handleOpenMapWizard}
+                  onDeleteMap={handleDeleteMap}
+                  onDeleteGroup={handleDeleteGroup}
+                />
+                <div className="grid gap-6 xl:grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)]">
+                  <div className="space-y-6">
+                    {selectedMap ? (
+                      <div className="rounded-2xl border border-amber-900/25 bg-white/85 p-6 shadow-lg shadow-amber-900/10 backdrop-blur dark:border-slate-800/70 dark:bg-slate-900/70 dark:shadow-black/40">
+                        <div className="mb-6 flex flex-wrap items-start justify-between gap-4">
+                          <div>
+                            <h3 className="text-2xl font-semibold text-slate-800 dark:text-white">{selectedMap.name}</h3>
+                            {mapDescription && <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">{mapDescription}</p>}
+                            {!mapDescription && mapNotes && <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">{mapNotes}</p>}
                           </div>
-                          <div className="overflow-hidden rounded-2xl border border-slate-800/70 bg-slate-950/70">
-                            <MapMaskCanvas
-                              imageUrl={selectedMap ? apiClient.buildMapDisplayUrl(selectedMap.id) : undefined}
-                              width={selectedMap.width}
-                              height={selectedMap.height}
-                              regions={regions}
-                              revealedRegionIds={[]}
-                              markers={markers}
-                              mode="dm"
-                            />
+                          <div className="flex flex-wrap items-center gap-4 text-xs uppercase tracking-[0.4em] text-slate-500 dark:text-slate-400">
+                            <span>Regions: {regions.length}</span>
+                            <span>Markers: {markers.length}</span>
+                            <span>
+                              Size: {selectedMap.width ?? '—'} × {selectedMap.height ?? '—'}
+                            </span>
                           </div>
-                          <div className="mt-6 grid gap-4 lg:grid-cols-2">
-                            <div className="rounded-2xl border border-slate-800/70 bg-slate-950/70 p-4">
-                              <p className="text-[10px] uppercase tracking-[0.4em] text-slate-500">Grouping</p>
-                              <p className="mt-2 text-sm font-semibold text-teal-200">{mapGrouping}</p>
-                              {mapNotes && mapDescription && (
-                                <p className="mt-3 text-xs text-slate-400">Notes: {mapNotes}</p>
-                              )}
-                            </div>
-                            <div className="rounded-2xl border border-slate-800/70 bg-slate-950/70 p-4">
-                              <p className="text-[10px] uppercase tracking-[0.4em] text-slate-500">Tags</p>
-                              {mapTags.length > 0 ? (
-                                <div className="mt-3 flex flex-wrap gap-2">
-                                  {mapTags.map((tag) => (
-                                    <span
-                                      key={tag}
-                                      className="inline-flex items-center rounded-full border border-slate-700/70 bg-slate-900/70 px-2 py-1 text-[10px] uppercase tracking-[0.3em] text-slate-300"
-                                    >
-                                      {tag}
-                                    </span>
-                                  ))}
-                                </div>
-                              ) : (
-                                <p className="mt-3 text-xs text-slate-500">No tags assigned yet.</p>
-                              )}
-                            </div>
-                          </div>
-                          {!mapDescription && !mapNotes && (
-                            <p className="mt-4 text-xs text-slate-500">
-                              Add details and notes through the map wizard to give your players extra context.
-                            </p>
-                          )}
                         </div>
-                      ) : (
-                        <div className="rounded-2xl border border-dashed border-slate-700/70 p-12 text-center text-sm text-slate-400">
-                          Select or create a map to begin shaping your encounter.
+                        <div className="overflow-hidden rounded-2xl border border-amber-900/25 bg-white/80 dark:border-slate-800/70 dark:bg-slate-950/70">
+                          <MapMaskCanvas
+                            imageUrl={selectedMap ? apiClient.buildMapDisplayUrl(selectedMap.id) : undefined}
+                            width={selectedMap.width}
+                            height={selectedMap.height}
+                            regions={regions}
+                            revealedRegionIds={[]}
+                            markers={markers}
+                            mode="dm"
+                          />
                         </div>
-                      )}
+                        <div className="mt-6 grid gap-4 lg:grid-cols-2">
+                          <div className="rounded-2xl border border-amber-900/25 bg-white/80 p-4 shadow-sm shadow-amber-900/10 backdrop-blur dark:border-slate-800/70 dark:bg-slate-900/70 dark:shadow-black/30">
+                            <p className="text-[10px] uppercase tracking-[0.4em] text-amber-800/70 dark:text-amber-200/80">Grouping</p>
+                            <p className="mt-2 text-sm font-semibold text-amber-700 dark:text-amber-200">{mapGrouping}</p>
+                            {mapNotes && mapDescription && (
+                              <p className="mt-3 text-xs text-slate-600 dark:text-slate-400">Notes: {mapNotes}</p>
+                            )}
+                          </div>
+                          <div className="rounded-2xl border border-amber-900/25 bg-white/80 p-4 shadow-sm shadow-amber-900/10 backdrop-blur dark:border-slate-800/70 dark:bg-slate-900/70 dark:shadow-black/30">
+                            <p className="text-[10px] uppercase tracking-[0.4em] text-amber-800/70 dark:text-amber-200/80">Tags</p>
+                            {mapTags.length > 0 ? (
+                              <div className="mt-3 flex flex-wrap gap-2">
+                                {mapTags.map((tag) => (
+                                  <span
+                                    key={tag}
+                                    className="inline-flex items-center rounded-full border border-amber-900/25 bg-white/85 px-2 py-1 text-[10px] uppercase tracking-[0.3em] text-amber-700 shadow-sm shadow-amber-900/10 dark:border-slate-700/70 dark:bg-slate-900/70 dark:text-amber-200"
+                                  >
+                                    {tag}
+                                  </span>
+                                ))}
+                              </div>
+                            ) : (
+                              <p className="mt-3 text-xs text-slate-600 dark:text-slate-400">No tags assigned yet.</p>
+                            )}
+                          </div>
+                        </div>
+                        {!mapDescription && !mapNotes && (
+                          <p className="mt-4 text-xs text-slate-600 dark:text-slate-400">
+                            Add details and notes through the map wizard to give your players extra context.
+                          </p>
+                        )}
+                      </div>
+                    ) : (
+                      <div className="rounded-2xl border border-dashed border-amber-900/25 p-12 text-center text-sm text-slate-500 dark:border-slate-700/70 dark:text-slate-400">
+                        Select or create a map to begin shaping your encounter.
+                      </div>
+                    )}
+                  </div>
+                  <div className="space-y-6">
+                    <div className="rounded-2xl border border-amber-900/25 bg-white/80 p-5 shadow-sm shadow-amber-900/10 backdrop-blur dark:border-slate-800/70 dark:bg-slate-900/70 dark:shadow-black/30">
+                      <div className="mb-3 flex items-center justify-between">
+                        <h3 className="text-xs uppercase tracking-[0.4em] text-amber-800/80 dark:text-amber-200/80">My Sessions</h3>
+                      </div>
+                      <ul className="space-y-2 text-sm">
+                        {mySessions.map((session) => (
+                          <li key={session.id}>
+                            <button
+                              onClick={() => handleJoinSession(session)}
+                              className="w-full rounded-xl border border-amber-900/25 bg-white/85 px-3 py-2 text-left text-slate-700 shadow-sm transition hover:border-amber-500/60 hover:text-amber-800 dark:border-slate-800/70 dark:bg-slate-950/60 dark:text-slate-200 dark:hover:text-amber-100"
+                            >
+                              {session.name}
+                            </button>
+                          </li>
+                        ))}
+                        {mySessions.length === 0 && (
+                          <li className="rounded-xl border border-dashed border-amber-900/25 px-3 py-6 text-center text-xs text-slate-500 dark:border-slate-700/70 dark:text-slate-400">
+                            No active sessions.
+                          </li>
+                        )}
+                      </ul>
                     </div>
-                    <div className="space-y-6">
-                      <div className="rounded-2xl border border-slate-800/70 bg-slate-900/70 p-5">
-                        <div className="mb-3 flex items-center justify-between">
-                          <h3 className="text-xs uppercase tracking-[0.4em] text-slate-400">My Sessions</h3>
-                        </div>
-                        <ul className="space-y-2 text-sm">
-                          {mySessions.map((session) => (
-                            <li key={session.id}>
-                              <button
-                                onClick={() => handleJoinSession(session)}
-                                className="w-full rounded-xl border border-slate-800/70 bg-slate-950/60 px-3 py-2 text-left text-slate-300 transition hover:border-teal-400/60 hover:text-teal-100"
-                              >
-                                {session.name}
-                              </button>
-                            </li>
-                          ))}
-                          {mySessions.length === 0 && (
-                            <li className="rounded-xl border border-dashed border-slate-700/70 px-3 py-6 text-center text-xs text-slate-500">
-                              No active sessions.
-                            </li>
-                          )}
-                        </ul>
+                    <div className="rounded-2xl border border-amber-900/25 bg-white/80 p-5 shadow-sm shadow-amber-900/10 backdrop-blur dark:border-slate-800/70 dark:bg-slate-900/70 dark:shadow-black/30">
+                      <div className="mb-3 flex items-center justify-between">
+                        <h3 className="text-xs uppercase tracking-[0.4em] text-amber-800/80 dark:text-amber-200/80">Lobby</h3>
+                        <button
+                          type="button"
+                          className="text-xs font-semibold uppercase tracking-[0.3em] text-amber-700 transition hover:text-amber-900 dark:text-amber-200 dark:hover:text-amber-100"
+                          onClick={refreshLobby}
+                        >
+                          Refresh
+                        </button>
                       </div>
-                      <div className="rounded-2xl border border-slate-800/70 bg-slate-900/70 p-5">
-                        <div className="mb-3 flex items-center justify-between">
-                          <h3 className="text-xs uppercase tracking-[0.4em] text-slate-400">Lobby</h3>
-                          <button
-                            type="button"
-                            className="text-xs font-semibold uppercase tracking-[0.3em] text-teal-200 transition hover:text-teal-100"
-                            onClick={refreshLobby}
+                      <ul className="space-y-2 text-sm">
+                        {lobbySessions.map((session) => (
+                          <li
+                            key={session.id}
+                            className="rounded-xl border border-amber-900/25 bg-white/90 p-3 shadow-sm shadow-amber-900/10 backdrop-blur dark:border-slate-800/70 dark:bg-slate-950/60 dark:shadow-black/30"
                           >
-                            Refresh
-                          </button>
-                        </div>
-                        <ul className="space-y-2 text-sm">
-                          {lobbySessions.map((session) => (
-                            <li key={session.id} className="rounded-xl border border-slate-800/70 bg-slate-950/60 p-3">
-                              <p className="font-semibold text-slate-100">{session.name}</p>
-                              <p className="text-[10px] uppercase tracking-[0.4em] text-slate-500">Campaign: {session.campaignName ?? 'Unknown'}</p>
-                              <p className="text-[10px] uppercase tracking-[0.4em] text-slate-500">Map: {session.mapName ?? 'Unknown'}</p>
-                              <button
-                                type="button"
-                                className="mt-3 w-full rounded-xl border border-teal-400/60 bg-teal-500/80 px-3 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-teal-400/90"
-                                onClick={() => handleJoinSession(session)}
-                              >
-                                Join as {session.hostId === user.id ? 'DM' : 'Player'}
-                              </button>
-                            </li>
-                          ))}
-                          {lobbySessions.length === 0 && (
-                            <li className="rounded-xl border border-dashed border-slate-700/70 px-3 py-6 text-center text-xs text-slate-500">
-                              No active sessions available.
-                            </li>
-                          )}
-                        </ul>
-                      </div>
+                            <p className="font-semibold text-slate-800 dark:text-slate-100">{session.name}</p>
+                            <p className="text-[10px] uppercase tracking-[0.4em] text-slate-500 dark:text-slate-400">
+                              Campaign: {session.campaignName ?? 'Unknown'}
+                            </p>
+                            <p className="text-[10px] uppercase tracking-[0.4em] text-slate-500 dark:text-slate-400">
+                              Map: {session.mapName ?? 'Unknown'}
+                            </p>
+                            <button
+                              type="button"
+                              className="mt-3 w-full rounded-xl bg-gradient-to-r from-amber-500 via-orange-500 to-rose-500 px-3 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-white shadow-lg shadow-amber-500/30 transition hover:scale-[1.02]"
+                              onClick={() => handleJoinSession(session)}
+                            >
+                              Join as {session.hostId === user.id ? 'DM' : 'Player'}
+                            </button>
+                          </li>
+                        ))}
+                        {lobbySessions.length === 0 && (
+                          <li className="rounded-xl border border-dashed border-amber-900/25 px-3 py-6 text-center text-xs text-slate-500 dark:border-slate-700/70 dark:text-slate-400">
+                            No active sessions available.
+                          </li>
+                        )}
+                      </ul>
                     </div>
                   </div>
                 </div>
               </div>
-            )}
-            {activeView === 'admin' && !selectedCampaign && (
-              <div className="rounded-2xl border border-dashed border-slate-700/70 p-12 text-center text-sm text-slate-400">
-                Choose a campaign from the manage tab to configure it here.
-              </div>
-            )}
-          </div>
-        </section>
-        {showMapWizard && selectedCampaign && (
-          <MapCreationWizard
-            campaign={selectedCampaign}
-            onClose={handleCloseMapWizard}
-            onComplete={handleMapWizardComplete}
-          />
-        )}
-      </div>
+            </div>
+          )}
+          {activeView === 'admin' && !selectedCampaign && (
+            <div className="rounded-2xl border border-dashed border-amber-900/25 p-12 text-center text-sm text-slate-500 dark:border-slate-700/70 dark:text-slate-400">
+              Choose a campaign from the manage tab to configure it here.
+            </div>
+          )}
+        </div>
+      </section>
+      {showMapWizard && selectedCampaign && (
+        <MapCreationWizard campaign={selectedCampaign} onClose={handleCloseMapWizard} onComplete={handleMapWizardComplete} />
+      )}
     </div>
   );
 };

--- a/apps/pages/src/components/AuthPanel.tsx
+++ b/apps/pages/src/components/AuthPanel.tsx
@@ -50,8 +50,8 @@ const AuthPanel: React.FC<AuthPanelProps> = ({ onAuthenticate, className, varian
     className
   );
 
-  const badgeText = mode === 'login' ? 'Return to the table' : 'Create a DM profile';
-  const headingText = mode === 'login' ? 'Sign in to D&D Map Reveal' : 'Join the D&D Map Reveal beta';
+  const badgeText = mode === 'login' ? 'Return to the light' : 'Create a torchbearer profile';
+  const headingText = mode === 'login' ? 'Sign in to TableTorch' : 'Join the TableTorch beta';
   const submitLabel = loading ? 'Please wait…' : mode === 'login' ? 'Log in' : 'Sign up';
   const toggleLabel = mode === 'login' ? 'Need an account?' : 'Already have an account?';
   const toggleHelper = mode === 'login' ? 'Create one instead' : 'Use your existing login';
@@ -60,11 +60,11 @@ const AuthPanel: React.FC<AuthPanelProps> = ({ onAuthenticate, className, varian
     <section className={containerClasses} aria-labelledby={`${formId}-title`}>
       <span
         aria-hidden
-        className="pointer-events-none absolute -top-28 left-1/2 h-72 w-72 -translate-x-1/2 rounded-full bg-teal-400/20 blur-3xl dark:bg-teal-500/10"
+        className="pointer-events-none absolute -top-28 left-1/2 h-72 w-72 -translate-x-1/2 rounded-full bg-amber-300/25 blur-3xl dark:bg-amber-500/15"
       />
       <div className="relative space-y-8">
         <header className="space-y-3">
-          <span className="inline-flex items-center rounded-full border border-teal-500/40 bg-teal-100/60 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.3em] text-teal-700 shadow-sm dark:border-teal-400/50 dark:bg-teal-500/10 dark:text-teal-200">
+          <span className="inline-flex items-center rounded-full border border-amber-500/40 bg-amber-100/70 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.3em] text-amber-700 shadow-sm dark:border-amber-400/50 dark:bg-amber-500/10 dark:text-amber-200">
             {badgeText}
           </span>
           <div className="flex flex-wrap items-start justify-between gap-4">
@@ -73,13 +73,13 @@ const AuthPanel: React.FC<AuthPanelProps> = ({ onAuthenticate, className, varian
                 {headingText}
               </h2>
               <p className="text-sm text-slate-600 dark:text-slate-300">
-                Use the pre-filled demo credentials or sign up with your own details to explore the DM console.
+                Use the pre-filled demo credentials or sign up with your own details to explore the TableTorch console.
               </p>
             </div>
             <button
               type="button"
               onClick={() => setMode((current) => (current === 'login' ? 'signup' : 'login'))}
-              className="inline-flex items-center rounded-full border border-slate-300/70 bg-white/40 px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-slate-500 transition hover:border-teal-400/60 hover:text-teal-600 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-300 dark:hover:border-teal-400/50 dark:hover:text-teal-200"
+              className="inline-flex items-center rounded-full border border-slate-300/70 bg-white/40 px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-slate-500 transition hover:border-amber-400/60 hover:text-amber-600 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-300 dark:hover:border-amber-400/50 dark:hover:text-amber-200"
               aria-pressed={mode === 'signup'}
             >
               {toggleLabel}
@@ -106,7 +106,7 @@ const AuthPanel: React.FC<AuthPanelProps> = ({ onAuthenticate, className, varian
                 value={email}
                 onChange={(event) => setEmail(event.target.value)}
                 autoComplete="email"
-                className="w-full rounded-2xl border border-slate-300/80 bg-white px-4 py-3 text-sm font-medium text-slate-900 shadow-sm transition focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-400/60 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:focus:border-teal-400"
+                className="w-full rounded-2xl border border-slate-300/80 bg-white px-4 py-3 text-sm font-medium text-slate-900 shadow-sm transition focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-400/60 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:focus:border-amber-400"
                 required
               />
             </div>
@@ -120,7 +120,7 @@ const AuthPanel: React.FC<AuthPanelProps> = ({ onAuthenticate, className, varian
                   value={displayName}
                   onChange={(event) => setDisplayName(event.target.value)}
                   autoComplete="name"
-                  className="w-full rounded-2xl border border-slate-300/80 bg-white px-4 py-3 text-sm font-medium text-slate-900 shadow-sm transition focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-400/60 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:focus:border-teal-400"
+                  className="w-full rounded-2xl border border-slate-300/80 bg-white px-4 py-3 text-sm font-medium text-slate-900 shadow-sm transition focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-400/60 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:focus:border-amber-400"
                   required
                 />
               </div>
@@ -135,7 +135,7 @@ const AuthPanel: React.FC<AuthPanelProps> = ({ onAuthenticate, className, varian
                 value={password}
                 onChange={(event) => setPassword(event.target.value)}
                 autoComplete={mode === 'login' ? 'current-password' : 'new-password'}
-                className="w-full rounded-2xl border border-slate-300/80 bg-white px-4 py-3 text-sm font-medium text-slate-900 shadow-sm transition focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-400/60 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:focus:border-teal-400"
+                className="w-full rounded-2xl border border-slate-300/80 bg-white px-4 py-3 text-sm font-medium text-slate-900 shadow-sm transition focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-400/60 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:focus:border-amber-400"
                 required
               />
             </div>
@@ -148,7 +148,7 @@ const AuthPanel: React.FC<AuthPanelProps> = ({ onAuthenticate, className, varian
           <button
             type="submit"
             disabled={loading}
-            className="flex w-full items-center justify-center gap-2 rounded-2xl bg-gradient-to-r from-teal-500 via-sky-500 to-blue-500 px-5 py-3 text-sm font-semibold uppercase tracking-[0.4em] text-white shadow-lg shadow-teal-500/30 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-white/80 focus-visible:ring-offset-2 focus-visible:ring-offset-teal-500 disabled:cursor-wait disabled:opacity-80"
+            className="flex w-full items-center justify-center gap-2 rounded-2xl bg-gradient-to-r from-amber-500 via-orange-500 to-rose-500 px-5 py-3 text-sm font-semibold uppercase tracking-[0.4em] text-white shadow-lg shadow-amber-500/30 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-white/80 focus-visible:ring-offset-2 focus-visible:ring-offset-amber-500 disabled:cursor-wait disabled:opacity-80"
           >
             {submitLabel}
           </button>

--- a/apps/pages/src/components/LandingPage.tsx
+++ b/apps/pages/src/components/LandingPage.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import type { AuthResponse } from '../types';
 import AuthPanel from './AuthPanel';
+import parchmentTextureUrl from '@textures/parchment-bg.jpg';
 
 interface LandingPageProps {
   theme: 'light' | 'dark';
@@ -11,25 +12,49 @@ interface LandingPageProps {
 const features = [
   {
     title: 'Reveal maps live',
-    description: 'Fade in fog-of-war with precision tools built for dramatic reveals and on-the-fly adjustments.',
+    description: 'Lift the shroud on battle maps with warm torchlight fades and cinematic timing you can control.',
     icon: '🗺️',
   },
   {
     title: 'Campaign control',
-    description: 'Organise every battlemap, note and marker by campaign so your prep is ready when players arrive.',
+    description: 'Keep every room, route, and note close at hand so your prep feels effortless at the table.',
     icon: '🎯',
   },
   {
     title: 'Share instantly',
-    description: 'Invite players with short join codes and let them explore revealed regions from any device.',
+    description: 'Invite players with short join codes and let them follow the glow of discovery on any device.',
     icon: '⚡',
   },
   {
     title: 'Save your progress',
-    description: 'Archive live sessions and pick up where you left off without losing the dramatic tension.',
+    description: 'Archive sessions and return to the adventure with every illuminated detail right where you left it.',
     icon: '🛡️',
   },
 ];
+
+const TorchIcon: React.FC<{ className?: string }> = ({ className }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 64 64"
+    fill="none"
+    className={className}
+    role="img"
+    aria-hidden
+  >
+    <path
+      d="M32 6c4 4 10 10 10 16 0 6-4.5 10-10 10s-10-4-10-10C22 16 28 10 32 6Z"
+      className="fill-amber-400 dark:fill-amber-300"
+    />
+    <path
+      d="M30 30h4l2 6-2 22h-4l-2-22 2-6Z"
+      className="fill-slate-800 dark:fill-slate-200"
+    />
+    <path
+      d="M26 32h12l-1.5 8h-9L26 32Z"
+      className="fill-amber-600/80 dark:fill-amber-500/70"
+    />
+  </svg>
+);
 
 const LandingPage: React.FC<LandingPageProps> = ({ theme, setTheme, onAuthenticate }) => {
   const themeLabel = theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode';
@@ -38,27 +63,41 @@ const LandingPage: React.FC<LandingPageProps> = ({ theme, setTheme, onAuthentica
     setTheme(theme === 'dark' ? 'light' : 'dark');
   };
 
+  const backgroundStyles = useMemo(
+    () => ({ '--parchment-texture': `url(${parchmentTextureUrl})` }) as React.CSSProperties,
+    []
+  );
+
   return (
-    <div className="bg-landing relative min-h-screen overflow-hidden text-slate-900 transition-colors dark:text-slate-100">
+    <div
+      style={backgroundStyles}
+      className="bg-landing relative min-h-screen overflow-hidden text-slate-900 transition-colors dark:text-slate-100"
+    >
       <div aria-hidden className="absolute inset-0 bg-grid-mask opacity-60 mix-blend-soft-light dark:opacity-40" />
-      <div aria-hidden className="pointer-events-none absolute -top-32 right-12 h-72 w-72 rounded-full bg-sky-400/30 blur-3xl dark:bg-sky-500/20 animate-float-slow" />
-      <div aria-hidden className="pointer-events-none absolute bottom-[-10rem] left-[-6rem] h-96 w-96 rounded-full bg-teal-400/20 blur-[120px] dark:bg-teal-500/20 animate-float-slow" />
+      <div aria-hidden className="pointer-events-none absolute -top-32 right-12 h-72 w-72 rounded-full bg-amber-300/30 blur-3xl dark:bg-amber-500/20 animate-float-slow" />
+      <div aria-hidden className="pointer-events-none absolute bottom-[-10rem] left-[-6rem] h-96 w-96 rounded-full bg-orange-300/20 blur-[120px] dark:bg-rose-500/20 animate-float-slow" />
       <div className="relative isolate">
         <header className="mx-auto flex max-w-7xl flex-wrap items-center justify-between gap-4 px-6 py-8 sm:py-10">
           <div className="flex items-center gap-4">
-            <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-slate-900/90 text-2xl font-black text-teal-300 shadow-2xl shadow-teal-500/20 ring-4 ring-white/50 backdrop-blur dark:bg-white/10 dark:text-teal-200 dark:ring-teal-500/30">
-              DM
+            <div className="relative">
+              <div className="relative flex h-16 w-16 items-center justify-center rounded-2xl border border-amber-500/30 bg-amber-100/70 shadow-lg shadow-amber-500/30 ring-4 ring-white/40 backdrop-blur dark:border-amber-200/30 dark:bg-slate-900/80 dark:ring-amber-500/20">
+                <TorchIcon className="h-10 w-10" />
+              </div>
+              <div
+                aria-hidden
+                className="pointer-events-none absolute -inset-6 hidden rounded-full bg-[radial-gradient(circle_at_center,_rgba(253,186,116,0.25),_rgba(253,186,116,0))] blur-md dark:block"
+              />
             </div>
             <div>
-              <p className="text-xs uppercase tracking-[0.45em] text-teal-600 dark:text-teal-300">D&D Map Reveal</p>
-              <p className="text-lg font-semibold text-slate-900 dark:text-slate-100">Fog-of-war built for dramatic storytelling</p>
+              <p className="text-xs uppercase tracking-[0.45em] text-amber-700 dark:text-amber-300">TableTorch</p>
+              <p className="text-lg font-semibold text-slate-900 dark:text-slate-100">Bring warm torchlight to every encounter</p>
             </div>
           </div>
           <button
             type="button"
             onClick={handleThemeToggle}
             aria-pressed={theme === 'dark'}
-            className="inline-flex items-center gap-2 rounded-full border border-slate-300/70 bg-white/40 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-600 shadow-sm transition hover:border-teal-400/70 hover:text-teal-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-teal-400 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-200 dark:hover:border-teal-400/60 dark:hover:text-teal-200"
+            className="inline-flex items-center gap-2 rounded-full border border-slate-300/70 bg-white/40 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-600 shadow-sm transition hover:border-amber-400/70 hover:text-amber-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-400 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-200 dark:hover:border-amber-400/60 dark:hover:text-amber-200"
           >
             <span className="text-base" aria-hidden>
               {theme === 'dark' ? '🌙' : '🌞'}
@@ -69,25 +108,25 @@ const LandingPage: React.FC<LandingPageProps> = ({ theme, setTheme, onAuthentica
         <main className="mx-auto grid max-w-7xl gap-16 px-6 pb-24 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,0.9fr)] lg:items-center">
           <section className="space-y-10">
             <div className="space-y-6">
-              <span className="inline-flex items-center rounded-full border border-teal-400/50 bg-teal-100/60 px-4 py-1 text-[11px] font-semibold uppercase tracking-[0.35em] text-teal-700 shadow-sm dark:border-teal-500/40 dark:bg-teal-500/10 dark:text-teal-200">
-                Your new DM co-pilot
+              <span className="inline-flex items-center rounded-full border border-amber-400/50 bg-amber-100/70 px-4 py-1 text-[11px] font-semibold uppercase tracking-[0.35em] text-amber-700 shadow-sm dark:border-amber-400/40 dark:bg-amber-500/10 dark:text-amber-200">
+                Your tabletop lighting co-pilot
               </span>
               <h1 className="text-4xl font-black tracking-tight text-slate-900 sm:text-5xl dark:text-white">
-                Guide your party through unforgettable encounters with cinematic map reveals.
+                Guide your party through unforgettable encounters with cinematic torchlit reveals.
               </h1>
               <p className="max-w-xl text-lg text-slate-600 dark:text-slate-300">
-                D&D Map Reveal keeps your battlemap prep organised and ready. Cue dramatic lighting, reveal regions in real time, and manage campaigns without breaking the table’s immersion.
+                TableTorch keeps your battlemap prep organised and ready. Cue dramatic lighting, reveal regions in real time, and manage campaigns without breaking the table’s immersion.
               </p>
               <div className="flex flex-wrap items-center gap-4">
                 <a
                   href="#auth-panel"
-                  className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-teal-500 via-sky-500 to-blue-500 px-6 py-3 text-xs font-semibold uppercase tracking-[0.45em] text-white shadow-lg shadow-teal-500/30 transition hover:scale-[1.02] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-teal-400"
+                  className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-amber-500 via-orange-500 to-rose-500 px-6 py-3 text-xs font-semibold uppercase tracking-[0.45em] text-white shadow-lg shadow-amber-500/30 transition hover:scale-[1.02] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-400"
                 >
-                  Launch the demo
+                  Ignite the demo
                 </a>
                 <a
                   href="#features"
-                  className="inline-flex items-center justify-center gap-2 rounded-full border border-slate-300/70 bg-white/60 px-6 py-3 text-xs font-semibold uppercase tracking-[0.35em] text-slate-600 transition hover:border-teal-400/60 hover:text-teal-600 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-200 dark:hover:border-teal-400/60 dark:hover:text-teal-200"
+                  className="inline-flex items-center justify-center gap-2 rounded-full border border-slate-300/70 bg-white/60 px-6 py-3 text-xs font-semibold uppercase tracking-[0.35em] text-slate-600 transition hover:border-amber-400/60 hover:text-amber-600 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-200 dark:hover:border-amber-400/60 dark:hover:text-amber-200"
                 >
                   Explore features
                   <span aria-hidden>→</span>
@@ -100,7 +139,7 @@ const LandingPage: React.FC<LandingPageProps> = ({ theme, setTheme, onAuthentica
                   key={feature.title}
                   className="group relative overflow-hidden rounded-3xl border border-white/60 bg-white/80 p-6 shadow-lg shadow-slate-200/40 transition hover:-translate-y-1 hover:shadow-2xl dark:border-slate-800/70 dark:bg-slate-900/70 dark:shadow-black/40"
                 >
-                  <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-teal-500/20 to-sky-500/10 text-2xl">
+                  <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-amber-500/20 to-rose-400/10 text-2xl">
                     <span aria-hidden>{feature.icon}</span>
                     <span className="sr-only">{feature.title} icon</span>
                   </div>
@@ -108,7 +147,7 @@ const LandingPage: React.FC<LandingPageProps> = ({ theme, setTheme, onAuthentica
                   <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">{feature.description}</p>
                   <div
                     aria-hidden
-                    className="pointer-events-none absolute inset-0 translate-y-full bg-gradient-to-t from-teal-500/10 to-transparent transition duration-500 group-hover:translate-y-0"
+                    className="pointer-events-none absolute inset-0 translate-y-full bg-gradient-to-t from-amber-500/10 to-transparent transition duration-500 group-hover:translate-y-0"
                   />
                 </article>
               ))}
@@ -116,17 +155,17 @@ const LandingPage: React.FC<LandingPageProps> = ({ theme, setTheme, onAuthentica
           </section>
           <aside className="relative">
             <div aria-hidden className="absolute inset-0 -translate-y-6 rounded-[2.75rem] bg-white/50 blur-3xl dark:bg-slate-900/50" />
-            <div className="relative rounded-[2.5rem] border border-white/40 bg-white/60 p-1 shadow-2xl shadow-teal-500/10 backdrop-blur-xl dark:border-slate-800/60 dark:bg-slate-950/60">
-              <div className="absolute -top-16 right-10 h-24 w-24 rounded-full bg-gradient-to-br from-teal-400/40 to-sky-500/20 blur-3xl dark:from-teal-500/30 dark:to-sky-500/20 animate-gradient" aria-hidden />
-              <div className="absolute bottom-10 left-10 h-20 w-20 rounded-full bg-teal-400/20 blur-2xl dark:bg-teal-500/20 animate-float-slow" aria-hidden />
+            <div className="relative rounded-[2.5rem] border border-white/40 bg-white/60 p-1 shadow-2xl shadow-amber-500/10 backdrop-blur-xl dark:border-slate-800/60 dark:bg-slate-950/60">
+              <div className="absolute -top-16 right-10 h-24 w-24 rounded-full bg-gradient-to-br from-amber-400/40 to-rose-400/20 blur-3xl dark:from-amber-500/30 dark:to-rose-500/20 animate-gradient" aria-hidden />
+              <div className="absolute bottom-10 left-10 h-20 w-20 rounded-full bg-amber-400/20 blur-2xl dark:bg-amber-500/20 animate-float-slow" aria-hidden />
               <AuthPanel
                 variant="wide"
-                className="border-transparent bg-white/80 shadow-none ring-1 ring-white/60 dark:bg-slate-950/70 dark:ring-teal-500/20"
+                className="border-transparent bg-white/80 shadow-none ring-1 ring-white/60 dark:bg-slate-950/70 dark:ring-amber-500/20"
                 onAuthenticate={onAuthenticate}
               />
             </div>
             <p id="auth-panel" className="mt-6 text-center text-xs text-slate-500 dark:text-slate-400">
-              No spam, no credit card – just a guided tour of the DM mission control.
+              No spam, no credit card – just a guided tour of the TableTorch control room.
             </p>
           </aside>
         </main>

--- a/apps/pages/src/images.d.ts
+++ b/apps/pages/src/images.d.ts
@@ -1,0 +1,4 @@
+declare module '*.jpg' {
+  const src: string;
+  export default src;
+}

--- a/apps/pages/src/index.css
+++ b/apps/pages/src/index.css
@@ -21,22 +21,30 @@ body.dark {
 @layer utilities {
   .bg-landing {
     background-image:
-      radial-gradient(circle at 10% -10%, rgba(56, 189, 248, 0.35), transparent 45%),
-      radial-gradient(circle at 80% 10%, rgba(20, 184, 166, 0.25), transparent 40%),
-      radial-gradient(circle at 0% 80%, rgba(14, 165, 233, 0.2), transparent 45%),
-      linear-gradient(135deg, #f8fafc 0%, #f1f5f9 50%, #e2e8f0 100%);
+      radial-gradient(circle at 20% -10%, rgba(252, 211, 77, 0.45), rgba(249, 115, 22, 0)),
+      linear-gradient(135deg, rgba(255, 241, 214, 0.95), rgba(254, 230, 200, 0.9)),
+      var(--parchment-texture, url('/textures/parchment-bg.jpg'));
+    background-size: 130% 130%, 100% 100%, cover;
+    background-position: center;
+    background-repeat: no-repeat;
+    background-color: #f6eddc;
+    background-blend-mode: screen, multiply, normal;
   }
 
   .dark .bg-landing {
     background-image:
-      radial-gradient(circle at 15% -10%, rgba(56, 189, 248, 0.2), transparent 45%),
-      radial-gradient(circle at 85% 15%, rgba(37, 99, 235, 0.18), transparent 45%),
-      radial-gradient(circle at 10% 85%, rgba(45, 212, 191, 0.18), transparent 45%),
-      linear-gradient(135deg, #020617 0%, #0f172a 55%, #020617 100%);
+      radial-gradient(circle at 20% 20%, rgba(251, 191, 36, 0.25), rgba(17, 24, 39, 0)),
+      linear-gradient(135deg, rgba(15, 23, 42, 0.96), rgba(12, 31, 53, 0.94)),
+      var(--parchment-texture, url('/textures/parchment-bg.jpg'));
+    background-size: 140% 140%, 100% 100%, cover;
+    background-position: center;
+    background-repeat: no-repeat;
+    background-color: #0f172a;
+    background-blend-mode: screen, multiply, normal;
   }
 
   .bg-grid-mask {
-    --grid-color: rgba(15, 23, 42, 0.08);
+    --grid-color: rgba(120, 53, 15, 0.08);
     background-image:
       linear-gradient(var(--grid-color) 1px, transparent 1px),
       linear-gradient(90deg, var(--grid-color) 1px, transparent 1px);
@@ -44,7 +52,7 @@ body.dark {
   }
 
   .dark .bg-grid-mask {
-    --grid-color: rgba(148, 163, 184, 0.1);
+    --grid-color: rgba(248, 250, 252, 0.06);
   }
 
   .animate-gradient {

--- a/apps/pages/vite.config.ts
+++ b/apps/pages/vite.config.ts
@@ -26,6 +26,8 @@ if (!hasModule('@testing-library/user-event')) {
   alias['@testing-library/user-event'] = resolvePath('./src/test-utils/testing-library-user-event.ts');
 }
 
+alias['@textures'] = resolvePath('../../textures');
+
 export default defineConfig({
   plugins: [react()],
   resolve: {
@@ -33,6 +35,9 @@ export default defineConfig({
   },
   server: {
     port: 5173,
+    fs: {
+      allow: [resolvePath('../..'), resolvePath('../../textures')],
+    },
   },
   build: {
     outDir: 'dist',


### PR DESCRIPTION
## Summary
- serve the parchment texture through a Vite alias and expose it to Tailwind utilities via a CSS variable
- apply the parchment background styling to both the landing page and authenticated shell with updated TableTorch theming
- refresh signed-in navigation, forms, and admin panels with light-mode friendly colors that still support dark mode

## Testing
- npm test -- --run *(fails: missing jsdom dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68db02b751e48323ad773c6dc5fc3857