### PR TITLE
Align App dashboard theming with landing page aesthetic

### DIFF
--- a/apps/pages/src/App.tsx
+++ b/apps/pages/src/App.tsx
@@ -536,11 +536,17 @@ const App: React.FC = () => {
 
   const themeLabel = theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode';
 
+  const themeToggleButtonClasses =
+    'inline-flex items-center gap-2 rounded-full border border-slate-300/70 bg-white/60 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-600 shadow-sm transition hover:border-amber-500/70 hover:text-amber-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-400 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-200 dark:hover:border-amber-400/60 dark:hover:text-amber-200';
+
+  const logoutButtonClasses =
+    'inline-flex items-center rounded-full border border-rose-300/70 bg-rose-100/60 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-rose-600 transition hover:border-rose-400/70 hover:bg-rose-100/80 dark:border-rose-500/40 dark:bg-rose-500/20 dark:text-rose-100 dark:hover:border-rose-400/50';
+
   const navButtonClasses = (view: 'join' | 'manage' | 'create' | 'admin') =>
     `group flex w-full items-center justify-between rounded-2xl border px-5 py-4 text-left text-sm font-semibold uppercase tracking-[0.3em] transition ${
       activeView === view
-        ? 'border-teal-400 bg-teal-400/90 text-slate-900 shadow-lg shadow-teal-500/40'
-        : 'border-slate-800/70 bg-slate-900/60 text-slate-300 hover:border-teal-400/60 hover:bg-slate-800/80'
+        ? 'border-amber-400/70 bg-gradient-to-r from-amber-200/80 via-orange-100/70 to-rose-100/60 text-slate-900 shadow-lg shadow-amber-500/30 dark:border-amber-400/50 dark:from-amber-400/30 dark:via-orange-400/20 dark:to-rose-400/20 dark:text-amber-50'
+        : 'border-white/60 bg-white/50 text-slate-700 hover:border-amber-400/60 hover:bg-white/70 dark:border-slate-800/70 dark:bg-slate-900/60 dark:text-slate-200 dark:hover:border-amber-400/50 dark:hover:bg-slate-900/70'
     }`;
 
   if (!token || !user) {
@@ -549,324 +555,337 @@ const App: React.FC = () => {
 
   if (activeSession) {
     return (
-      <div className="min-h-screen bg-slate-100 p-6 dark:bg-slate-900">
-        <div className="mb-4 flex items-center justify-between">
-          <div>
-            <h1 className="text-2xl font-bold text-primary">TableTorch</h1>
-            <p className="text-sm text-slate-500 dark:text-slate-400">Logged in as {user.displayName}</p>
-          </div>
-          <div className="flex items-center gap-2">
-            <button
-              className="rounded-full border border-slate-300 px-3 py-1 text-xs hover:bg-slate-100 dark:border-slate-600 dark:hover:bg-slate-700"
-              onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
-            >
-              {themeLabel}
-            </button>
-            <button
-              className="rounded-full border border-slate-300 px-3 py-1 text-xs hover:bg-slate-100 dark:border-slate-600 dark:hover:bg-slate-700"
-              onClick={handleLogout}
-            >
-              Logout
-            </button>
+      <div className="relative min-h-screen overflow-hidden bg-landing text-slate-900 transition-colors dark:text-slate-100">
+        <div aria-hidden className="absolute inset-0 bg-grid-mask opacity-60 mix-blend-soft-light dark:opacity-40" />
+        <div aria-hidden className="pointer-events-none absolute -top-40 right-10 h-96 w-96 rounded-full bg-amber-300/20 blur-[160px] dark:bg-amber-500/20" />
+        <div aria-hidden className="pointer-events-none absolute bottom-[-12rem] left-[-8rem] h-[32rem] w-[32rem] rounded-full bg-orange-300/15 blur-[140px] dark:bg-orange-500/20" />
+        <div className="relative isolate">
+          <div className="mx-auto flex min-h-screen max-w-6xl flex-col gap-6 px-4 py-10">
+            <header className="flex flex-wrap items-center justify-between gap-4 rounded-3xl border border-white/70 bg-white/70 px-6 py-4 shadow-lg shadow-amber-500/10 backdrop-blur-xl dark:border-slate-800/70 dark:bg-slate-950/70">
+              <div>
+                <p className="text-xs uppercase tracking-[0.45em] text-amber-600 dark:text-amber-200">Live Session</p>
+                <h1 className="text-3xl font-black uppercase tracking-wide text-slate-900 dark:text-white">TableTorch</h1>
+                <p className="text-sm text-slate-600 dark:text-slate-400">Logged in as {user.displayName}</p>
+              </div>
+              <div className="flex flex-wrap items-center gap-3">
+                <button className={themeToggleButtonClasses} onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}>
+                  <span aria-hidden className="text-base">{theme === 'dark' ? '🌙' : '🌞'}</span>
+                  {themeLabel}
+                </button>
+                <button className={logoutButtonClasses} onClick={handleLogout}>
+                  Logout
+                </button>
+              </div>
+            </header>
+            {statusMessage && (
+              <div className="rounded-2xl border border-amber-300/60 bg-white/70 px-5 py-3 text-sm text-slate-700 shadow-sm backdrop-blur-xl dark:border-amber-400/40 dark:bg-slate-900/70 dark:text-slate-100">
+                {statusMessage}
+              </div>
+            )}
+            <div className="rounded-[2.5rem] border border-white/70 bg-white/60 p-4 shadow-2xl shadow-amber-500/10 backdrop-blur-2xl dark:border-slate-800/70 dark:bg-slate-950/70">
+              <SessionViewer
+                session={activeSession}
+                mapImageUrl={selectedMap ? apiClient.buildMapDisplayUrl(selectedMap.id) : undefined}
+                mapWidth={selectedMap?.width}
+                mapHeight={selectedMap?.height}
+                regions={regions}
+                baseMarkers={markers}
+                mode={sessionMode}
+                user={user}
+                onLeave={handleLeaveSession}
+                onSaveSession={sessionMode === 'dm' ? handleSaveSession : undefined}
+                onEndSession={sessionMode === 'dm' ? handleEndSession : undefined}
+              />
+            </div>
           </div>
         </div>
-        {statusMessage && (
-          <div className="mb-4 rounded border border-slate-200 bg-white px-4 py-2 text-sm text-slate-600 shadow dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200">
-            {statusMessage}
-          </div>
-        )}
-        <SessionViewer
-          session={activeSession}
-          mapImageUrl={selectedMap ? apiClient.buildMapDisplayUrl(selectedMap.id) : undefined}
-          mapWidth={selectedMap?.width}
-          mapHeight={selectedMap?.height}
-          regions={regions}
-          baseMarkers={markers}
-          mode={sessionMode}
-          user={user}
-          onLeave={handleLeaveSession}
-          onSaveSession={sessionMode === 'dm' ? handleSaveSession : undefined}
-          onEndSession={sessionMode === 'dm' ? handleEndSession : undefined}
-        />
       </div>
     );
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 text-slate-100">
-      <div className="mx-auto flex min-h-screen max-w-6xl flex-col gap-6 px-4 py-8 md:flex-row md:py-12">
-        <aside className="flex flex-col gap-6 rounded-3xl border border-slate-800/70 bg-slate-950/70 p-6 shadow-2xl md:w-72">
-          <div>
-            <p className="text-xs uppercase tracking-[0.4em] text-slate-500">Mission Control</p>
-            <h2 className="mt-3 text-2xl font-black uppercase tracking-wide text-teal-300">Command Deck</h2>
-          </div>
-          <div className="rounded-2xl border border-slate-800/70 bg-slate-900/70 p-4">
-            <p className="text-xs uppercase tracking-[0.5em] text-slate-500">Logged in</p>
-            <p className="mt-2 text-lg font-semibold text-white">{user.displayName}</p>
-            <p className="text-xs text-slate-500">Ready for launch</p>
-          </div>
-          <nav className="space-y-3">
-            <button className={navButtonClasses('join')} onClick={() => setActiveView('join')}>
-              <span>Join Campaign</span>
-              <span className="text-[10px] tracking-[0.4em] text-slate-900/70 transition group-hover:text-slate-900/90">START</span>
-            </button>
-            <button className={navButtonClasses('manage')} onClick={() => setActiveView('manage')}>
-              <span>Manage Campaigns</span>
-              <span className="text-[10px] tracking-[0.4em] text-slate-900/70 transition group-hover:text-slate-900/90">HANGAR</span>
-            </button>
-            <button className={navButtonClasses('create')} onClick={() => setActiveView('create')}>
-              <span>Create Campaign</span>
-              <span className="text-[10px] tracking-[0.4em] text-slate-900/70 transition group-hover:text-slate-900/90">NEW</span>
-            </button>
-          </nav>
-          <div className="mt-auto space-y-2 text-xs text-slate-500">
-            <p>Need a room code? Ask your DM to share their campaign key.</p>
-            <p>Switch tabs to manage, create, or join adventures.</p>
-          </div>
-        </aside>
-        <section className="flex-1 space-y-6">
-          <header className="flex flex-wrap items-center justify-between gap-3 rounded-3xl border border-slate-800/70 bg-slate-950/70 px-6 py-4 shadow-xl">
+    <div className="relative min-h-screen overflow-hidden bg-landing text-slate-900 transition-colors dark:text-slate-100">
+      <div aria-hidden className="absolute inset-0 bg-grid-mask opacity-60 mix-blend-soft-light dark:opacity-40" />
+      <div aria-hidden className="pointer-events-none absolute -top-36 right-24 h-[26rem] w-[26rem] rounded-full bg-amber-300/20 blur-[140px] dark:bg-amber-500/20" />
+      <div aria-hidden className="pointer-events-none absolute bottom-[-14rem] left-[-10rem] h-[34rem] w-[34rem] rounded-full bg-orange-300/15 blur-[160px] dark:bg-orange-500/20" />
+      <div className="relative isolate">
+        <div className="mx-auto flex min-h-screen max-w-6xl flex-col gap-6 px-4 py-10 md:flex-row md:py-16">
+          <aside className="flex flex-col gap-6 rounded-3xl border border-white/70 bg-white/70 p-6 shadow-2xl shadow-amber-500/20 backdrop-blur-xl md:w-72 dark:border-slate-800/70 dark:bg-slate-950/70">
             <div>
-              <p className="text-xs uppercase tracking-[0.5em] text-teal-300">Campaign Control</p>
-              <h1 className="text-3xl font-black uppercase tracking-wide text-white">TableTorch</h1>
+              <p className="text-xs uppercase tracking-[0.45em] text-amber-600 dark:text-amber-200">Mission Control</p>
+              <h2 className="mt-3 text-2xl font-black uppercase tracking-wide text-slate-900 dark:text-amber-100">Command Deck</h2>
             </div>
-            <div className="flex items-center gap-3">
-              <button
-                className="rounded-full border border-teal-400/60 bg-teal-400/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-teal-200 transition hover:bg-teal-400/20"
-                onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
-              >
-                {themeLabel}
+            <div className="rounded-2xl border border-white/60 bg-white/70 p-4 backdrop-blur-xl dark:border-slate-800/70 dark:bg-slate-900/70">
+              <p className="text-xs uppercase tracking-[0.5em] text-slate-500 dark:text-slate-400">Logged in</p>
+              <p className="mt-2 text-lg font-semibold text-slate-900 dark:text-white">{user.displayName}</p>
+              <p className="text-xs text-slate-600 dark:text-slate-400">Ready for launch</p>
+            </div>
+            <nav className="space-y-3">
+              <button className={navButtonClasses('join')} onClick={() => setActiveView('join')}>
+                <span>Join Campaign</span>
+                <span className="text-[10px] tracking-[0.4em] text-amber-600/70 transition group-hover:text-amber-700 dark:text-amber-200/70 dark:group-hover:text-amber-100">
+                  START
+                </span>
               </button>
-              <button
-                className="rounded-full border border-rose-400/60 bg-rose-500/20 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-rose-200 transition hover:bg-rose-500/30"
-                onClick={handleLogout}
-              >
-                Logout
+              <button className={navButtonClasses('manage')} onClick={() => setActiveView('manage')}>
+                <span>Manage Campaigns</span>
+                <span className="text-[10px] tracking-[0.4em] text-amber-600/70 transition group-hover:text-amber-700 dark:text-amber-200/70 dark:group-hover:text-amber-100">
+                  HANGAR
+                </span>
               </button>
+              <button className={navButtonClasses('create')} onClick={() => setActiveView('create')}>
+                <span>Create Campaign</span>
+                <span className="text-[10px] tracking-[0.4em] text-amber-600/70 transition group-hover:text-amber-700 dark:text-amber-200/70 dark:group-hover:text-amber-100">
+                  NEW
+                </span>
+              </button>
+            </nav>
+            <div className="mt-auto space-y-2 text-xs text-slate-600 dark:text-slate-400">
+              <p>Need a room code? Ask your DM to share their campaign key.</p>
+              <p>Switch tabs to manage, create, or join adventures.</p>
             </div>
-          </header>
-          {statusMessage && (
-            <div className="rounded-3xl border border-teal-500/40 bg-teal-500/10 px-5 py-3 text-sm text-teal-200 shadow-lg shadow-teal-500/10">
-              {statusMessage}
-            </div>
-          )}
-          <div className="flex-1 rounded-3xl border border-slate-800/70 bg-slate-950/70 p-6 shadow-2xl">
-            {activeView === 'join' && (
-              <div className="space-y-6">
-                <h2 className="text-3xl font-black uppercase tracking-wide text-teal-200">Join Campaign</h2>
-                <p className="max-w-xl text-sm text-slate-300">
-                  Enter the campaign key provided by your Dungeon Master to hop into their room.
-                </p>
-                <form onSubmit={handleJoinByKey} className="space-y-4">
-                  <label className="block text-xs uppercase tracking-[0.4em] text-slate-400">
-                    Campaign Key
-                    <div className="mt-2 flex flex-col gap-3 sm:flex-row">
-                      <input
-                        value={joinKey}
-                        onChange={(event) => setJoinKey(event.target.value)}
-                        placeholder="e.g. A1B2C3"
-                        className="flex-1 rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm uppercase tracking-[0.3em] text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
-                      />
+          </aside>
+          <section className="flex-1 space-y-6">
+            <header className="flex flex-wrap items-center justify-between gap-3 rounded-3xl border border-white/70 bg-white/70 px-6 py-4 shadow-xl shadow-amber-500/10 backdrop-blur-xl dark:border-slate-800/70 dark:bg-slate-950/70">
+              <div>
+                <p className="text-xs uppercase tracking-[0.5em] text-amber-600 dark:text-amber-200">Campaign Control</p>
+                <h1 className="text-3xl font-black uppercase tracking-wide text-slate-900 dark:text-white">TableTorch</h1>
+              </div>
+              <div className="flex flex-wrap items-center gap-3">
+                <button className={themeToggleButtonClasses} onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}>
+                  <span aria-hidden className="text-base">{theme === 'dark' ? '🌙' : '🌞'}</span>
+                  {themeLabel}
+                </button>
+                <button className={logoutButtonClasses} onClick={handleLogout}>
+                  Logout
+                </button>
+              </div>
+            </header>
+            {statusMessage && (
+              <div className="rounded-3xl border border-amber-300/60 bg-white/70 px-5 py-3 text-sm text-slate-700 shadow-lg shadow-amber-500/10 backdrop-blur-xl dark:border-amber-400/40 dark:bg-slate-900/70 dark:text-slate-100">
+                {statusMessage}
+              </div>
+            )}
+            <div className="flex-1 rounded-3xl border border-white/70 bg-white/70 p-6 shadow-2xl shadow-amber-500/10 backdrop-blur-xl dark:border-slate-800/70 dark:bg-slate-950/70">
+              {activeView === 'join' && (
+                <div className="space-y-6">
+                  <h2 className="text-3xl font-black uppercase tracking-wide text-slate-900 dark:text-amber-100">Join Campaign</h2>
+                  <p className="max-w-xl text-sm text-slate-600 dark:text-slate-300">
+                    Enter the campaign key provided by your Dungeon Master to hop into their room.
+                  </p>
+                  <form onSubmit={handleJoinByKey} className="space-y-4">
+                    <label className="block text-xs uppercase tracking-[0.4em] text-slate-500 dark:text-slate-400">
+                      Campaign Key
+                      <div className="mt-2 flex flex-col gap-3 sm:flex-row">
+                        <input
+                          value={joinKey}
+                          onChange={(event) => setJoinKey(event.target.value)}
+                          placeholder="e.g. A1B2C3"
+                          className="flex-1 rounded-xl border border-slate-300/70 bg-white/80 px-4 py-3 text-sm uppercase tracking-[0.3em] text-slate-800 placeholder:text-slate-500 shadow-sm transition focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-300/40 dark:border-slate-700 dark:bg-slate-900/70 dark:text-slate-100 dark:placeholder:text-slate-500 dark:focus:border-amber-400 dark:focus:ring-amber-400/40"
+                        />
+                        <button
+                          type="submit"
+                          className="rounded-xl border border-amber-400/70 bg-gradient-to-r from-amber-400/90 to-orange-400/80 px-6 py-3 text-sm font-semibold uppercase tracking-[0.3em] text-slate-900 shadow-md shadow-amber-500/20 transition hover:from-amber-400 hover:to-orange-400 focus:outline-none focus:ring-2 focus:ring-amber-300/40 dark:from-amber-400/60 dark:to-rose-400/50 dark:text-amber-50 dark:focus:ring-amber-400/40"
+                        >
+                          Join Room
+                        </button>
+                      </div>
+                    </label>
+                    {joinError && <p className="text-xs font-semibold text-rose-500 dark:text-rose-300">{joinError}</p>}
+                  </form>
+                  <div className="rounded-2xl border border-white/60 bg-white/70 p-4 backdrop-blur-xl dark:border-slate-800/70 dark:bg-slate-900/70">
+                    <div className="mb-3 flex items-center justify-between">
+                      <h3 className="text-xs uppercase tracking-[0.4em] text-slate-500 dark:text-slate-400">Active Rooms</h3>
                       <button
-                        type="submit"
-                        className="rounded-xl border border-teal-400/60 bg-teal-500/80 px-6 py-3 text-sm font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-teal-400/90 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                        type="button"
+                        className="text-xs font-semibold uppercase tracking-[0.3em] text-amber-600 transition hover:text-amber-700 dark:text-amber-200 dark:hover:text-amber-100"
+                        onClick={refreshLobby}
                       >
-                        Join Room
+                        Refresh
                       </button>
                     </div>
-                  </label>
-                  {joinError && <p className="text-xs font-semibold text-rose-300">{joinError}</p>}
-                </form>
-                <div className="rounded-2xl border border-slate-800/70 bg-slate-900/70 p-4">
-                  <div className="mb-3 flex items-center justify-between">
-                    <h3 className="text-xs uppercase tracking-[0.4em] text-slate-400">Active Rooms</h3>
+                    <ul className="max-h-48 space-y-2 overflow-y-auto pr-1 text-sm">
+                      {lobbySessions.map((session) => (
+                        <li
+                          key={session.id}
+                          className="rounded-xl border border-white/60 bg-white/60 p-3 backdrop-blur-xl transition hover:border-amber-400/60 hover:bg-white/80 dark:border-slate-800/70 dark:bg-slate-950/60 dark:hover:border-amber-400/50"
+                        >
+                          <div className="flex flex-wrap items-center justify-between gap-2">
+                            <div>
+                              <p className="font-semibold text-slate-800 dark:text-slate-100">{session.name}</p>
+                              <p className="text-[10px] uppercase tracking-[0.4em] text-slate-500 dark:text-slate-400">Key: {session.id}</p>
+                            </div>
+                            <button
+                              type="button"
+                              className="rounded-lg border border-amber-400/70 bg-gradient-to-r from-amber-400/90 to-orange-400/80 px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:from-amber-400 hover:to-orange-400 dark:from-amber-400/60 dark:to-rose-400/50 dark:text-amber-50"
+                              onClick={() => handleJoinSession(session)}
+                            >
+                              Join
+                            </button>
+                          </div>
+                          <p className="mt-2 text-xs text-slate-500 dark:text-slate-400">
+                            Campaign: {session.campaignName ?? 'Unknown'} • Map: {session.mapName ?? 'Unknown'}
+                          </p>
+                        </li>
+                      ))}
+                      {lobbySessions.length === 0 && (
+                        <li className="rounded-xl border border-dashed border-slate-300/70 px-3 py-6 text-center text-xs text-slate-500 dark:border-slate-700/70 dark:text-slate-400">
+                          No active rooms yet.
+                        </li>
+                      )}
+                    </ul>
+                  </div>
+                </div>
+              )}
+              {activeView === 'manage' && (
+                <div className="space-y-6">
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <div>
+                      <h2 className="text-3xl font-black uppercase tracking-wide text-slate-900 dark:text-amber-100">Manage Campaigns</h2>
+                      <p className="text-sm text-slate-600 dark:text-slate-300">Select a campaign to open the admin hangar.</p>
+                    </div>
                     <button
                       type="button"
-                      className="text-xs font-semibold uppercase tracking-[0.3em] text-teal-200 transition hover:text-teal-100"
-                      onClick={refreshLobby}
+                      className="rounded-full border border-slate-300/70 bg-white/60 px-5 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-600 transition hover:border-amber-400/70 hover:text-amber-600 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-200 dark:hover:border-amber-400/60 dark:hover:text-amber-200"
+                      onClick={() => refreshCampaigns()}
                     >
                       Refresh
                     </button>
                   </div>
-                  <ul className="max-h-48 space-y-2 overflow-y-auto pr-1 text-sm">
-                    {lobbySessions.map((session) => (
-                      <li key={session.id} className="rounded-xl border border-slate-800/70 bg-slate-950/60 p-3">
-                        <div className="flex flex-wrap items-center justify-between gap-2">
-                          <div>
-                            <p className="font-semibold text-slate-100">{session.name}</p>
-                            <p className="text-[10px] uppercase tracking-[0.4em] text-slate-500">Key: {session.id}</p>
-                          </div>
-                          <button
-                            type="button"
-                            className="rounded-lg border border-teal-400/60 bg-teal-500/80 px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-teal-400/90"
-                            onClick={() => handleJoinSession(session)}
-                          >
-                            Join
-                          </button>
+                  <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+                    {campaigns.map((campaign) => (
+                      <button
+                        key={campaign.id}
+                        className="group flex h-full flex-col justify-between rounded-2xl border border-white/60 bg-white/60 p-4 text-left transition hover:border-amber-400/60 hover:bg-white/80 dark:border-slate-800/70 dark:bg-slate-950/60 dark:hover:border-amber-400/50"
+                        onClick={() => handleOpenCampaignAdmin(campaign)}
+                      >
+                        <div>
+                          <p className="text-xs uppercase tracking-[0.4em] text-slate-500 dark:text-slate-400">Campaign</p>
+                          <h3 className="mt-2 text-lg font-semibold text-slate-900 dark:text-white">{campaign.name}</h3>
+                          <p className="mt-2 text-xs text-slate-600 dark:text-slate-400">{campaign.description || 'No description provided.'}</p>
                         </div>
-                        <p className="mt-2 text-xs text-slate-400">
-                          Campaign: {session.campaignName ?? 'Unknown'} • Map: {session.mapName ?? 'Unknown'}
-                        </p>
-                      </li>
+                        <span className="mt-4 inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.3em] text-amber-600 transition group-hover:text-amber-700 dark:text-amber-200 dark:group-hover:text-amber-100">
+                          Open Hangar <span aria-hidden>→</span>
+                        </span>
+                      </button>
                     ))}
-                    {lobbySessions.length === 0 && (
-                      <li className="rounded-xl border border-dashed border-slate-700/70 px-3 py-6 text-center text-xs text-slate-500">
-                        No active rooms yet.
-                      </li>
-                    )}
-                  </ul>
-                </div>
-              </div>
-            )}
-            {activeView === 'manage' && (
-              <div className="space-y-6">
-                <div className="flex flex-wrap items-center justify-between gap-3">
-                  <div>
-                    <h2 className="text-3xl font-black uppercase tracking-wide text-teal-200">Manage Campaigns</h2>
-                    <p className="text-sm text-slate-300">Select a campaign to open the admin hangar.</p>
-                  </div>
-                  <button
-                    type="button"
-                    className="rounded-full border border-teal-400/60 px-5 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-teal-200 transition hover:bg-teal-500/20"
-                    onClick={() => refreshCampaigns()}
-                  >
-                    Refresh
-                  </button>
-                </div>
-                <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
-                  {campaigns.map((campaign) => (
-                    <button
-                      key={campaign.id}
-                      className="group flex h-full flex-col justify-between rounded-2xl border border-slate-800/70 bg-slate-950/60 p-4 text-left transition hover:border-teal-400/60 hover:bg-slate-900/70"
-                      onClick={() => handleOpenCampaignAdmin(campaign)}
-                    >
-                      <div>
-                        <p className="text-xs uppercase tracking-[0.4em] text-slate-500">Campaign</p>
-                        <h3 className="mt-2 text-lg font-semibold text-white">{campaign.name}</h3>
-                        <p className="mt-2 text-xs text-slate-400">{campaign.description || 'No description provided.'}</p>
+                    {campaigns.length === 0 && (
+                      <div className="rounded-2xl border border-dashed border-slate-300/70 p-6 text-center text-sm text-slate-500 dark:border-slate-700/70 dark:text-slate-400">
+                        You haven't created any campaigns yet. Try the create tab to launch a new adventure.
                       </div>
-                      <span className="mt-4 inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.3em] text-teal-200">
-                        Open Hangar <span aria-hidden>→</span>
-                      </span>
-                    </button>
-                  ))}
-                  {campaigns.length === 0 && (
-                    <div className="rounded-2xl border border-dashed border-slate-700/70 p-6 text-center text-sm text-slate-400">
-                      You haven't created any campaigns yet. Try the create tab to launch a new adventure.
-                    </div>
-                  )}
-                </div>
-              </div>
-            )}
-            {activeView === 'create' && (
-              <div className="space-y-6">
-                <h2 className="text-3xl font-black uppercase tracking-wide text-teal-200">Create Campaign</h2>
-                <p className="max-w-xl text-sm text-slate-300">Set up a new campaign for your players and start building encounters.</p>
-                <form onSubmit={handleCreateCampaign} className="space-y-5">
-                  <div>
-                    <label className="text-xs uppercase tracking-[0.4em] text-slate-400">Campaign Name</label>
-                    <input
-                      value={newCampaignName}
-                      onChange={(event) => setNewCampaignName(event.target.value)}
-                      className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
-                      placeholder="Give your mission a title"
-                    />
-                  </div>
-                  <div>
-                    <label className="text-xs uppercase tracking-[0.4em] text-slate-400">Description</label>
-                    <textarea
-                      value={newCampaignDescription}
-                      onChange={(event) => setNewCampaignDescription(event.target.value)}
-                      rows={4}
-                      className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
-                      placeholder="Share a quick briefing for your players"
-                    />
-                  </div>
-                  <label className="flex items-center gap-3 text-xs uppercase tracking-[0.4em] text-slate-400">
-                    <input
-                      type="checkbox"
-                      checked={newCampaignPublic}
-                      onChange={(event) => setNewCampaignPublic(event.target.checked)}
-                      className="h-4 w-4 rounded border border-slate-700 bg-slate-900 text-teal-400 focus:ring-teal-400"
-                    />
-                    <span className="text-slate-300">List publicly for players to discover</span>
-                  </label>
-                  {createError && <p className="text-xs font-semibold text-rose-300">{createError}</p>}
-                  <div className="flex flex-wrap gap-3">
-                    <button
-                      type="submit"
-                      className="rounded-xl border border-teal-400/60 bg-teal-500/80 px-6 py-3 text-sm font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-teal-400/90"
-                    >
-                      Launch Campaign
-                    </button>
-                    <button
-                      type="button"
-                      className="rounded-xl border border-slate-700/70 px-6 py-3 text-sm font-semibold uppercase tracking-[0.3em] text-slate-300 transition hover:border-teal-400/60 hover:text-teal-200"
-                      onClick={() => {
-                        setNewCampaignName('');
-                        setNewCampaignDescription('');
-                        setNewCampaignPublic(false);
-                        setCreateError(null);
-                      }}
-                    >
-                      Reset
-                    </button>
-                  </div>
-                </form>
-              </div>
-            )}
-            {activeView === 'admin' && selectedCampaign && (
-              <div className="space-y-6">
-                <div className="flex flex-wrap items-center justify-between gap-3">
-                  <div>
-                    <p className="text-xs uppercase tracking-[0.4em] text-teal-300">Managing Campaign</p>
-                    <h2 className="text-3xl font-black uppercase tracking-wide text-white">{selectedCampaign.name}</h2>
-                    {selectedCampaign.description && <p className="text-sm text-slate-300">{selectedCampaign.description}</p>}
-                  </div>
-                  <div className="flex flex-wrap items-center gap-3">
-                    <button
-                      type="button"
-                      className="rounded-full border border-slate-700/70 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-300 transition hover:border-teal-400/60 hover:text-teal-200"
-                      onClick={handleBackToManage}
-                    >
-                      Campaign List
-                    </button>
-                    <button
-                      type="button"
-                      className="rounded-full border border-rose-400/60 bg-rose-500/20 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-rose-200 transition hover:bg-rose-500/30"
-                      onClick={handleDeleteCampaign}
-                    >
-                      Delete Campaign
-                    </button>
-                    <button
-                      type="button"
-                      className="rounded-full border border-teal-400/60 bg-teal-500/80 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-teal-400/90"
-                      onClick={handleStartSession}
-                    >
-                      Launch Session
-                    </button>
+                    )}
                   </div>
                 </div>
+              )}
+              {activeView === 'create' && (
                 <div className="space-y-6">
-                  <MapFolderList
-                    maps={maps}
-                    selectedMapId={selectedMap?.id ?? null}
-                    onSelect={(map) => setSelectedMap(map)}
-                    onCreateMap={handleOpenMapWizard}
-                    onDeleteMap={handleDeleteMap}
-                    onDeleteGroup={handleDeleteGroup}
-                  />
-                  <div className="grid gap-6 xl:grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)]">
-                    <div className="space-y-6">
+                  <h2 className="text-3xl font-black uppercase tracking-wide text-slate-900 dark:text-amber-100">Create Campaign</h2>
+                  <p className="max-w-xl text-sm text-slate-600 dark:text-slate-300">Set up a new campaign for your players and start building encounters.</p>
+                  <form onSubmit={handleCreateCampaign} className="space-y-5">
+                    <div>
+                      <label className="text-xs uppercase tracking-[0.4em] text-slate-500 dark:text-slate-400">Campaign Name</label>
+                      <input
+                        value={newCampaignName}
+                        onChange={(event) => setNewCampaignName(event.target.value)}
+                        className="mt-2 w-full rounded-xl border border-slate-300/70 bg-white/80 px-4 py-3 text-sm text-slate-800 placeholder:text-slate-500 shadow-sm focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-300/40 dark:border-slate-700 dark:bg-slate-900/70 dark:text-slate-100 dark:placeholder:text-slate-500 dark:focus:border-amber-400 dark:focus:ring-amber-400/40"
+                        placeholder="Give your mission a title"
+                      />
+                    </div>
+                    <div>
+                      <label className="text-xs uppercase tracking-[0.4em] text-slate-500 dark:text-slate-400">Description</label>
+                      <textarea
+                        value={newCampaignDescription}
+                        onChange={(event) => setNewCampaignDescription(event.target.value)}
+                        rows={4}
+                        className="mt-2 w-full rounded-xl border border-slate-300/70 bg-white/80 px-4 py-3 text-sm text-slate-800 placeholder:text-slate-500 shadow-sm focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-300/40 dark:border-slate-700 dark:bg-slate-900/70 dark:text-slate-100 dark:placeholder:text-slate-500 dark:focus:border-amber-400 dark:focus:ring-amber-400/40"
+                        placeholder="Share a quick briefing for your players"
+                      />
+                    </div>
+                    <label className="flex items-center gap-3 text-xs uppercase tracking-[0.4em] text-slate-500 dark:text-slate-400">
+                      <input
+                        type="checkbox"
+                        checked={newCampaignPublic}
+                        onChange={(event) => setNewCampaignPublic(event.target.checked)}
+                        className="h-4 w-4 rounded border border-slate-300/70 bg-white text-amber-500 focus:ring-amber-400 dark:border-slate-700 dark:bg-slate-900 dark:text-amber-400 dark:focus:ring-amber-400"
+                      />
+                      <span className="text-slate-600 dark:text-slate-300">List publicly for players to discover</span>
+                    </label>
+                    {createError && <p className="text-xs font-semibold text-rose-500 dark:text-rose-300">{createError}</p>}
+                    <div className="flex flex-wrap gap-3">
+                      <button
+                        type="submit"
+                        className="rounded-xl border border-amber-400/70 bg-gradient-to-r from-amber-400/90 to-orange-400/80 px-6 py-3 text-sm font-semibold uppercase tracking-[0.3em] text-slate-900 shadow-md shadow-amber-500/20 transition hover:from-amber-400 hover:to-orange-400 dark:from-amber-400/60 dark:to-rose-400/50 dark:text-amber-50"
+                      >
+                        Launch Campaign
+                      </button>
+                      <button
+                        type="button"
+                        className="rounded-xl border border-slate-300/70 px-6 py-3 text-sm font-semibold uppercase tracking-[0.3em] text-slate-600 transition hover:border-amber-400/70 hover:text-amber-600 dark:border-slate-700 dark:text-slate-300 dark:hover:border-amber-400/60 dark:hover:text-amber-200"
+                        onClick={() => {
+                          setNewCampaignName('');
+                          setNewCampaignDescription('');
+                          setNewCampaignPublic(false);
+                          setCreateError(null);
+                        }}
+                      >
+                        Reset
+                      </button>
+                    </div>
+                  </form>
+                </div>
+              )}
+              {activeView === 'admin' && selectedCampaign && (
+                <div className="space-y-6">
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <div>
+                      <p className="text-xs uppercase tracking-[0.4em] text-amber-600 dark:text-amber-200">Managing Campaign</p>
+                      <h2 className="text-3xl font-black uppercase tracking-wide text-slate-900 dark:text-white">{selectedCampaign.name}</h2>
+                      {selectedCampaign.description && <p className="text-sm text-slate-600 dark:text-slate-300">{selectedCampaign.description}</p>}
+                    </div>
+                    <div className="flex flex-wrap items-center gap-3">
+                      <button
+                        type="button"
+                        className="rounded-full border border-slate-300/70 bg-white/60 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-600 transition hover:border-amber-400/70 hover:text-amber-600 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-200 dark:hover:border-amber-400/60 dark:hover:text-amber-200"
+                        onClick={handleBackToManage}
+                      >
+                        Campaign List
+                      </button>
+                      <button
+                        type="button"
+                        className="rounded-full border border-rose-300/70 bg-rose-100/60 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-rose-600 transition hover:border-rose-400/70 hover:bg-rose-100/80 dark:border-rose-500/40 dark:bg-rose-500/20 dark:text-rose-100"
+                        onClick={handleDeleteCampaign}
+                      >
+                        Delete Campaign
+                      </button>
+                      <button
+                        type="button"
+                        className="rounded-full border border-amber-400/70 bg-gradient-to-r from-amber-400/90 to-orange-400/80 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-900 shadow-md shadow-amber-500/20 transition hover:from-amber-400 hover:to-orange-400 dark:from-amber-400/60 dark:to-rose-400/50 dark:text-amber-50"
+                        onClick={handleStartSession}
+                      >
+                        Launch Session
+                      </button>
+                    </div>
+                  </div>
+                  <div className="space-y-6">
+                    <MapFolderList
+                      maps={maps}
+                      selectedMapId={selectedMap?.id ?? null}
+                      onSelect={(map) => setSelectedMap(map)}
+                      onCreateMap={handleOpenMapWizard}
+                      onDeleteMap={handleDeleteMap}
+                      onDeleteGroup={handleDeleteGroup}
+                    />
+                    <div className="grid gap-6 xl:grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)]">
+                      <div className="space-y-6">
                       {selectedMap ? (
-                        <div className="rounded-2xl border border-slate-800/70 bg-slate-900/70 p-6">
+                        <div className="rounded-2xl border border-white/70 bg-white/70 p-6 backdrop-blur-xl dark:border-slate-800/70 dark:bg-slate-900/70">
                           <div className="mb-6 flex flex-wrap items-start justify-between gap-4">
                             <div>
-                              <h3 className="text-2xl font-semibold text-white">{selectedMap.name}</h3>
-                              {mapDescription && <p className="mt-2 text-sm text-slate-300">{mapDescription}</p>}
-                              {!mapDescription && mapNotes && <p className="mt-2 text-sm text-slate-400">{mapNotes}</p>}
+                              <h3 className="text-2xl font-semibold text-slate-900 dark:text-white">{selectedMap.name}</h3>
+                              {mapDescription && <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">{mapDescription}</p>}
+                              {!mapDescription && mapNotes && <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">{mapNotes}</p>}
                             </div>
-                            <div className="flex flex-wrap items-center gap-4 text-xs uppercase tracking-[0.4em] text-slate-500">
+                            <div className="flex flex-wrap items-center gap-4 text-xs uppercase tracking-[0.4em] text-slate-500 dark:text-slate-400">
                               <span>Regions: {regions.length}</span>
                               <span>Markers: {markers.length}</span>
                               <span>
@@ -874,7 +893,7 @@ const App: React.FC = () => {
                               </span>
                             </div>
                           </div>
-                          <div className="overflow-hidden rounded-2xl border border-slate-800/70 bg-slate-950/70">
+                          <div className="overflow-hidden rounded-2xl border border-white/60 bg-white/60 backdrop-blur-xl dark:border-slate-800/70 dark:bg-slate-950/70">
                             <MapMaskCanvas
                               imageUrl={selectedMap ? apiClient.buildMapDisplayUrl(selectedMap.id) : undefined}
                               width={selectedMap.width}
@@ -886,109 +905,113 @@ const App: React.FC = () => {
                             />
                           </div>
                           <div className="mt-6 grid gap-4 lg:grid-cols-2">
-                            <div className="rounded-2xl border border-slate-800/70 bg-slate-950/70 p-4">
-                              <p className="text-[10px] uppercase tracking-[0.4em] text-slate-500">Grouping</p>
-                              <p className="mt-2 text-sm font-semibold text-teal-200">{mapGrouping}</p>
+                            <div className="rounded-2xl border border-white/60 bg-white/60 p-4 backdrop-blur-xl dark:border-slate-800/70 dark:bg-slate-950/70">
+                              <p className="text-[10px] uppercase tracking-[0.4em] text-slate-500 dark:text-slate-400">Grouping</p>
+                              <p className="mt-2 text-sm font-semibold text-amber-600 dark:text-amber-200">{mapGrouping}</p>
                               {mapNotes && mapDescription && (
-                                <p className="mt-3 text-xs text-slate-400">Notes: {mapNotes}</p>
+                                <p className="mt-3 text-xs text-slate-500 dark:text-slate-400">Notes: {mapNotes}</p>
                               )}
                             </div>
-                            <div className="rounded-2xl border border-slate-800/70 bg-slate-950/70 p-4">
-                              <p className="text-[10px] uppercase tracking-[0.4em] text-slate-500">Tags</p>
+                            <div className="rounded-2xl border border-white/60 bg-white/60 p-4 backdrop-blur-xl dark:border-slate-800/70 dark:bg-slate-950/70">
+                              <p className="text-[10px] uppercase tracking-[0.4em] text-slate-500 dark:text-slate-400">Tags</p>
                               {mapTags.length > 0 ? (
                                 <div className="mt-3 flex flex-wrap gap-2">
                                   {mapTags.map((tag) => (
                                     <span
                                       key={tag}
-                                      className="inline-flex items-center rounded-full border border-slate-700/70 bg-slate-900/70 px-2 py-1 text-[10px] uppercase tracking-[0.3em] text-slate-300"
+                                      className="inline-flex items-center rounded-full border border-white/60 bg-white/60 px-2 py-1 text-[10px] uppercase tracking-[0.3em] text-slate-700 dark:border-slate-700/70 dark:bg-slate-900/60 dark:text-slate-300"
                                     >
                                       {tag}
                                     </span>
                                   ))}
                                 </div>
                               ) : (
-                                <p className="mt-3 text-xs text-slate-500">No tags assigned yet.</p>
+                                <p className="mt-3 text-xs text-slate-500 dark:text-slate-400">No tags assigned yet.</p>
                               )}
                             </div>
                           </div>
                           {!mapDescription && !mapNotes && (
-                            <p className="mt-4 text-xs text-slate-500">
+                            <p className="mt-4 text-xs text-slate-500 dark:text-slate-400">
                               Add details and notes through the map wizard to give your players extra context.
                             </p>
                           )}
                         </div>
                       ) : (
-                        <div className="rounded-2xl border border-dashed border-slate-700/70 p-12 text-center text-sm text-slate-400">
+                        <div className="rounded-2xl border border-dashed border-slate-300/70 p-12 text-center text-sm text-slate-500 dark:border-slate-700/70 dark:text-slate-400">
                           Select or create a map to begin shaping your encounter.
                         </div>
                       )}
-                    </div>
-                    <div className="space-y-6">
-                      <div className="rounded-2xl border border-slate-800/70 bg-slate-900/70 p-5">
-                        <div className="mb-3 flex items-center justify-between">
-                          <h3 className="text-xs uppercase tracking-[0.4em] text-slate-400">My Sessions</h3>
-                        </div>
-                        <ul className="space-y-2 text-sm">
-                          {mySessions.map((session) => (
-                            <li key={session.id}>
-                              <button
-                                onClick={() => handleJoinSession(session)}
-                                className="w-full rounded-xl border border-slate-800/70 bg-slate-950/60 px-3 py-2 text-left text-slate-300 transition hover:border-teal-400/60 hover:text-teal-100"
-                              >
-                                {session.name}
-                              </button>
-                            </li>
-                          ))}
-                          {mySessions.length === 0 && (
-                            <li className="rounded-xl border border-dashed border-slate-700/70 px-3 py-6 text-center text-xs text-slate-500">
-                              No active sessions.
-                            </li>
-                          )}
-                        </ul>
                       </div>
-                      <div className="rounded-2xl border border-slate-800/70 bg-slate-900/70 p-5">
-                        <div className="mb-3 flex items-center justify-between">
-                          <h3 className="text-xs uppercase tracking-[0.4em] text-slate-400">Lobby</h3>
-                          <button
-                            type="button"
-                            className="text-xs font-semibold uppercase tracking-[0.3em] text-teal-200 transition hover:text-teal-100"
-                            onClick={refreshLobby}
-                          >
-                            Refresh
-                          </button>
+                      <div className="space-y-6">
+                        <div className="rounded-2xl border border-white/60 bg-white/70 p-5 backdrop-blur-xl dark:border-slate-800/70 dark:bg-slate-900/70">
+                          <div className="mb-3 flex items-center justify-between">
+                            <h3 className="text-xs uppercase tracking-[0.4em] text-slate-500 dark:text-slate-400">My Sessions</h3>
+                          </div>
+                          <ul className="space-y-2 text-sm">
+                            {mySessions.map((session) => (
+                              <li key={session.id}>
+                                <button
+                                  onClick={() => handleJoinSession(session)}
+                                  className="w-full rounded-xl border border-white/60 bg-white/60 px-3 py-2 text-left text-slate-700 transition hover:border-amber-400/60 hover:bg-white/80 dark:border-slate-800/70 dark:bg-slate-950/60 dark:text-slate-300 dark:hover:border-amber-400/50"
+                                >
+                                  {session.name}
+                                </button>
+                              </li>
+                            ))}
+                            {mySessions.length === 0 && (
+                              <li className="rounded-xl border border-dashed border-slate-300/70 px-3 py-6 text-center text-xs text-slate-500 dark:border-slate-700/70 dark:text-slate-400">
+                                No active sessions.
+                              </li>
+                            )}
+                          </ul>
                         </div>
-                        <ul className="space-y-2 text-sm">
-                          {lobbySessions.map((session) => (
-                            <li key={session.id} className="rounded-xl border border-slate-800/70 bg-slate-950/60 p-3">
-                              <p className="font-semibold text-slate-100">{session.name}</p>
-                              <p className="text-[10px] uppercase tracking-[0.4em] text-slate-500">Campaign: {session.campaignName ?? 'Unknown'}</p>
-                              <p className="text-[10px] uppercase tracking-[0.4em] text-slate-500">Map: {session.mapName ?? 'Unknown'}</p>
-                              <button
-                                type="button"
-                                className="mt-3 w-full rounded-xl border border-teal-400/60 bg-teal-500/80 px-3 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-teal-400/90"
-                                onClick={() => handleJoinSession(session)}
+                        <div className="rounded-2xl border border-white/60 bg-white/70 p-5 backdrop-blur-xl dark:border-slate-800/70 dark:bg-slate-900/70">
+                          <div className="mb-3 flex items-center justify-between">
+                            <h3 className="text-xs uppercase tracking-[0.4em] text-slate-500 dark:text-slate-400">Lobby</h3>
+                            <button
+                              type="button"
+                              className="text-xs font-semibold uppercase tracking-[0.3em] text-amber-600 transition hover:text-amber-700 dark:text-amber-200 dark:hover:text-amber-100"
+                              onClick={refreshLobby}
+                            >
+                              Refresh
+                            </button>
+                          </div>
+                          <ul className="space-y-2 text-sm">
+                            {lobbySessions.map((session) => (
+                              <li
+                                key={session.id}
+                                className="rounded-xl border border-white/60 bg-white/60 p-3 backdrop-blur-xl transition hover:border-amber-400/60 hover:bg-white/80 dark:border-slate-800/70 dark:bg-slate-950/60 dark:hover:border-amber-400/50"
                               >
-                                Join as {session.hostId === user.id ? 'DM' : 'Player'}
-                              </button>
-                            </li>
-                          ))}
-                          {lobbySessions.length === 0 && (
-                            <li className="rounded-xl border border-dashed border-slate-700/70 px-3 py-6 text-center text-xs text-slate-500">
-                              No active sessions available.
-                            </li>
-                          )}
-                        </ul>
+                                <p className="font-semibold text-slate-800 dark:text-slate-100">{session.name}</p>
+                                <p className="text-[10px] uppercase tracking-[0.4em] text-slate-500 dark:text-slate-400">Campaign: {session.campaignName ?? 'Unknown'}</p>
+                                <p className="text-[10px] uppercase tracking-[0.4em] text-slate-500 dark:text-slate-400">Map: {session.mapName ?? 'Unknown'}</p>
+                                <button
+                                  type="button"
+                                  className="mt-3 w-full rounded-xl border border-amber-400/70 bg-gradient-to-r from-amber-400/90 to-orange-400/80 px-3 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:from-amber-400 hover:to-orange-400 dark:from-amber-400/60 dark:to-rose-400/50 dark:text-amber-50"
+                                  onClick={() => handleJoinSession(session)}
+                                >
+                                  Join as {session.hostId === user.id ? 'DM' : 'Player'}
+                                </button>
+                              </li>
+                            ))}
+                            {lobbySessions.length === 0 && (
+                              <li className="rounded-xl border border-dashed border-slate-300/70 px-3 py-6 text-center text-xs text-slate-500 dark:border-slate-700/70 dark:text-slate-400">
+                                No active sessions available.
+                              </li>
+                            )}
+                          </ul>
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
-              </div>
-            )}
-            {activeView === 'admin' && !selectedCampaign && (
-              <div className="rounded-2xl border border-dashed border-slate-700/70 p-12 text-center text-sm text-slate-400">
-                Choose a campaign from the manage tab to configure it here.
-              </div>
-            )}
+              )}
+              {activeView === 'admin' && !selectedCampaign && (
+                <div className="rounded-2xl border border-dashed border-slate-300/70 p-12 text-center text-sm text-slate-500 dark:border-slate-700/70 dark:text-slate-400">
+                  Choose a campaign from the manage tab to configure it here.
+                </div>
+              )}
+            </div>
           </div>
         </section>
         {showMapWizard && selectedCampaign && (


### PR DESCRIPTION
## Summary
- restyle the authenticated App shell to reuse the landing page’s ambient background, glassmorphism, and amber accent palette
- update session view header, navigation buttons, forms, and status panels to match the refreshed light/dark treatment
- centralize reusable theme toggle and logout button styling helpers for consistent accenting across views

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db452f052c8323938feafa2b9590b6