### PR TITLE
Retheme TableTorch landing experience

### DIFF
--- a/apps/pages/src/App.tsx
+++ b/apps/pages/src/App.tsx
@@ -552,7 +552,7 @@ const App: React.FC = () => {
       <div className="min-h-screen bg-slate-100 p-6 dark:bg-slate-900">
         <div className="mb-4 flex items-center justify-between">
           <div>
-            <h1 className="text-2xl font-bold text-primary">D&D Map Reveal</h1>
+            <h1 className="text-2xl font-bold text-primary">TableTorch</h1>
             <p className="text-sm text-slate-500 dark:text-slate-400">Logged in as {user.displayName}</p>
           </div>
           <div className="flex items-center gap-2">
@@ -628,7 +628,7 @@ const App: React.FC = () => {
           <header className="flex flex-wrap items-center justify-between gap-3 rounded-3xl border border-slate-800/70 bg-slate-950/70 px-6 py-4 shadow-xl">
             <div>
               <p className="text-xs uppercase tracking-[0.5em] text-teal-300">Campaign Control</p>
-              <h1 className="text-3xl font-black uppercase tracking-wide text-white">D&D Map Reveal</h1>
+              <h1 className="text-3xl font-black uppercase tracking-wide text-white">TableTorch</h1>
             </div>
             <div className="flex items-center gap-3">
               <button

--- a/apps/pages/src/components/AuthPanel.tsx
+++ b/apps/pages/src/components/AuthPanel.tsx
@@ -50,8 +50,8 @@ const AuthPanel: React.FC<AuthPanelProps> = ({ onAuthenticate, className, varian
     className
   );
 
-  const badgeText = mode === 'login' ? 'Return to the table' : 'Create a DM profile';
-  const headingText = mode === 'login' ? 'Sign in to D&D Map Reveal' : 'Join the D&D Map Reveal beta';
+  const badgeText = mode === 'login' ? 'Return to the firelight' : 'Create your torchbearer profile';
+  const headingText = mode === 'login' ? 'Sign in to TableTorch' : 'Join the TableTorch beta';
   const submitLabel = loading ? 'Please wait…' : mode === 'login' ? 'Log in' : 'Sign up';
   const toggleLabel = mode === 'login' ? 'Need an account?' : 'Already have an account?';
   const toggleHelper = mode === 'login' ? 'Create one instead' : 'Use your existing login';

--- a/apps/pages/src/components/LandingPage.tsx
+++ b/apps/pages/src/components/LandingPage.tsx
@@ -10,23 +10,23 @@ interface LandingPageProps {
 
 const features = [
   {
-    title: 'Reveal maps live',
-    description: 'Fade in fog-of-war with precision tools built for dramatic reveals and on-the-fly adjustments.',
-    icon: '🗺️',
+    title: 'Illuminate every scene',
+    description: 'Warm torchlight sweeps across your battlemaps with smooth reveals tuned for live storytelling.',
+    icon: '🕯️',
   },
   {
     title: 'Campaign control',
-    description: 'Organise every battlemap, note and marker by campaign so your prep is ready when players arrive.',
+    description: 'Keep every map, note, and marker organised by adventure so your table is ready the moment players gather.',
     icon: '🎯',
   },
   {
     title: 'Share instantly',
-    description: 'Invite players with short join codes and let them explore revealed regions from any device.',
+    description: 'Invite players with quick join codes and let them follow the glow from any device in the room.',
     icon: '⚡',
   },
   {
     title: 'Save your progress',
-    description: 'Archive live sessions and pick up where you left off without losing the dramatic tension.',
+    description: 'Bookmark every session to pick up right where the torchlight faded at the end of the night.',
     icon: '🛡️',
   },
 ];
@@ -46,12 +46,13 @@ const LandingPage: React.FC<LandingPageProps> = ({ theme, setTheme, onAuthentica
       <div className="relative isolate">
         <header className="mx-auto flex max-w-7xl flex-wrap items-center justify-between gap-4 px-6 py-8 sm:py-10">
           <div className="flex items-center gap-4">
-            <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-slate-900/90 text-2xl font-black text-teal-300 shadow-2xl shadow-teal-500/20 ring-4 ring-white/50 backdrop-blur dark:bg-white/10 dark:text-teal-200 dark:ring-teal-500/30">
-              DM
+            <div className="torch-logo">
+              <span aria-hidden>🔥</span>
+              <span className="sr-only">TableTorch logo placeholder</span>
             </div>
             <div>
-              <p className="text-xs uppercase tracking-[0.45em] text-teal-600 dark:text-teal-300">D&D Map Reveal</p>
-              <p className="text-lg font-semibold text-slate-900 dark:text-slate-100">Fog-of-war built for dramatic storytelling</p>
+              <p className="text-xs uppercase tracking-[0.45em] text-amber-700 dark:text-amber-300">TableTorch</p>
+              <p className="text-lg font-semibold text-slate-900 dark:text-slate-100">Torchlit encounters for unforgettable storytelling</p>
             </div>
           </div>
           <button
@@ -69,14 +70,14 @@ const LandingPage: React.FC<LandingPageProps> = ({ theme, setTheme, onAuthentica
         <main className="mx-auto grid max-w-7xl gap-16 px-6 pb-24 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,0.9fr)] lg:items-center">
           <section className="space-y-10">
             <div className="space-y-6">
-              <span className="inline-flex items-center rounded-full border border-teal-400/50 bg-teal-100/60 px-4 py-1 text-[11px] font-semibold uppercase tracking-[0.35em] text-teal-700 shadow-sm dark:border-teal-500/40 dark:bg-teal-500/10 dark:text-teal-200">
-                Your new DM co-pilot
+              <span className="inline-flex items-center rounded-full border border-amber-500/40 bg-amber-100/70 px-4 py-1 text-[11px] font-semibold uppercase tracking-[0.35em] text-amber-800 shadow-sm dark:border-amber-400/40 dark:bg-amber-500/10 dark:text-amber-200">
+                Ignite your tabletop
               </span>
               <h1 className="text-4xl font-black tracking-tight text-slate-900 sm:text-5xl dark:text-white">
-                Guide your party through unforgettable encounters with cinematic map reveals.
+                Guide your party through unforgettable encounters with cinematic torchlight reveals.
               </h1>
               <p className="max-w-xl text-lg text-slate-600 dark:text-slate-300">
-                D&D Map Reveal keeps your battlemap prep organised and ready. Cue dramatic lighting, reveal regions in real time, and manage campaigns without breaking the table’s immersion.
+                TableTorch keeps your battlemap prep organised and ready. Cue dramatic lighting, unveil new territory in real time, and manage campaigns without breaking the table’s immersion.
               </p>
               <div className="flex flex-wrap items-center gap-4">
                 <a
@@ -126,7 +127,7 @@ const LandingPage: React.FC<LandingPageProps> = ({ theme, setTheme, onAuthentica
               />
             </div>
             <p id="auth-panel" className="mt-6 text-center text-xs text-slate-500 dark:text-slate-400">
-              No spam, no credit card – just a guided tour of the DM mission control.
+              No spam, no credit card – just a guided tour of the TableTorch command deck.
             </p>
           </aside>
         </main>

--- a/apps/pages/src/index.css
+++ b/apps/pages/src/index.css
@@ -21,22 +21,22 @@ body.dark {
 @layer utilities {
   .bg-landing {
     background-image:
-      radial-gradient(circle at 10% -10%, rgba(56, 189, 248, 0.35), transparent 45%),
-      radial-gradient(circle at 80% 10%, rgba(20, 184, 166, 0.25), transparent 40%),
-      radial-gradient(circle at 0% 80%, rgba(14, 165, 233, 0.2), transparent 45%),
-      linear-gradient(135deg, #f8fafc 0%, #f1f5f9 50%, #e2e8f0 100%);
+      linear-gradient(120deg, rgba(243, 232, 208, 0.92), rgba(226, 196, 150, 0.88)),
+      url('./textures/parchment-bg.jpg');
+    background-size: cover;
+    background-position: center;
   }
 
   .dark .bg-landing {
     background-image:
-      radial-gradient(circle at 15% -10%, rgba(56, 189, 248, 0.2), transparent 45%),
-      radial-gradient(circle at 85% 15%, rgba(37, 99, 235, 0.18), transparent 45%),
-      radial-gradient(circle at 10% 85%, rgba(45, 212, 191, 0.18), transparent 45%),
-      linear-gradient(135deg, #020617 0%, #0f172a 55%, #020617 100%);
+      linear-gradient(120deg, rgba(17, 17, 22, 0.8), rgba(54, 38, 28, 0.82)),
+      url('./textures/parchment-bg.jpg');
+    background-size: cover;
+    background-position: center;
   }
 
   .bg-grid-mask {
-    --grid-color: rgba(15, 23, 42, 0.08);
+    --grid-color: rgba(120, 86, 56, 0.14);
     background-image:
       linear-gradient(var(--grid-color) 1px, transparent 1px),
       linear-gradient(90deg, var(--grid-color) 1px, transparent 1px);
@@ -44,7 +44,7 @@ body.dark {
   }
 
   .dark .bg-grid-mask {
-    --grid-color: rgba(148, 163, 184, 0.1);
+    --grid-color: rgba(248, 239, 220, 0.08);
   }
 
   .animate-gradient {
@@ -54,6 +54,33 @@ body.dark {
 
   .animate-float-slow {
     animation: floatSlow 14s ease-in-out infinite;
+  }
+}
+
+@layer components {
+  .torch-logo {
+    @apply relative flex h-14 w-14 items-center justify-center rounded-2xl bg-amber-100/90 text-2xl text-amber-800 shadow-xl shadow-amber-500/30 ring-2 ring-amber-700/20 backdrop-blur;
+  }
+
+  .dark .torch-logo {
+    @apply bg-amber-500/10 text-amber-100 shadow-amber-500/20 ring-amber-400/30;
+  }
+
+  .torch-logo::after {
+    content: '';
+    position: absolute;
+    inset: -20%;
+    border-radius: 9999px;
+    background: radial-gradient(circle, rgba(253, 230, 138, 0.3), rgba(253, 230, 138, 0));
+    opacity: 0.7;
+    filter: blur(4px);
+    pointer-events: none;
+  }
+
+  .dark .torch-logo::after {
+    background: radial-gradient(circle, rgba(253, 186, 116, 0.35), rgba(15, 15, 15, 0));
+    opacity: 0.9;
+    filter: blur(8px);
   }
 }
 


### PR DESCRIPTION
## Summary
- replace the landing copy with TableTorch branding and torch-themed visuals, including a placeholder logo
- apply the parchment texture as the light and dark mode background with an amber-accent grid overlay
- update authentication messaging and in-app headings to reference TableTorch consistently

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db1ea4922883238358ef4211dde778