### PR TITLE
Add TableTorch branding and parchment theming

### DIFF
--- a/apps/pages/src/App.tsx
+++ b/apps/pages/src/App.tsx
@@ -552,7 +552,7 @@ const App: React.FC = () => {
       <div className="min-h-screen bg-slate-100 p-6 dark:bg-slate-900">
         <div className="mb-4 flex items-center justify-between">
           <div>
-            <h1 className="text-2xl font-bold text-primary">D&D Map Reveal</h1>
+            <h1 className="text-2xl font-bold text-primary">TableTorch</h1>
             <p className="text-sm text-slate-500 dark:text-slate-400">Logged in as {user.displayName}</p>
           </div>
           <div className="flex items-center gap-2">
@@ -628,7 +628,7 @@ const App: React.FC = () => {
           <header className="flex flex-wrap items-center justify-between gap-3 rounded-3xl border border-slate-800/70 bg-slate-950/70 px-6 py-4 shadow-xl">
             <div>
               <p className="text-xs uppercase tracking-[0.5em] text-teal-300">Campaign Control</p>
-              <h1 className="text-3xl font-black uppercase tracking-wide text-white">D&D Map Reveal</h1>
+              <h1 className="text-3xl font-black uppercase tracking-wide text-white">TableTorch</h1>
             </div>
             <div className="flex items-center gap-3">
               <button

--- a/apps/pages/src/components/AuthPanel.tsx
+++ b/apps/pages/src/components/AuthPanel.tsx
@@ -51,7 +51,7 @@ const AuthPanel: React.FC<AuthPanelProps> = ({ onAuthenticate, className, varian
   );
 
   const badgeText = mode === 'login' ? 'Return to the table' : 'Create a DM profile';
-  const headingText = mode === 'login' ? 'Sign in to D&D Map Reveal' : 'Join the D&D Map Reveal beta';
+  const headingText = mode === 'login' ? 'Sign in to TableTorch' : 'Join the TableTorch beta';
   const submitLabel = loading ? 'Please wait…' : mode === 'login' ? 'Log in' : 'Sign up';
   const toggleLabel = mode === 'login' ? 'Need an account?' : 'Already have an account?';
   const toggleHelper = mode === 'login' ? 'Create one instead' : 'Use your existing login';
@@ -73,7 +73,7 @@ const AuthPanel: React.FC<AuthPanelProps> = ({ onAuthenticate, className, varian
                 {headingText}
               </h2>
               <p className="text-sm text-slate-600 dark:text-slate-300">
-                Use the pre-filled demo credentials or sign up with your own details to explore the DM console.
+                Use the pre-filled demo credentials or sign up with your own details to explore the TableTorch console.
               </p>
             </div>
             <button

--- a/apps/pages/src/components/LandingPage.tsx
+++ b/apps/pages/src/components/LandingPage.tsx
@@ -11,27 +11,28 @@ interface LandingPageProps {
 const features = [
   {
     title: 'Reveal maps live',
-    description: 'Fade in fog-of-war with precision tools built for dramatic reveals and on-the-fly adjustments.',
+    description: 'Illuminate every chamber with TableTorch’s precise reveal tools and painterly masking controls.',
     icon: '🗺️',
   },
   {
     title: 'Campaign control',
-    description: 'Organise every battlemap, note and marker by campaign so your prep is ready when players arrive.',
+    description: 'Arrange battlemaps, lore, and markers by campaign so every scene is prepped before the torch is lit.',
     icon: '🎯',
   },
   {
     title: 'Share instantly',
-    description: 'Invite players with short join codes and let them explore revealed regions from any device.',
+    description: 'Invite players with short join codes and let them follow the glow from any connected device.',
     icon: '⚡',
   },
   {
     title: 'Save your progress',
-    description: 'Archive live sessions and pick up where you left off without losing the dramatic tension.',
+    description: 'Archive live sessions and resume the tale exactly where the last ember faded.',
     icon: '🛡️',
   },
 ];
 
 const LandingPage: React.FC<LandingPageProps> = ({ theme, setTheme, onAuthenticate }) => {
+  const gradientId = React.useId();
   const themeLabel = theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode';
 
   const handleThemeToggle = () => {
@@ -46,12 +47,33 @@ const LandingPage: React.FC<LandingPageProps> = ({ theme, setTheme, onAuthentica
       <div className="relative isolate">
         <header className="mx-auto flex max-w-7xl flex-wrap items-center justify-between gap-4 px-6 py-8 sm:py-10">
           <div className="flex items-center gap-4">
-            <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-slate-900/90 text-2xl font-black text-teal-300 shadow-2xl shadow-teal-500/20 ring-4 ring-white/50 backdrop-blur dark:bg-white/10 dark:text-teal-200 dark:ring-teal-500/30">
-              DM
+            <div className="torch-emblem" aria-hidden>
+              <svg viewBox="0 0 32 32" role="presentation" aria-hidden>
+                <path
+                  d="M12.5 13.2c0-2.8 2.1-5.7 5.4-7.9-.4 1.8 1 3.2 2.7 4.8 1.8 1.7 3.7 3.6 3.7 6.2 0 3.6-2.9 6.5-6.5 6.5s-5.3-2.1-5.3-4.8c0-1.8.9-3.3 2.5-4.8-1.4.6-2.5-.2-2.5-1.9Z"
+                  fill={`url(#${gradientId})`}
+                />
+                <path d="M12 19h8v7.5a3 3 0 0 1-3 3h-2a3 3 0 0 1-3-3Z" fill="#1f2937" opacity="0.85" />
+                <path d="M14.5 18h3l-1.1 5.5h-0.8Z" fill="#facc15" opacity="0.4" />
+                <defs>
+                  <radialGradient
+                    id={gradientId}
+                    cx="0"
+                    cy="0"
+                    r="1"
+                    gradientTransform="translate(16 9) rotate(75) scale(11 8)"
+                    gradientUnits="userSpaceOnUse"
+                  >
+                    <stop offset="0%" stopColor="#fde68a" />
+                    <stop offset="55%" stopColor="#fb923c" />
+                    <stop offset="100%" stopColor="#7c2d12" />
+                  </radialGradient>
+                </defs>
+              </svg>
             </div>
             <div>
-              <p className="text-xs uppercase tracking-[0.45em] text-teal-600 dark:text-teal-300">D&D Map Reveal</p>
-              <p className="text-lg font-semibold text-slate-900 dark:text-slate-100">Fog-of-war built for dramatic storytelling</p>
+              <p className="text-xs uppercase tracking-[0.45em] text-teal-700 drop-shadow-sm dark:text-teal-200">TableTorch</p>
+              <p className="text-lg font-semibold text-slate-900 dark:text-slate-100">Light the way for unforgettable tabletop reveals</p>
             </div>
           </div>
           <button
@@ -73,10 +95,10 @@ const LandingPage: React.FC<LandingPageProps> = ({ theme, setTheme, onAuthentica
                 Your new DM co-pilot
               </span>
               <h1 className="text-4xl font-black tracking-tight text-slate-900 sm:text-5xl dark:text-white">
-                Guide your party through unforgettable encounters with cinematic map reveals.
+                Guide your party through torchlit encounters with cinematic map reveals.
               </h1>
               <p className="max-w-xl text-lg text-slate-600 dark:text-slate-300">
-                D&D Map Reveal keeps your battlemap prep organised and ready. Cue dramatic lighting, reveal regions in real time, and manage campaigns without breaking the table’s immersion.
+                TableTorch keeps your battlemap prep organised and ready. Cue dramatic lighting, reveal regions in real time, and manage campaigns without breaking the table’s immersion.
               </p>
               <div className="flex flex-wrap items-center gap-4">
                 <a

--- a/apps/pages/src/index.css
+++ b/apps/pages/src/index.css
@@ -20,23 +20,24 @@ body.dark {
 
 @layer utilities {
   .bg-landing {
+    background-color: #f6efe2;
     background-image:
-      radial-gradient(circle at 10% -10%, rgba(56, 189, 248, 0.35), transparent 45%),
-      radial-gradient(circle at 80% 10%, rgba(20, 184, 166, 0.25), transparent 40%),
-      radial-gradient(circle at 0% 80%, rgba(14, 165, 233, 0.2), transparent 45%),
-      linear-gradient(135deg, #f8fafc 0%, #f1f5f9 50%, #e2e8f0 100%);
+      linear-gradient(120deg, rgba(252, 211, 77, 0.12), rgba(251, 191, 36, 0.05)),
+      url('./textures/parchment-bg.jpg');
+    background-size: cover;
+    background-position: center;
   }
 
   .dark .bg-landing {
+    background-color: #0f172a;
     background-image:
-      radial-gradient(circle at 15% -10%, rgba(56, 189, 248, 0.2), transparent 45%),
-      radial-gradient(circle at 85% 15%, rgba(37, 99, 235, 0.18), transparent 45%),
-      radial-gradient(circle at 10% 85%, rgba(45, 212, 191, 0.18), transparent 45%),
-      linear-gradient(135deg, #020617 0%, #0f172a 55%, #020617 100%);
+      linear-gradient(120deg, rgba(15, 23, 42, 0.78), rgba(15, 23, 42, 0.92)),
+      url('./textures/parchment-bg.jpg');
+    background-blend-mode: multiply;
   }
 
   .bg-grid-mask {
-    --grid-color: rgba(15, 23, 42, 0.08);
+    --grid-color: rgba(100, 69, 35, 0.15);
     background-image:
       linear-gradient(var(--grid-color) 1px, transparent 1px),
       linear-gradient(90deg, var(--grid-color) 1px, transparent 1px);
@@ -44,7 +45,41 @@ body.dark {
   }
 
   .dark .bg-grid-mask {
-    --grid-color: rgba(148, 163, 184, 0.1);
+    --grid-color: rgba(248, 250, 252, 0.12);
+  }
+
+  .torch-emblem {
+    position: relative;
+    display: inline-flex;
+    height: 3.5rem;
+    width: 3.5rem;
+    align-items: center;
+    justify-content: center;
+    border-radius: 1.25rem;
+    background-image: radial-gradient(circle at 50% 35%, #fde68a 0%, #fb923c 42%, #7c2d12 92%);
+    box-shadow: 0 20px 40px rgba(124, 45, 18, 0.22);
+    color: #f8fafc;
+    transform: rotate(-4deg);
+  }
+
+  .torch-emblem svg {
+    height: 1.85rem;
+    width: 1.85rem;
+  }
+
+  .torch-emblem::after {
+    content: '';
+    position: absolute;
+    inset: -1.75rem;
+    border-radius: 50%;
+    background: radial-gradient(circle, rgba(251, 191, 36, 0.28), transparent 70%);
+    opacity: 0;
+    transition: opacity 200ms ease;
+    z-index: -1;
+  }
+
+  .dark .torch-emblem::after {
+    opacity: 1;
   }
 
   .animate-gradient {


### PR DESCRIPTION
## Summary
- replace Fog of War branding with TableTorch messaging across the landing experience
- add a parchment-textured background with dark-mode treatment and torch emblem halo styling
- update in-app headers and auth copy to reference TableTorch

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db1ea4922883238358ef4211dde778