### PR TITLE
Brighten landing torch glow gradient

### DIFF
--- a/apps/pages/src/index.css
+++ b/apps/pages/src/index.css
@@ -22,7 +22,14 @@ body.dark {
   .bg-landing {
     background-color: #f7f1df;
     background-image:
-      radial-gradient(circle at 12% -12%, rgba(255, 214, 102, 0.55), transparent 60%),
+      radial-gradient(
+        circle at 12% -12%,
+        rgba(255, 214, 102, 0.65) 0%,
+        rgba(255, 214, 102, 0.62) 58%,
+        rgba(255, 214, 102, 0.46) 72%,
+        rgba(255, 214, 102, 0.16) 82%,
+        transparent 88%
+      ),
       radial-gradient(circle at 82% 12%, rgba(249, 115, 22, 0.2), transparent 40%),
       radial-gradient(circle at 0% 82%, rgba(250, 204, 21, 0.18), transparent 45%),
       linear-gradient(135deg, rgba(252, 233, 202, 0.85), rgba(248, 214, 181, 0.75)),
@@ -36,7 +43,14 @@ body.dark {
   .dark .bg-landing {
     background-color: #111827;
     background-image:
-      radial-gradient(circle at 18% -12%, rgba(249, 145, 22, 0.32), transparent 60%),
+      radial-gradient(
+        circle at 18% -12%,
+        rgba(249, 145, 22, 0.38) 0%,
+        rgba(249, 145, 22, 0.36) 58%,
+        rgba(249, 145, 22, 0.26) 72%,
+        rgba(249, 145, 22, 0.1) 82%,
+        transparent 88%
+      ),
       radial-gradient(circle at 88% 18%, rgba(248, 250, 252, 0.07), transparent 50%),
       radial-gradient(circle at 12% 90%, rgba(253, 224, 71, 0.16), transparent 48%),
       linear-gradient(135deg, rgba(17, 24, 39, 0.92), rgba(15, 23, 42, 0.96)),


### PR DESCRIPTION
## Summary
- intensify the top-left landing page radial gradient to appear brighter around the torch logo
- expand the gradient falloff so the illuminated area extends further into the hero background
- mirror the brightness and spread adjustments for the dark theme variant

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db2e828f3c8323af354e208c2989f2