### PR TITLE
Fix aside layout to prevent stretching with main content

### DIFF
--- a/apps/pages/src/App.tsx
+++ b/apps/pages/src/App.tsx
@@ -610,7 +610,7 @@ const App: React.FC = () => {
       <div aria-hidden className="pointer-events-none absolute bottom-[-10rem] left-[-6rem] h-96 w-96 rounded-full bg-orange-300/20 blur-[120px] dark:bg-orange-500/20 animate-float-slow" />
       <div className="relative isolate min-h-screen px-4 py-8 sm:px-6 lg:px-8">
         <div className="mx-auto flex min-h-full max-w-6xl flex-col gap-6 md:flex-row md:gap-8">
-          <aside className="flex flex-col gap-6 rounded-3xl border border-white/60 bg-white/70 p-6 shadow-2xl shadow-amber-500/20 backdrop-blur-xl md:w-72 dark:border-slate-800/70 dark:bg-slate-950/70 dark:shadow-black/40">
+          <aside className="flex flex-col gap-6 rounded-3xl border border-white/60 bg-white/70 p-6 shadow-2xl shadow-amber-500/20 backdrop-blur-xl md:w-72 md:self-start dark:border-slate-800/70 dark:bg-slate-950/70 dark:shadow-black/40">
             <div>
               <p className="text-xs uppercase tracking-[0.4em] text-slate-600 dark:text-slate-400">Mission Control</p>
               <h2 className="mt-3 text-2xl font-black uppercase tracking-wide text-slate-900 dark:text-white">Command Deck</h2>


### PR DESCRIPTION
## Summary
- stop the mission control aside from stretching with the main content area by aligning it to flex-start on wider layouts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db4e1b1c248323a240cb394c11c703