### PR TITLE
Sharpen landing torch glow cutoff

### DIFF
--- a/apps/pages/src/index.css
+++ b/apps/pages/src/index.css
@@ -22,7 +22,7 @@ body.dark {
   .bg-landing {
     background-color: #f7f1df;
     background-image:
-      radial-gradient(circle at 12% -12%, rgba(255, 214, 102, 0.35), transparent 45%),
+      radial-gradient(circle at 12% -12%, rgba(255, 214, 102, 0.64), rgba(255, 214, 102, 0.6) 58%, rgba(255, 214, 102, 0.18) 70%, transparent 78%),
       radial-gradient(circle at 82% 12%, rgba(249, 115, 22, 0.2), transparent 40%),
       radial-gradient(circle at 0% 82%, rgba(250, 204, 21, 0.18), transparent 45%),
       linear-gradient(135deg, rgba(252, 233, 202, 0.85), rgba(248, 214, 181, 0.75)),
@@ -36,7 +36,7 @@ body.dark {
   .dark .bg-landing {
     background-color: #111827;
     background-image:
-      radial-gradient(circle at 18% -12%, rgba(249, 115, 22, 0.18), transparent 45%),
+      radial-gradient(circle at 18% -12%, rgba(249, 145, 22, 0.38), rgba(249, 145, 22, 0.34) 56%, rgba(249, 145, 22, 0.1) 68%, transparent 76%),
       radial-gradient(circle at 88% 18%, rgba(248, 250, 252, 0.07), transparent 50%),
       radial-gradient(circle at 12% 90%, rgba(253, 224, 71, 0.16), transparent 48%),
       linear-gradient(135deg, rgba(17, 24, 39, 0.92), rgba(15, 23, 42, 0.96)),


### PR DESCRIPTION
## Summary
- intensify the top-left landing page radial gradient so the torch glow stays bright deeper into the hero background
- tighten the falloff so the illumination drops sharply near the edge of the glow
- mirror the brightness and falloff adjustments for the dark theme variant to keep the lighting treatment consistent

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68db2e828f3c8323af354e208c2989f2