### PR TITLE
Align dashboard theming with landing page aesthetics

### DIFF
--- a/apps/pages/src/App.tsx
+++ b/apps/pages/src/App.tsx
@@ -537,10 +537,10 @@ const App: React.FC = () => {
   const themeLabel = theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode';
 
   const navButtonClasses = (view: 'join' | 'manage' | 'create' | 'admin') =>
-    `group flex w-full items-center justify-between rounded-2xl border px-5 py-4 text-left text-sm font-semibold uppercase tracking-[0.3em] transition ${
+    `group flex w-full items-center justify-between rounded-2xl border px-5 py-4 text-left text-sm font-semibold uppercase tracking-[0.3em] transition backdrop-blur ${
       activeView === view
-        ? 'border-teal-400 bg-teal-400/90 text-slate-900 shadow-lg shadow-teal-500/40'
-        : 'border-slate-800/70 bg-slate-900/60 text-slate-300 hover:border-teal-400/60 hover:bg-slate-800/80'
+        ? 'border-amber-400/70 bg-gradient-to-r from-amber-200/90 to-orange-200/80 text-slate-900 shadow-lg shadow-amber-500/40 dark:from-amber-400/40 dark:to-orange-500/40 dark:text-slate-900'
+        : 'border-white/60 bg-white/70 text-slate-700 hover:border-amber-400/60 hover:bg-white/80 dark:border-slate-800/60 dark:bg-slate-900/60 dark:text-slate-200 dark:hover:border-amber-400/60 dark:hover:bg-slate-900/70'
     }`;
 
   if (!token || !user) {
@@ -593,402 +593,406 @@ const App: React.FC = () => {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 text-slate-100">
-      <div className="mx-auto flex min-h-screen max-w-6xl flex-col gap-6 px-4 py-8 md:flex-row md:py-12">
-        <aside className="flex flex-col gap-6 rounded-3xl border border-slate-800/70 bg-slate-950/70 p-6 shadow-2xl md:w-72">
-          <div>
-            <p className="text-xs uppercase tracking-[0.4em] text-slate-500">Mission Control</p>
-            <h2 className="mt-3 text-2xl font-black uppercase tracking-wide text-teal-300">Command Deck</h2>
-          </div>
-          <div className="rounded-2xl border border-slate-800/70 bg-slate-900/70 p-4">
-            <p className="text-xs uppercase tracking-[0.5em] text-slate-500">Logged in</p>
-            <p className="mt-2 text-lg font-semibold text-white">{user.displayName}</p>
-            <p className="text-xs text-slate-500">Ready for launch</p>
-          </div>
-          <nav className="space-y-3">
-            <button className={navButtonClasses('join')} onClick={() => setActiveView('join')}>
-              <span>Join Campaign</span>
-              <span className="text-[10px] tracking-[0.4em] text-slate-900/70 transition group-hover:text-slate-900/90">START</span>
-            </button>
-            <button className={navButtonClasses('manage')} onClick={() => setActiveView('manage')}>
-              <span>Manage Campaigns</span>
-              <span className="text-[10px] tracking-[0.4em] text-slate-900/70 transition group-hover:text-slate-900/90">HANGAR</span>
-            </button>
-            <button className={navButtonClasses('create')} onClick={() => setActiveView('create')}>
-              <span>Create Campaign</span>
-              <span className="text-[10px] tracking-[0.4em] text-slate-900/70 transition group-hover:text-slate-900/90">NEW</span>
-            </button>
-          </nav>
-          <div className="mt-auto space-y-2 text-xs text-slate-500">
-            <p>Need a room code? Ask your DM to share their campaign key.</p>
-            <p>Switch tabs to manage, create, or join adventures.</p>
-          </div>
-        </aside>
-        <section className="flex-1 space-y-6">
-          <header className="flex flex-wrap items-center justify-between gap-3 rounded-3xl border border-slate-800/70 bg-slate-950/70 px-6 py-4 shadow-xl">
+    <div className="bg-landing relative min-h-screen overflow-hidden text-slate-900 transition-colors dark:text-slate-100">
+      <div aria-hidden className="absolute inset-0 bg-grid-mask opacity-60 mix-blend-soft-light dark:opacity-40" />
+      <div aria-hidden className="pointer-events-none absolute -top-32 right-12 h-72 w-72 rounded-full bg-amber-300/25 blur-3xl dark:bg-amber-500/20 animate-float-slow" />
+      <div aria-hidden className="pointer-events-none absolute bottom-[-10rem] left-[-6rem] h-96 w-96 rounded-full bg-orange-300/20 blur-[120px] dark:bg-orange-500/20 animate-float-slow" />
+      <div className="relative isolate">
+        <div className="mx-auto flex min-h-screen max-w-6xl flex-col gap-6 px-4 py-8 md:flex-row md:py-12">
+          <aside className="flex flex-col gap-6 rounded-3xl border border-white/60 bg-white/70 p-6 shadow-2xl shadow-amber-500/20 backdrop-blur-xl dark:border-slate-800/60 dark:bg-slate-950/60 md:w-72">
             <div>
-              <p className="text-xs uppercase tracking-[0.5em] text-teal-300">Campaign Control</p>
-              <h1 className="text-3xl font-black uppercase tracking-wide text-white">TableTorch</h1>
+              <p className="text-xs uppercase tracking-[0.4em] text-amber-600 dark:text-amber-200">Mission Control</p>
+              <h2 className="mt-3 text-2xl font-black uppercase tracking-wide text-slate-900 dark:text-amber-100">Command Deck</h2>
             </div>
-            <div className="flex items-center gap-3">
-              <button
-                className="rounded-full border border-teal-400/60 bg-teal-400/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-teal-200 transition hover:bg-teal-400/20"
-                onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
-              >
-                {themeLabel}
+            <div className="rounded-2xl border border-white/60 bg-white/70 p-4 backdrop-blur dark:border-slate-800/60 dark:bg-slate-900/60">
+              <p className="text-xs uppercase tracking-[0.5em] text-slate-500 dark:text-slate-400">Logged in</p>
+              <p className="mt-2 text-lg font-semibold text-slate-900 dark:text-white">{user.displayName}</p>
+              <p className="text-xs text-slate-500 dark:text-slate-400">Ready for launch</p>
+            </div>
+            <nav className="space-y-3">
+              <button className={navButtonClasses('join')} onClick={() => setActiveView('join')}>
+                <span>Join Campaign</span>
+                <span className="text-[10px] tracking-[0.4em] text-slate-900/70 transition group-hover:text-slate-900">START</span>
               </button>
-              <button
-                className="rounded-full border border-rose-400/60 bg-rose-500/20 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-rose-200 transition hover:bg-rose-500/30"
-                onClick={handleLogout}
-              >
-                Logout
+              <button className={navButtonClasses('manage')} onClick={() => setActiveView('manage')}>
+                <span>Manage Campaigns</span>
+                <span className="text-[10px] tracking-[0.4em] text-slate-900/70 transition group-hover:text-slate-900">HANGAR</span>
               </button>
+              <button className={navButtonClasses('create')} onClick={() => setActiveView('create')}>
+                <span>Create Campaign</span>
+                <span className="text-[10px] tracking-[0.4em] text-slate-900/70 transition group-hover:text-slate-900">NEW</span>
+              </button>
+            </nav>
+            <div className="mt-auto space-y-2 text-xs text-slate-500 dark:text-slate-400">
+              <p>Need a room code? Ask your DM to share their campaign key.</p>
+              <p>Switch tabs to manage, create, or join adventures.</p>
             </div>
-          </header>
-          {statusMessage && (
-            <div className="rounded-3xl border border-teal-500/40 bg-teal-500/10 px-5 py-3 text-sm text-teal-200 shadow-lg shadow-teal-500/10">
-              {statusMessage}
-            </div>
-          )}
-          <div className="flex-1 rounded-3xl border border-slate-800/70 bg-slate-950/70 p-6 shadow-2xl">
-            {activeView === 'join' && (
-              <div className="space-y-6">
-                <h2 className="text-3xl font-black uppercase tracking-wide text-teal-200">Join Campaign</h2>
-                <p className="max-w-xl text-sm text-slate-300">
-                  Enter the campaign key provided by your Dungeon Master to hop into their room.
-                </p>
-                <form onSubmit={handleJoinByKey} className="space-y-4">
-                  <label className="block text-xs uppercase tracking-[0.4em] text-slate-400">
-                    Campaign Key
-                    <div className="mt-2 flex flex-col gap-3 sm:flex-row">
-                      <input
-                        value={joinKey}
-                        onChange={(event) => setJoinKey(event.target.value)}
-                        placeholder="e.g. A1B2C3"
-                        className="flex-1 rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm uppercase tracking-[0.3em] text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
-                      />
+          </aside>
+          <section className="flex-1 space-y-6">
+            <header className="flex flex-wrap items-center justify-between gap-3 rounded-3xl border border-white/60 bg-white/70 px-6 py-4 shadow-xl backdrop-blur dark:border-slate-800/60 dark:bg-slate-950/60">
+              <div>
+                <p className="text-xs uppercase tracking-[0.5em] text-amber-600 dark:text-amber-200">Campaign Control</p>
+                <h1 className="text-3xl font-black uppercase tracking-wide text-slate-900 dark:text-white">TableTorch</h1>
+              </div>
+              <div className="flex items-center gap-3">
+                <button
+                  className="rounded-full border border-amber-400/60 bg-amber-300/30 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-amber-700 transition hover:bg-amber-300/50 dark:border-amber-400/40 dark:bg-amber-400/20 dark:text-amber-100 dark:hover:bg-amber-400/30"
+                  onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
+                >
+                  {themeLabel}
+                </button>
+                <button
+                  className="rounded-full border border-rose-400/60 bg-rose-300/30 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-rose-700 transition hover:bg-rose-300/50 dark:border-rose-500/50 dark:bg-rose-500/20 dark:text-rose-100 dark:hover:bg-rose-500/30"
+                  onClick={handleLogout}
+                >
+                  Logout
+                </button>
+              </div>
+            </header>
+            {statusMessage && (
+              <div className="rounded-3xl border border-amber-400/40 bg-amber-200/40 px-5 py-3 text-sm text-amber-800 shadow-lg shadow-amber-500/20 dark:border-amber-500/40 dark:bg-amber-500/20 dark:text-amber-100">
+                {statusMessage}
+              </div>
+            )}
+            <div className="flex-1 rounded-3xl border border-white/60 bg-white/70 p-6 shadow-2xl backdrop-blur dark:border-slate-800/60 dark:bg-slate-950/60">
+              {activeView === 'join' && (
+                <div className="space-y-6">
+                  <h2 className="text-3xl font-black tracking-tight text-slate-900 dark:text-white">Join Campaign</h2>
+                  <p className="max-w-xl text-sm text-slate-600 dark:text-slate-300">
+                    Enter the campaign key provided by your Dungeon Master to hop into their room.
+                  </p>
+                  <form onSubmit={handleJoinByKey} className="space-y-4">
+                    <label className="block text-xs uppercase tracking-[0.4em] text-slate-500 dark:text-slate-400">
+                      Campaign Key
+                      <div className="mt-2 flex flex-col gap-3 sm:flex-row">
+                        <input
+                          value={joinKey}
+                          onChange={(event) => setJoinKey(event.target.value)}
+                          placeholder="e.g. A1B2C3"
+                          className="flex-1 rounded-xl border border-white/60 bg-white/80 px-4 py-3 text-sm uppercase tracking-[0.3em] text-slate-900 placeholder:text-slate-400 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/40 dark:border-slate-800/60 dark:bg-slate-900/60 dark:text-slate-100 dark:placeholder:text-slate-500"
+                        />
+                        <button
+                          type="submit"
+                          className="rounded-xl border border-amber-400/70 bg-gradient-to-r from-amber-400/90 to-orange-400/80 px-6 py-3 text-sm font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:from-amber-300 hover:to-orange-300 focus:outline-none focus:ring-2 focus:ring-amber-400/40"
+                        >
+                          Join Room
+                        </button>
+                      </div>
+                    </label>
+                    {joinError && <p className="text-xs font-semibold text-rose-500 dark:text-rose-300">{joinError}</p>}
+                  </form>
+                  <div className="rounded-2xl border border-white/60 bg-white/70 p-4 backdrop-blur dark:border-slate-800/60 dark:bg-slate-900/60">
+                    <div className="mb-3 flex items-center justify-between">
+                      <h3 className="text-xs uppercase tracking-[0.4em] text-slate-500 dark:text-slate-400">Active Rooms</h3>
                       <button
-                        type="submit"
-                        className="rounded-xl border border-teal-400/60 bg-teal-500/80 px-6 py-3 text-sm font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-teal-400/90 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                        type="button"
+                        className="text-xs font-semibold uppercase tracking-[0.3em] text-amber-600 transition hover:text-amber-500 dark:text-amber-200 dark:hover:text-amber-100"
+                        onClick={refreshLobby}
                       >
-                        Join Room
+                        Refresh
                       </button>
                     </div>
-                  </label>
-                  {joinError && <p className="text-xs font-semibold text-rose-300">{joinError}</p>}
-                </form>
-                <div className="rounded-2xl border border-slate-800/70 bg-slate-900/70 p-4">
-                  <div className="mb-3 flex items-center justify-between">
-                    <h3 className="text-xs uppercase tracking-[0.4em] text-slate-400">Active Rooms</h3>
+                    <ul className="max-h-48 space-y-2 overflow-y-auto pr-1 text-sm">
+                      {lobbySessions.map((session) => (
+                        <li key={session.id} className="rounded-xl border border-white/60 bg-white/80 p-3 backdrop-blur dark:border-slate-800/60 dark:bg-slate-950/60">
+                          <div className="flex flex-wrap items-center justify-between gap-2">
+                            <div>
+                              <p className="font-semibold text-slate-900 dark:text-white">{session.name}</p>
+                              <p className="text-[10px] uppercase tracking-[0.4em] text-slate-500 dark:text-slate-400">Key: {session.id}</p>
+                            </div>
+                            <button
+                              type="button"
+                              className="rounded-lg border border-amber-400/70 bg-gradient-to-r from-amber-400/90 to-orange-400/80 px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:from-amber-300 hover:to-orange-300"
+                              onClick={() => handleJoinSession(session)}
+                            >
+                              Join
+                            </button>
+                          </div>
+                          <p className="mt-2 text-xs text-slate-600 dark:text-slate-400">
+                            Campaign: {session.campaignName ?? 'Unknown'} • Map: {session.mapName ?? 'Unknown'}
+                          </p>
+                        </li>
+                      ))}
+                      {lobbySessions.length === 0 && (
+                        <li className="rounded-xl border border-dashed border-slate-300 px-3 py-6 text-center text-xs text-slate-500 dark:border-slate-700 dark:text-slate-400">
+                          No active rooms yet.
+                        </li>
+                      )}
+                    </ul>
+                  </div>
+                </div>
+              )}
+              {activeView === 'manage' && (
+                <div className="space-y-6">
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <div>
+                      <h2 className="text-3xl font-black tracking-tight text-slate-900 dark:text-white">Manage Campaigns</h2>
+                      <p className="text-sm text-slate-600 dark:text-slate-300">Select a campaign to open the admin hangar.</p>
+                    </div>
                     <button
                       type="button"
-                      className="text-xs font-semibold uppercase tracking-[0.3em] text-teal-200 transition hover:text-teal-100"
-                      onClick={refreshLobby}
+                      className="rounded-full border border-amber-400/60 px-5 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-amber-700 transition hover:bg-amber-300/40 dark:border-amber-400/50 dark:text-amber-100 dark:hover:bg-amber-400/20"
+                      onClick={() => refreshCampaigns()}
                     >
                       Refresh
                     </button>
                   </div>
-                  <ul className="max-h-48 space-y-2 overflow-y-auto pr-1 text-sm">
-                    {lobbySessions.map((session) => (
-                      <li key={session.id} className="rounded-xl border border-slate-800/70 bg-slate-950/60 p-3">
-                        <div className="flex flex-wrap items-center justify-between gap-2">
-                          <div>
-                            <p className="font-semibold text-slate-100">{session.name}</p>
-                            <p className="text-[10px] uppercase tracking-[0.4em] text-slate-500">Key: {session.id}</p>
-                          </div>
-                          <button
-                            type="button"
-                            className="rounded-lg border border-teal-400/60 bg-teal-500/80 px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-teal-400/90"
-                            onClick={() => handleJoinSession(session)}
-                          >
-                            Join
-                          </button>
+                  <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+                    {campaigns.map((campaign) => (
+                      <button
+                        key={campaign.id}
+                        className="group flex h-full flex-col justify-between rounded-2xl border border-white/60 bg-white/80 p-4 text-left shadow-sm transition hover:-translate-y-1 hover:border-amber-400/60 hover:shadow-lg hover:shadow-amber-500/20 dark:border-slate-800/60 dark:bg-slate-950/60"
+                        onClick={() => handleOpenCampaignAdmin(campaign)}
+                      >
+                        <div>
+                          <p className="text-xs uppercase tracking-[0.4em] text-slate-500 dark:text-slate-400">Campaign</p>
+                          <h3 className="mt-2 text-lg font-semibold text-slate-900 dark:text-white">{campaign.name}</h3>
+                          <p className="mt-2 text-xs text-slate-600 dark:text-slate-400">{campaign.description || 'No description provided.'}</p>
                         </div>
-                        <p className="mt-2 text-xs text-slate-400">
-                          Campaign: {session.campaignName ?? 'Unknown'} • Map: {session.mapName ?? 'Unknown'}
-                        </p>
-                      </li>
+                        <span className="mt-4 inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.3em] text-amber-600 transition group-hover:text-amber-500 dark:text-amber-200 dark:group-hover:text-amber-100">
+                          Open Hangar <span aria-hidden>→</span>
+                        </span>
+                      </button>
                     ))}
-                    {lobbySessions.length === 0 && (
-                      <li className="rounded-xl border border-dashed border-slate-700/70 px-3 py-6 text-center text-xs text-slate-500">
-                        No active rooms yet.
-                      </li>
+                    {campaigns.length === 0 && (
+                      <div className="rounded-2xl border border-dashed border-slate-300 p-6 text-center text-sm text-slate-500 dark:border-slate-700 dark:text-slate-400">
+                        You haven't created any campaigns yet. Try the create tab to launch a new adventure.
+                      </div>
                     )}
-                  </ul>
-                </div>
-              </div>
-            )}
-            {activeView === 'manage' && (
-              <div className="space-y-6">
-                <div className="flex flex-wrap items-center justify-between gap-3">
-                  <div>
-                    <h2 className="text-3xl font-black uppercase tracking-wide text-teal-200">Manage Campaigns</h2>
-                    <p className="text-sm text-slate-300">Select a campaign to open the admin hangar.</p>
-                  </div>
-                  <button
-                    type="button"
-                    className="rounded-full border border-teal-400/60 px-5 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-teal-200 transition hover:bg-teal-500/20"
-                    onClick={() => refreshCampaigns()}
-                  >
-                    Refresh
-                  </button>
-                </div>
-                <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
-                  {campaigns.map((campaign) => (
-                    <button
-                      key={campaign.id}
-                      className="group flex h-full flex-col justify-between rounded-2xl border border-slate-800/70 bg-slate-950/60 p-4 text-left transition hover:border-teal-400/60 hover:bg-slate-900/70"
-                      onClick={() => handleOpenCampaignAdmin(campaign)}
-                    >
-                      <div>
-                        <p className="text-xs uppercase tracking-[0.4em] text-slate-500">Campaign</p>
-                        <h3 className="mt-2 text-lg font-semibold text-white">{campaign.name}</h3>
-                        <p className="mt-2 text-xs text-slate-400">{campaign.description || 'No description provided.'}</p>
-                      </div>
-                      <span className="mt-4 inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.3em] text-teal-200">
-                        Open Hangar <span aria-hidden>→</span>
-                      </span>
-                    </button>
-                  ))}
-                  {campaigns.length === 0 && (
-                    <div className="rounded-2xl border border-dashed border-slate-700/70 p-6 text-center text-sm text-slate-400">
-                      You haven't created any campaigns yet. Try the create tab to launch a new adventure.
-                    </div>
-                  )}
-                </div>
-              </div>
-            )}
-            {activeView === 'create' && (
-              <div className="space-y-6">
-                <h2 className="text-3xl font-black uppercase tracking-wide text-teal-200">Create Campaign</h2>
-                <p className="max-w-xl text-sm text-slate-300">Set up a new campaign for your players and start building encounters.</p>
-                <form onSubmit={handleCreateCampaign} className="space-y-5">
-                  <div>
-                    <label className="text-xs uppercase tracking-[0.4em] text-slate-400">Campaign Name</label>
-                    <input
-                      value={newCampaignName}
-                      onChange={(event) => setNewCampaignName(event.target.value)}
-                      className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
-                      placeholder="Give your mission a title"
-                    />
-                  </div>
-                  <div>
-                    <label className="text-xs uppercase tracking-[0.4em] text-slate-400">Description</label>
-                    <textarea
-                      value={newCampaignDescription}
-                      onChange={(event) => setNewCampaignDescription(event.target.value)}
-                      rows={4}
-                      className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
-                      placeholder="Share a quick briefing for your players"
-                    />
-                  </div>
-                  <label className="flex items-center gap-3 text-xs uppercase tracking-[0.4em] text-slate-400">
-                    <input
-                      type="checkbox"
-                      checked={newCampaignPublic}
-                      onChange={(event) => setNewCampaignPublic(event.target.checked)}
-                      className="h-4 w-4 rounded border border-slate-700 bg-slate-900 text-teal-400 focus:ring-teal-400"
-                    />
-                    <span className="text-slate-300">List publicly for players to discover</span>
-                  </label>
-                  {createError && <p className="text-xs font-semibold text-rose-300">{createError}</p>}
-                  <div className="flex flex-wrap gap-3">
-                    <button
-                      type="submit"
-                      className="rounded-xl border border-teal-400/60 bg-teal-500/80 px-6 py-3 text-sm font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-teal-400/90"
-                    >
-                      Launch Campaign
-                    </button>
-                    <button
-                      type="button"
-                      className="rounded-xl border border-slate-700/70 px-6 py-3 text-sm font-semibold uppercase tracking-[0.3em] text-slate-300 transition hover:border-teal-400/60 hover:text-teal-200"
-                      onClick={() => {
-                        setNewCampaignName('');
-                        setNewCampaignDescription('');
-                        setNewCampaignPublic(false);
-                        setCreateError(null);
-                      }}
-                    >
-                      Reset
-                    </button>
-                  </div>
-                </form>
-              </div>
-            )}
-            {activeView === 'admin' && selectedCampaign && (
-              <div className="space-y-6">
-                <div className="flex flex-wrap items-center justify-between gap-3">
-                  <div>
-                    <p className="text-xs uppercase tracking-[0.4em] text-teal-300">Managing Campaign</p>
-                    <h2 className="text-3xl font-black uppercase tracking-wide text-white">{selectedCampaign.name}</h2>
-                    {selectedCampaign.description && <p className="text-sm text-slate-300">{selectedCampaign.description}</p>}
-                  </div>
-                  <div className="flex flex-wrap items-center gap-3">
-                    <button
-                      type="button"
-                      className="rounded-full border border-slate-700/70 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-300 transition hover:border-teal-400/60 hover:text-teal-200"
-                      onClick={handleBackToManage}
-                    >
-                      Campaign List
-                    </button>
-                    <button
-                      type="button"
-                      className="rounded-full border border-rose-400/60 bg-rose-500/20 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-rose-200 transition hover:bg-rose-500/30"
-                      onClick={handleDeleteCampaign}
-                    >
-                      Delete Campaign
-                    </button>
-                    <button
-                      type="button"
-                      className="rounded-full border border-teal-400/60 bg-teal-500/80 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-teal-400/90"
-                      onClick={handleStartSession}
-                    >
-                      Launch Session
-                    </button>
                   </div>
                 </div>
+              )}
+              {activeView === 'create' && (
                 <div className="space-y-6">
-                  <MapFolderList
-                    maps={maps}
-                    selectedMapId={selectedMap?.id ?? null}
-                    onSelect={(map) => setSelectedMap(map)}
-                    onCreateMap={handleOpenMapWizard}
-                    onDeleteMap={handleDeleteMap}
-                    onDeleteGroup={handleDeleteGroup}
-                  />
-                  <div className="grid gap-6 xl:grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)]">
-                    <div className="space-y-6">
-                      {selectedMap ? (
-                        <div className="rounded-2xl border border-slate-800/70 bg-slate-900/70 p-6">
-                          <div className="mb-6 flex flex-wrap items-start justify-between gap-4">
-                            <div>
-                              <h3 className="text-2xl font-semibold text-white">{selectedMap.name}</h3>
-                              {mapDescription && <p className="mt-2 text-sm text-slate-300">{mapDescription}</p>}
-                              {!mapDescription && mapNotes && <p className="mt-2 text-sm text-slate-400">{mapNotes}</p>}
-                            </div>
-                            <div className="flex flex-wrap items-center gap-4 text-xs uppercase tracking-[0.4em] text-slate-500">
-                              <span>Regions: {regions.length}</span>
-                              <span>Markers: {markers.length}</span>
-                              <span>
-                                Size: {selectedMap.width ?? '—'} × {selectedMap.height ?? '—'}
-                              </span>
-                            </div>
-                          </div>
-                          <div className="overflow-hidden rounded-2xl border border-slate-800/70 bg-slate-950/70">
-                            <MapMaskCanvas
-                              imageUrl={selectedMap ? apiClient.buildMapDisplayUrl(selectedMap.id) : undefined}
-                              width={selectedMap.width}
-                              height={selectedMap.height}
-                              regions={regions}
-                              revealedRegionIds={[]}
-                              markers={markers}
-                              mode="dm"
-                            />
-                          </div>
-                          <div className="mt-6 grid gap-4 lg:grid-cols-2">
-                            <div className="rounded-2xl border border-slate-800/70 bg-slate-950/70 p-4">
-                              <p className="text-[10px] uppercase tracking-[0.4em] text-slate-500">Grouping</p>
-                              <p className="mt-2 text-sm font-semibold text-teal-200">{mapGrouping}</p>
-                              {mapNotes && mapDescription && (
-                                <p className="mt-3 text-xs text-slate-400">Notes: {mapNotes}</p>
-                              )}
-                            </div>
-                            <div className="rounded-2xl border border-slate-800/70 bg-slate-950/70 p-4">
-                              <p className="text-[10px] uppercase tracking-[0.4em] text-slate-500">Tags</p>
-                              {mapTags.length > 0 ? (
-                                <div className="mt-3 flex flex-wrap gap-2">
-                                  {mapTags.map((tag) => (
-                                    <span
-                                      key={tag}
-                                      className="inline-flex items-center rounded-full border border-slate-700/70 bg-slate-900/70 px-2 py-1 text-[10px] uppercase tracking-[0.3em] text-slate-300"
-                                    >
-                                      {tag}
-                                    </span>
-                                  ))}
-                                </div>
-                              ) : (
-                                <p className="mt-3 text-xs text-slate-500">No tags assigned yet.</p>
-                              )}
-                            </div>
-                          </div>
-                          {!mapDescription && !mapNotes && (
-                            <p className="mt-4 text-xs text-slate-500">
-                              Add details and notes through the map wizard to give your players extra context.
-                            </p>
-                          )}
-                        </div>
-                      ) : (
-                        <div className="rounded-2xl border border-dashed border-slate-700/70 p-12 text-center text-sm text-slate-400">
-                          Select or create a map to begin shaping your encounter.
-                        </div>
-                      )}
+                  <h2 className="text-3xl font-black tracking-tight text-slate-900 dark:text-white">Create Campaign</h2>
+                  <p className="max-w-xl text-sm text-slate-600 dark:text-slate-300">Set up a new campaign for your players and start building encounters.</p>
+                  <form onSubmit={handleCreateCampaign} className="space-y-5">
+                    <div>
+                      <label className="text-xs uppercase tracking-[0.4em] text-slate-500 dark:text-slate-400">Campaign Name</label>
+                      <input
+                        value={newCampaignName}
+                        onChange={(event) => setNewCampaignName(event.target.value)}
+                        className="mt-2 w-full rounded-xl border border-white/60 bg-white/80 px-4 py-3 text-sm text-slate-900 placeholder:text-slate-400 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/40 dark:border-slate-800/60 dark:bg-slate-900/60 dark:text-slate-100 dark:placeholder:text-slate-500"
+                        placeholder="Give your mission a title"
+                      />
                     </div>
-                    <div className="space-y-6">
-                      <div className="rounded-2xl border border-slate-800/70 bg-slate-900/70 p-5">
-                        <div className="mb-3 flex items-center justify-between">
-                          <h3 className="text-xs uppercase tracking-[0.4em] text-slate-400">My Sessions</h3>
-                        </div>
-                        <ul className="space-y-2 text-sm">
-                          {mySessions.map((session) => (
-                            <li key={session.id}>
-                              <button
-                                onClick={() => handleJoinSession(session)}
-                                className="w-full rounded-xl border border-slate-800/70 bg-slate-950/60 px-3 py-2 text-left text-slate-300 transition hover:border-teal-400/60 hover:text-teal-100"
-                              >
-                                {session.name}
-                              </button>
-                            </li>
-                          ))}
-                          {mySessions.length === 0 && (
-                            <li className="rounded-xl border border-dashed border-slate-700/70 px-3 py-6 text-center text-xs text-slate-500">
-                              No active sessions.
-                            </li>
-                          )}
-                        </ul>
+                    <div>
+                      <label className="text-xs uppercase tracking-[0.4em] text-slate-500 dark:text-slate-400">Description</label>
+                      <textarea
+                        value={newCampaignDescription}
+                        onChange={(event) => setNewCampaignDescription(event.target.value)}
+                        rows={4}
+                        className="mt-2 w-full rounded-xl border border-white/60 bg-white/80 px-4 py-3 text-sm text-slate-900 placeholder:text-slate-400 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/40 dark:border-slate-800/60 dark:bg-slate-900/60 dark:text-slate-100 dark:placeholder:text-slate-500"
+                        placeholder="Share a quick briefing for your players"
+                      />
+                    </div>
+                    <label className="flex items-center gap-3 text-xs uppercase tracking-[0.4em] text-slate-500 dark:text-slate-400">
+                      <input
+                        type="checkbox"
+                        checked={newCampaignPublic}
+                        onChange={(event) => setNewCampaignPublic(event.target.checked)}
+                        className="h-4 w-4 rounded border border-slate-300 bg-white text-amber-500 focus:ring-amber-400 dark:border-slate-700 dark:bg-slate-900 dark:text-amber-400 dark:focus:ring-amber-400"
+                      />
+                      <span className="text-slate-600 dark:text-slate-300">List publicly for players to discover</span>
+                    </label>
+                    {createError && <p className="text-xs font-semibold text-rose-500 dark:text-rose-300">{createError}</p>}
+                    <div className="flex flex-wrap gap-3">
+                      <button
+                        type="submit"
+                        className="rounded-xl border border-amber-400/70 bg-gradient-to-r from-amber-400/90 to-orange-400/80 px-6 py-3 text-sm font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:from-amber-300 hover:to-orange-300"
+                      >
+                        Launch Campaign
+                      </button>
+                      <button
+                        type="button"
+                        className="rounded-xl border border-slate-300 px-6 py-3 text-sm font-semibold uppercase tracking-[0.3em] text-slate-500 transition hover:border-amber-400/60 hover:text-amber-500 dark:border-slate-700 dark:text-slate-300 dark:hover:border-amber-400/60 dark:hover:text-amber-200"
+                        onClick={() => {
+                          setNewCampaignName('');
+                          setNewCampaignDescription('');
+                          setNewCampaignPublic(false);
+                          setCreateError(null);
+                        }}
+                      >
+                        Reset
+                      </button>
+                    </div>
+                  </form>
+                </div>
+              )}
+              {activeView === 'admin' && selectedCampaign && (
+                <div className="space-y-6">
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <div>
+                      <p className="text-xs uppercase tracking-[0.4em] text-amber-600 dark:text-amber-200">Managing Campaign</p>
+                      <h2 className="text-3xl font-black tracking-tight text-slate-900 dark:text-white">{selectedCampaign.name}</h2>
+                      {selectedCampaign.description && <p className="text-sm text-slate-600 dark:text-slate-300">{selectedCampaign.description}</p>}
+                    </div>
+                    <div className="flex flex-wrap items-center gap-3">
+                      <button
+                        type="button"
+                        className="rounded-full border border-slate-300 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-600 transition hover:border-amber-400/60 hover:text-amber-600 dark:border-slate-700 dark:text-slate-300 dark:hover:border-amber-400/60 dark:hover:text-amber-200"
+                        onClick={handleBackToManage}
+                      >
+                        Campaign List
+                      </button>
+                      <button
+                        type="button"
+                        className="rounded-full border border-rose-400/60 bg-rose-300/30 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-rose-700 transition hover:bg-rose-300/50 dark:border-rose-500/60 dark:bg-rose-500/20 dark:text-rose-100 dark:hover:bg-rose-500/30"
+                        onClick={handleDeleteCampaign}
+                      >
+                        Delete Campaign
+                      </button>
+                      <button
+                        type="button"
+                        className="rounded-full border border-amber-400/70 bg-gradient-to-r from-amber-400/90 to-orange-400/80 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:from-amber-300 hover:to-orange-300"
+                        onClick={handleStartSession}
+                      >
+                        Launch Session
+                      </button>
+                    </div>
+                  </div>
+                  <div className="space-y-6">
+                    <MapFolderList
+                      maps={maps}
+                      selectedMapId={selectedMap?.id ?? null}
+                      onSelect={(map) => setSelectedMap(map)}
+                      onCreateMap={handleOpenMapWizard}
+                      onDeleteMap={handleDeleteMap}
+                      onDeleteGroup={handleDeleteGroup}
+                    />
+                    <div className="grid gap-6 xl:grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)]">
+                      <div className="space-y-6">
+                        {selectedMap ? (
+                          <div className="rounded-2xl border border-white/60 bg-white/80 p-6 shadow-sm backdrop-blur dark:border-slate-800/60 dark:bg-slate-900/60">
+                            <div className="mb-6 flex flex-wrap items-start justify-between gap-4">
+                              <div>
+                                <h3 className="text-2xl font-semibold text-slate-900 dark:text-white">{selectedMap.name}</h3>
+                                {mapDescription && <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">{mapDescription}</p>}
+                                {!mapDescription && mapNotes && <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">{mapNotes}</p>}
+                              </div>
+                              <div className="flex flex-wrap items-center gap-4 text-xs uppercase tracking-[0.4em] text-slate-500 dark:text-slate-400">
+                                <span>Regions: {regions.length}</span>
+                                <span>Markers: {markers.length}</span>
+                                <span>
+                                  Size: {selectedMap.width ?? '—'} × {selectedMap.height ?? '—'}
+                                </span>
+                              </div>
+                            </div>
+                            <div className="overflow-hidden rounded-2xl border border-white/60 bg-white/70 dark:border-slate-800/60 dark:bg-slate-950/60">
+                              <MapMaskCanvas
+                                imageUrl={selectedMap ? apiClient.buildMapDisplayUrl(selectedMap.id) : undefined}
+                                width={selectedMap.width}
+                                height={selectedMap.height}
+                                regions={regions}
+                                revealedRegionIds={[]}
+                                markers={markers}
+                                mode="dm"
+                              />
+                            </div>
+                            <div className="mt-6 grid gap-4 lg:grid-cols-2">
+                              <div className="rounded-2xl border border-white/60 bg-white/70 p-4 backdrop-blur dark:border-slate-800/60 dark:bg-slate-950/60">
+                                <p className="text-[10px] uppercase tracking-[0.4em] text-slate-500 dark:text-slate-400">Grouping</p>
+                                <p className="mt-2 text-sm font-semibold text-amber-600 dark:text-amber-200">{mapGrouping}</p>
+                                {mapNotes && mapDescription && (
+                                  <p className="mt-3 text-xs text-slate-600 dark:text-slate-400">Notes: {mapNotes}</p>
+                                )}
+                              </div>
+                              <div className="rounded-2xl border border-white/60 bg-white/70 p-4 backdrop-blur dark:border-slate-800/60 dark:bg-slate-950/60">
+                                <p className="text-[10px] uppercase tracking-[0.4em] text-slate-500 dark:text-slate-400">Tags</p>
+                                {mapTags.length > 0 ? (
+                                  <div className="mt-3 flex flex-wrap gap-2">
+                                    {mapTags.map((tag) => (
+                                      <span
+                                        key={tag}
+                                        className="inline-flex items-center rounded-full border border-slate-300 bg-white/80 px-2 py-1 text-[10px] uppercase tracking-[0.3em] text-slate-600 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-300"
+                                      >
+                                        {tag}
+                                      </span>
+                                    ))}
+                                  </div>
+                                ) : (
+                                  <p className="mt-3 text-xs text-slate-500 dark:text-slate-400">No tags assigned yet.</p>
+                                )}
+                              </div>
+                            </div>
+                            {!mapDescription && !mapNotes && (
+                              <p className="mt-4 text-xs text-slate-500 dark:text-slate-400">
+                                Add details and notes through the map wizard to give your players extra context.
+                              </p>
+                            )}
+                          </div>
+                        ) : (
+                          <div className="rounded-2xl border border-dashed border-slate-300 p-12 text-center text-sm text-slate-500 dark:border-slate-700 dark:text-slate-400">
+                            Select or create a map to begin shaping your encounter.
+                          </div>
+                        )}
                       </div>
-                      <div className="rounded-2xl border border-slate-800/70 bg-slate-900/70 p-5">
-                        <div className="mb-3 flex items-center justify-between">
-                          <h3 className="text-xs uppercase tracking-[0.4em] text-slate-400">Lobby</h3>
-                          <button
-                            type="button"
-                            className="text-xs font-semibold uppercase tracking-[0.3em] text-teal-200 transition hover:text-teal-100"
-                            onClick={refreshLobby}
-                          >
-                            Refresh
-                          </button>
+                      <div className="space-y-6">
+                        <div className="rounded-2xl border border-white/60 bg-white/80 p-5 backdrop-blur dark:border-slate-800/60 dark:bg-slate-900/60">
+                          <div className="mb-3 flex items-center justify-between">
+                            <h3 className="text-xs uppercase tracking-[0.4em] text-slate-500 dark:text-slate-400">My Sessions</h3>
+                          </div>
+                          <ul className="space-y-2 text-sm">
+                            {mySessions.map((session) => (
+                              <li key={session.id}>
+                                <button
+                                  onClick={() => handleJoinSession(session)}
+                                  className="w-full rounded-xl border border-white/60 bg-white/70 px-3 py-2 text-left text-slate-700 transition hover:border-amber-400/60 hover:text-amber-600 dark:border-slate-800/60 dark:bg-slate-950/60 dark:text-slate-300 dark:hover:border-amber-400/60 dark:hover:text-amber-200"
+                                >
+                                  {session.name}
+                                </button>
+                              </li>
+                            ))}
+                            {mySessions.length === 0 && (
+                              <li className="rounded-xl border border-dashed border-slate-300 px-3 py-6 text-center text-xs text-slate-500 dark:border-slate-700 dark:text-slate-400">
+                                No active sessions.
+                              </li>
+                            )}
+                          </ul>
                         </div>
-                        <ul className="space-y-2 text-sm">
-                          {lobbySessions.map((session) => (
-                            <li key={session.id} className="rounded-xl border border-slate-800/70 bg-slate-950/60 p-3">
-                              <p className="font-semibold text-slate-100">{session.name}</p>
-                              <p className="text-[10px] uppercase tracking-[0.4em] text-slate-500">Campaign: {session.campaignName ?? 'Unknown'}</p>
-                              <p className="text-[10px] uppercase tracking-[0.4em] text-slate-500">Map: {session.mapName ?? 'Unknown'}</p>
-                              <button
-                                type="button"
-                                className="mt-3 w-full rounded-xl border border-teal-400/60 bg-teal-500/80 px-3 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-teal-400/90"
-                                onClick={() => handleJoinSession(session)}
-                              >
-                                Join as {session.hostId === user.id ? 'DM' : 'Player'}
-                              </button>
-                            </li>
-                          ))}
-                          {lobbySessions.length === 0 && (
-                            <li className="rounded-xl border border-dashed border-slate-700/70 px-3 py-6 text-center text-xs text-slate-500">
-                              No active sessions available.
-                            </li>
-                          )}
-                        </ul>
+                        <div className="rounded-2xl border border-white/60 bg-white/80 p-5 backdrop-blur dark:border-slate-800/60 dark:bg-slate-900/60">
+                          <div className="mb-3 flex items-center justify-between">
+                            <h3 className="text-xs uppercase tracking-[0.4em] text-slate-500 dark:text-slate-400">Lobby</h3>
+                            <button
+                              type="button"
+                              className="text-xs font-semibold uppercase tracking-[0.3em] text-amber-600 transition hover:text-amber-500 dark:text-amber-200 dark:hover:text-amber-100"
+                              onClick={refreshLobby}
+                            >
+                              Refresh
+                            </button>
+                          </div>
+                          <ul className="space-y-2 text-sm">
+                            {lobbySessions.map((session) => (
+                              <li key={session.id} className="rounded-xl border border-white/60 bg-white/80 p-3 backdrop-blur dark:border-slate-800/60 dark:bg-slate-950/60">
+                                <p className="font-semibold text-slate-900 dark:text-white">{session.name}</p>
+                                <p className="text-[10px] uppercase tracking-[0.4em] text-slate-500 dark:text-slate-400">Campaign: {session.campaignName ?? 'Unknown'}</p>
+                                <p className="text-[10px] uppercase tracking-[0.4em] text-slate-500 dark:text-slate-400">Map: {session.mapName ?? 'Unknown'}</p>
+                                <button
+                                  type="button"
+                                  className="mt-3 w-full rounded-xl border border-amber-400/70 bg-gradient-to-r from-amber-400/90 to-orange-400/80 px-3 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:from-amber-300 hover:to-orange-300"
+                                  onClick={() => handleJoinSession(session)}
+                                >
+                                  Join as {session.hostId === user.id ? 'DM' : 'Player'}
+                                </button>
+                              </li>
+                            ))}
+                            {lobbySessions.length === 0 && (
+                              <li className="rounded-xl border border-dashed border-slate-300 px-3 py-6 text-center text-xs text-slate-500 dark:border-slate-700 dark:text-slate-400">
+                                No active sessions available.
+                              </li>
+                            )}
+                          </ul>
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
-              </div>
-            )}
-            {activeView === 'admin' && !selectedCampaign && (
-              <div className="rounded-2xl border border-dashed border-slate-700/70 p-12 text-center text-sm text-slate-400">
-                Choose a campaign from the manage tab to configure it here.
-              </div>
-            )}
+              )}
+              {activeView === 'admin' && !selectedCampaign && (
+                <div className="rounded-2xl border border-dashed border-slate-300 p-12 text-center text-sm text-slate-500 dark:border-slate-700 dark:text-slate-400">
+                  Choose a campaign from the manage tab to configure it here.
+                </div>
+              )}
           </div>
         </section>
         {showMapWizard && selectedCampaign && (
@@ -999,6 +1003,7 @@ const App: React.FC = () => {
           />
         )}
       </div>
+    </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- refresh the authenticated dashboard shell with landing-page inspired gradient backdrops and glassmorphism panels
- restyle join/manage/create/admin views with lighter palettes, amber highlights, and improved contrast across light and dark themes

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68db452f052c8323938feafa2b9590b6