### PR TITLE
Align component theming with landing experience

### DIFF
--- a/apps/pages/src/components/MapCreationWizard.tsx
+++ b/apps/pages/src/components/MapCreationWizard.tsx
@@ -690,61 +690,65 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex flex-col bg-slate-950/95 backdrop-blur-sm">
-      <header className="mb-0.5 border-b border-slate-800/70 px-5 py-3">
-        <div className="flex flex-wrap items-center justify-between gap-4">
-          <div>
-            <p className="text-xs uppercase tracking-[0.4em] text-teal-300">New Map Wizard</p>
-            <h2 className="text-2xl font-bold text-white">{steps[step].title}</h2>
-            <p className="text-sm text-slate-400">{steps[step].description}</p>
+    <div className="fixed inset-0 z-50 flex flex-col overflow-hidden bg-white/85 text-slate-900 backdrop-blur-xl transition-colors dark:bg-slate-950/90 dark:text-slate-100">
+      <div aria-hidden className="pointer-events-none absolute inset-0 bg-grid-mask opacity-30 mix-blend-soft-light dark:opacity-15" />
+      <div aria-hidden className="pointer-events-none absolute -top-24 right-10 h-80 w-80 rounded-full bg-amber-300/25 blur-3xl dark:bg-amber-500/20" />
+      <div aria-hidden className="pointer-events-none absolute bottom-[-12rem] left-[-10rem] h-96 w-96 rounded-full bg-orange-300/20 blur-[140px] dark:bg-orange-500/20" />
+      <div className="relative flex flex-1 flex-col">
+        <header className="mb-0.5 border-b border-white/60 bg-white/70 px-5 py-3 shadow-sm shadow-amber-500/10 dark:border-slate-800/60 dark:bg-slate-950/70">
+          <div className="flex flex-wrap items-center justify-between gap-4">
+            <div>
+              <p className="text-xs uppercase tracking-[0.4em] text-amber-600 dark:text-amber-300">New Map Wizard</p>
+              <h2 className="text-2xl font-bold text-slate-900 dark:text-white">{steps[step].title}</h2>
+              <p className="text-sm text-slate-600 dark:text-slate-400">{steps[step].description}</p>
+            </div>
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-full border border-slate-300/70 bg-white/70 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-700 transition hover:border-amber-400/70 hover:text-amber-600 dark:border-slate-700/70 dark:bg-slate-900/70 dark:text-slate-300 dark:hover:border-rose-400/60 dark:hover:text-rose-200"
+            >
+              Exit Wizard
+            </button>
           </div>
-          <button
-            type="button"
-            onClick={onClose}
-            className="rounded-full border border-slate-700/70 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-300 transition hover:border-rose-400/60 hover:text-rose-200"
-          >
-            Exit Wizard
-          </button>
-        </div>
-        <div className="mt-4 flex flex-wrap gap-2">
-          {steps.map((item, index) => {
-            const isActive = index === step;
-            const isComplete = index < step;
-            return (
-              <div
-                key={item.title}
+          <div className="mt-4 flex flex-wrap gap-2">
+            {steps.map((item, index) => {
+              const isActive = index === step;
+              const isComplete = index < step;
+              return (
+                <div
+                  key={item.title}
                 className={`flex items-center gap-3 rounded-full border px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] transition ${
                   isActive
-                    ? 'border-teal-400/70 bg-teal-500/20 text-teal-100'
+                    ? 'border-amber-400/80 bg-amber-200/60 text-slate-900 shadow shadow-amber-500/20 dark:border-amber-400/60 dark:bg-amber-400/20 dark:text-amber-100'
                     : isComplete
-                    ? 'border-slate-700/70 bg-slate-800/80 text-slate-200'
-                    : 'border-slate-800/70 bg-slate-900/80 text-slate-500'
+                    ? 'border-white/60 bg-white/60 text-slate-700 dark:border-slate-700/70 dark:bg-slate-900/70 dark:text-slate-200'
+                    : 'border-white/40 bg-white/40 text-slate-400 dark:border-slate-800/70 dark:bg-slate-950/60 dark:text-slate-500'
                 }`}
-              >
-                <span className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-current">
-                  {index + 1}
-                </span>
-                {item.title}
-              </div>
-            );
-          })}
-        </div>
-      </header>
-      <main className="flex-1 overflow-x-visible overflow-y-auto py-4">
-        <div className="flex h-full">
-          <div
-            ref={brushSliderHostRef}
-            className="relative flex h-full w-0 flex-shrink-0 overflow-visible"
-          />
-          <div className="flex h-full flex-1 flex-col overflow-x-visible overflow-y-hidden px-[10vw]">
+                >
+                  <span className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-current">
+                    {index + 1}
+                  </span>
+                  {item.title}
+                </div>
+              );
+            })}
+          </div>
+        </header>
+        <main className="flex-1 overflow-x-visible overflow-y-auto py-4">
+          <div className="flex h-full">
+            <div
+              ref={brushSliderHostRef}
+              className="relative flex h-full w-0 flex-shrink-0 overflow-visible"
+            />
+            <div className="flex h-full flex-1 flex-col overflow-x-visible overflow-y-hidden px-[8vw] pb-8">
           {step === 0 && (
             <div className="flex flex-1 items-center justify-center">
-              <div className="w-full max-w-4xl rounded-3xl border border-slate-800/70 bg-slate-900/70 p-8 text-center">
+              <div className="w-full max-w-4xl rounded-3xl border border-white/60 bg-white/75 p-8 text-center shadow-2xl shadow-amber-500/20 dark:border-slate-800/70 dark:bg-slate-950/70 dark:shadow-black/40">
                 <div
                   onDragEnter={(event) => event.preventDefault()}
                   onDragOver={(event) => event.preventDefault()}
                   onDrop={handleDrop}
-                  className="group relative flex min-h-[200px] flex-col items-center justify-center rounded-2xl border-2 border-dashed border-slate-700/70 bg-slate-950/70 px-6 py-8 transition hover:border-teal-400/60"
+                  className="group relative flex min-h-[200px] flex-col items-center justify-center rounded-2xl border-2 border-dashed border-slate-300/70 bg-white/80 px-6 py-8 transition hover:border-amber-400/70 dark:border-slate-700/70 dark:bg-slate-950/70 dark:hover:border-amber-400/60"
                 >
                   <input
                     ref={fileInputRef}
@@ -758,23 +762,23 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                       }
                     }}
                   />
-                  <p className="text-sm uppercase tracking-[0.4em] text-slate-500">Drag &amp; Drop</p>
-                  <h3 className="mt-3 text-2xl font-semibold text-white">Drop your map image here</h3>
-                  <p className="mt-2 max-w-xl text-sm text-slate-400">
+                  <p className="text-sm uppercase tracking-[0.4em] text-slate-600 dark:text-slate-400">Drag &amp; Drop</p>
+                  <h3 className="mt-3 text-2xl font-semibold text-slate-900 dark:text-white">Drop your map image here</h3>
+                  <p className="mt-2 max-w-xl text-sm text-slate-600 dark:text-slate-400">
                     We accept PNG, JPG, WEBP, and other common image formats. Drop the file or browse your computer to get started.
                   </p>
                   <button
                     type="button"
                     onClick={handleBrowse}
-                    className="mt-5 rounded-full border border-teal-400/60 bg-teal-500/80 px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-teal-400/90"
+                    className="mt-5 rounded-full border border-amber-400/70 bg-amber-300/80 px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-amber-300/90 dark:border-amber-400/50 dark:bg-amber-400/20 dark:text-amber-100 dark:hover:bg-amber-400/30"
                   >
                     Browse Files
                   </button>
                 </div>
                 {previewUrl && (
                   <div className="mt-6">
-                    <p className="text-xs uppercase tracking-[0.4em] text-teal-300">Preview</p>
-                    <div className="mt-3 overflow-hidden rounded-2xl border border-slate-800/70">
+                    <p className="text-xs uppercase tracking-[0.4em] text-amber-600 dark:text-amber-300">Preview</p>
+                    <div className="mt-3 overflow-hidden rounded-2xl border border-white/60 dark:border-slate-800/70">
                       <img
                         src={previewUrl}
                         alt="Uploaded map preview"
@@ -782,7 +786,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                       />
                     </div>
                     {imageDimensions && (
-                      <p className="mt-2 text-xs uppercase tracking-[0.4em] text-slate-500">
+                      <p className="mt-2 text-xs uppercase tracking-[0.4em] text-slate-600 dark:text-slate-400">
                         {imageDimensions.width} × {imageDimensions.height} pixels
                       </p>
                     )}
@@ -793,63 +797,63 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
           )}
           {step === 1 && (
             <div className="flex flex-1 items-stretch justify-center">
-              <div className="flex h-full w-full flex-col rounded-3xl border border-slate-800/70 bg-slate-900/70 p-8">
+              <div className="flex h-full w-full flex-col rounded-3xl border border-white/60 bg-white/75 p-8 shadow-2xl shadow-amber-500/20 dark:border-slate-800/70 dark:bg-slate-950/70 dark:shadow-black/40">
                 <div className="grid flex-1 min-h-0 gap-6 md:grid-cols-[minmax(0,1fr)_260px]">
                   <div className="flex flex-col gap-5">
                     <div>
-                      <label className="block text-xs uppercase tracking-[0.4em] text-slate-400">Map Name</label>
+                      <label className="block text-xs uppercase tracking-[0.4em] text-slate-600 dark:text-slate-400">Map Name</label>
                       <input
                         type="text"
                         value={name}
                         onChange={(event) => setName(event.target.value)}
-                        className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                        className="mt-2 w-full rounded-xl border border-white/70 bg-white/80 px-4 py-3 text-sm text-slate-900 placeholder:text-slate-500 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/40 dark:border-slate-800/70 dark:bg-slate-950/70 dark:text-slate-100 dark:placeholder:text-slate-500 dark:focus:border-amber-400 dark:focus:ring-amber-400/30"
                         placeholder="Ancient Ruins"
                       />
                     </div>
                     <div>
-                      <label className="block text-xs uppercase tracking-[0.4em] text-slate-400">Description</label>
+                      <label className="block text-xs uppercase tracking-[0.4em] text-slate-600 dark:text-slate-400">Description</label>
                       <textarea
                         value={description}
                         onChange={(event) => setDescription(event.target.value)}
                         rows={3}
-                        className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                        className="mt-2 w-full rounded-xl border border-white/70 bg-white/80 px-4 py-3 text-sm text-slate-900 placeholder:text-slate-500 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/40 dark:border-slate-800/70 dark:bg-slate-950/70 dark:text-slate-100 dark:placeholder:text-slate-500 dark:focus:border-amber-400 dark:focus:ring-amber-400/30"
                         placeholder="Give a brief overview of the map."
                       />
                     </div>
                     <div>
-                      <label className="block text-xs uppercase tracking-[0.4em] text-slate-400">Grouping</label>
+                      <label className="block text-xs uppercase tracking-[0.4em] text-slate-600 dark:text-slate-400">Grouping</label>
                       <input
                         type="text"
                         value={grouping}
                         onChange={(event) => setGrouping(event.target.value)}
-                        className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                        className="mt-2 w-full rounded-xl border border-white/70 bg-white/80 px-4 py-3 text-sm text-slate-900 placeholder:text-slate-500 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/40 dark:border-slate-800/70 dark:bg-slate-950/70 dark:text-slate-100 dark:placeholder:text-slate-500 dark:focus:border-amber-400 dark:focus:ring-amber-400/30"
                         placeholder="Dungeon Delves"
                       />
                     </div>
                     <div>
-                      <label className="block text-xs uppercase tracking-[0.4em] text-slate-400">Notes</label>
+                      <label className="block text-xs uppercase tracking-[0.4em] text-slate-600 dark:text-slate-400">Notes</label>
                       <textarea
                         value={notes}
                         onChange={(event) => setNotes(event.target.value)}
                         rows={3}
-                        className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                        className="mt-2 w-full rounded-xl border border-white/70 bg-white/80 px-4 py-3 text-sm text-slate-900 placeholder:text-slate-500 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/40 dark:border-slate-800/70 dark:bg-slate-950/70 dark:text-slate-100 dark:placeholder:text-slate-500 dark:focus:border-amber-400 dark:focus:ring-amber-400/30"
                         placeholder="DM-only reminders or encounter tips"
                       />
                     </div>
                     <div>
-                      <label className="block text-xs uppercase tracking-[0.4em] text-slate-400">Tags</label>
+                      <label className="block text-xs uppercase tracking-[0.4em] text-slate-600 dark:text-slate-400">Tags</label>
                       <input
                         type="text"
                         value={tagsInput}
                         onChange={(event) => setTagsInput(event.target.value)}
-                        className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                        className="mt-2 w-full rounded-xl border border-white/70 bg-white/80 px-4 py-3 text-sm text-slate-900 placeholder:text-slate-500 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/40 dark:border-slate-800/70 dark:bg-slate-950/70 dark:text-slate-100 dark:placeholder:text-slate-500 dark:focus:border-amber-400 dark:focus:ring-amber-400/30"
                         placeholder="forest, ruins, night"
                       />
-                      <p className="mt-2 text-xs text-slate-500">Separate tags with commas to help search and filtering.</p>
+                      <p className="mt-2 text-xs text-slate-600 dark:text-slate-400">Separate tags with commas to help search and filtering.</p>
                     </div>
                   </div>
                   <div className="flex h-full flex-col gap-4">
-                    <div className="flex flex-1 items-center justify-center overflow-hidden rounded-2xl border border-slate-800/70 bg-slate-950/70">
+                    <div className="flex flex-1 items-center justify-center overflow-hidden rounded-2xl border border-white/60 bg-white/80 dark:border-slate-800/70 dark:bg-slate-950/70">
                       {previewUrl ? (
                         <img
                           src={previewUrl}
@@ -857,14 +861,14 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                           className="max-h-full w-full object-contain"
                         />
                       ) : (
-                        <p className="text-xs uppercase tracking-[0.4em] text-slate-500">
+                        <p className="text-xs uppercase tracking-[0.4em] text-slate-600 dark:text-slate-400">
                           Upload a map image to preview it here.
                         </p>
                       )}
                     </div>
-                    <div className="rounded-2xl border border-slate-800/70 bg-slate-950/70 p-4">
-                      <p className="text-xs uppercase tracking-[0.4em] text-slate-400">Tips</p>
-                      <ul className="mt-2 space-y-2 text-xs text-slate-400">
+                    <div className="rounded-2xl border border-white/60 bg-white/70 p-4 shadow shadow-amber-500/10 dark:border-slate-800/70 dark:bg-slate-950/70">
+                      <p className="text-xs uppercase tracking-[0.4em] text-slate-600 dark:text-slate-400">Tips</p>
+                      <ul className="mt-2 space-y-2 text-xs text-slate-600 dark:text-slate-400">
                         <li>Keep names short but descriptive for quick reference during sessions.</li>
                         <li>Use notes to capture secrets, traps, or DM-only reminders.</li>
                         <li>Tags help you filter maps later in the campaign dashboard.</li>
@@ -877,11 +881,11 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
           )}
           {step === 2 && (
             <div className="flex h-full min-h-0 flex-1 justify-center">
-              <div className="flex h-full min-h-0 w-full rounded-3xl border border-slate-800/70 bg-slate-900/70 p-4">
+              <div className="flex h-full min-h-0 w-full rounded-3xl border border-white/60 bg-white/75 p-4 shadow-2xl shadow-amber-500/20 dark:border-slate-800/70 dark:bg-slate-950/70 dark:shadow-black/40">
                 <div
                   ref={defineRoomContainerRef}
-                  className={`flex h-full min-h-0 w-full flex-col overflow-visible rounded-2xl border border-slate-800/70 bg-slate-950/80 ${
-                    canLaunchRoomsEditor ? '' : 'items-center justify-center text-sm text-slate-500'
+                  className={`flex h-full min-h-0 w-full flex-col overflow-visible rounded-2xl border border-white/60 bg-white/80 dark:border-slate-800/70 dark:bg-slate-950/80 ${
+                    canLaunchRoomsEditor ? '' : 'items-center justify-center text-sm text-slate-600 dark:text-slate-400'
                   }`}
                 >
                   {!canLaunchRoomsEditor && (
@@ -891,11 +895,11 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
               </div>
             </div>
           )}
-{step === 3 && (
+          {step === 3 && (
             <div className="grid h-full min-h-0 gap-6 lg:grid-cols-[minmax(0,1fr)_340px]">
               <div
                 ref={mapAreaRef}
-                className="relative flex h-full min-h-0 max-h-full items-center justify-center overflow-hidden rounded-3xl border border-slate-800/70 bg-slate-900/70"
+                className="relative flex h-full min-h-0 max-h-full items-center justify-center overflow-hidden rounded-3xl border border-white/60 bg-white/80 shadow-2xl shadow-amber-500/20 dark:border-slate-800/70 dark:bg-slate-950/70 dark:shadow-black/40"
               >
                 {previewUrl ? (
                   <>
@@ -918,39 +922,39 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                             markerDisplayMetrics,
                           ),
                         )}
-                        className="group absolute -translate-x-1/2 -translate-y-1/2 rounded-full border border-white/40 bg-slate-950/80 px-3 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-white shadow-lg transition hover:border-teal-300/80 hover:text-teal-100"
+                        className="group absolute -translate-x-1/2 -translate-y-1/2 rounded-full border border-amber-400/70 bg-amber-300/80 px-3 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-900 shadow-lg shadow-amber-500/30 transition hover:bg-amber-300/90 dark:border-amber-400/50 dark:bg-amber-400/20 dark:text-amber-100 dark:hover:bg-amber-400/30"
                       >
                         {marker.label || 'Marker'}
                       </button>
                     ))}
                     {markers.length === 0 && (
-                      <div className="absolute inset-0 flex items-center justify-center text-sm text-slate-400">
+                      <div className="absolute inset-0 flex items-center justify-center text-sm text-slate-600 dark:text-slate-400">
                         Add markers from the panel to start placing points of interest.
                       </div>
                     )}
                   </>
                 ) : (
-                  <div className="flex h-full w-full items-center justify-center text-sm text-slate-400">
+                  <div className="flex h-full w-full items-center justify-center text-sm text-slate-600 dark:text-slate-400">
                     Upload a map image to place markers.
                   </div>
                 )}
               </div>
-              <div className="flex h-full min-h-0 flex-col rounded-3xl border border-slate-800/70 bg-slate-900/70">
-                <div className="border-b border-slate-800/70 p-4">
+              <div className="flex h-full min-h-0 flex-col rounded-3xl border border-white/60 bg-white/75 shadow-2xl shadow-amber-500/20 dark:border-slate-800/70 dark:bg-slate-950/70 dark:shadow-black/40">
+                <div className="border-b border-white/60 p-4 dark:border-slate-800/70">
                   <div className="flex items-center justify-between gap-3">
                     <div>
-                      <p className="text-xs uppercase tracking-[0.4em] text-slate-400">Markers</p>
-                      <h3 className="text-lg font-semibold text-white">Drag &amp; Drop Points</h3>
+                      <p className="text-xs uppercase tracking-[0.4em] text-slate-600 dark:text-slate-400">Markers</p>
+                      <h3 className="text-lg font-semibold text-slate-900 dark:text-white">Drag &amp; Drop Points</h3>
                     </div>
                     <button
                       type="button"
                       onClick={handleAddMarker}
-                      className="rounded-full border border-teal-400/60 bg-teal-500/80 px-4 py-2 text-[10px] font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-teal-400/90"
+                      className="rounded-full border border-amber-400/70 bg-amber-300/80 px-4 py-2 text-[10px] font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-amber-300/90 dark:border-amber-400/50 dark:bg-amber-400/20 dark:text-amber-100 dark:hover:bg-amber-400/30"
                     >
                       Add Marker
                     </button>
                   </div>
-                  <p className="mt-2 text-xs text-slate-500">
+                  <p className="mt-2 text-xs text-slate-600 dark:text-slate-400">
                     Create markers and drag them directly onto the map. Use notes to capture quick reminders.
                   </p>
                 </div>
@@ -962,8 +966,8 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                         key={marker.id}
                         className={`rounded-2xl border px-4 py-3 transition ${
                           isExpanded
-                            ? 'border-teal-400/60 bg-slate-950/80'
-                            : 'border-slate-800/70 bg-slate-950/70'
+                            ? 'border-amber-400/70 bg-amber-200/30 shadow shadow-amber-500/20 dark:border-amber-400/50 dark:bg-amber-400/15'
+                            : 'border-white/60 bg-white/70 dark:border-slate-800/70 dark:bg-slate-950/70'
                         }`}
                       >
                         <button
@@ -975,14 +979,14 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                           aria-expanded={isExpanded}
                         >
                           <div>
-                            <p className="text-sm font-semibold text-white">{marker.label || 'Marker'}</p>
-                            <div className="mt-1 flex flex-wrap items-center gap-3 text-[10px] uppercase tracking-[0.35em] text-slate-500">
+                            <p className="text-sm font-semibold text-slate-900 dark:text-white">{marker.label || 'Marker'}</p>
+                            <div className="mt-1 flex flex-wrap items-center gap-3 text-[10px] uppercase tracking-[0.35em] text-slate-500 dark:text-slate-400">
                               <span>
                                 Position: {Math.round(marker.x * 100)}% × {Math.round(marker.y * 100)}%
                               </span>
                               <span className="flex items-center gap-2">
                                 <span
-                                  className="h-3 w-3 rounded-full border border-slate-700/70"
+                                  className="h-3 w-3 rounded-full border border-white/70 dark:border-slate-700/70"
                                   style={{ backgroundColor: marker.color || '#facc15' }}
                                 />
                                 <span>{marker.color}</span>
@@ -991,7 +995,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                           </div>
                           <span
                             className={`text-[10px] uppercase tracking-[0.35em] ${
-                              isExpanded ? 'text-teal-200' : 'text-slate-400'
+                              isExpanded ? 'text-amber-600 dark:text-amber-200' : 'text-slate-400 dark:text-slate-500'
                             }`}
                           >
                             {isExpanded ? 'Hide' : 'Edit'}
@@ -999,7 +1003,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                         </button>
                         {isExpanded && (
                           <div className="mt-3 space-y-3">
-                            <label className="block text-[10px] uppercase tracking-[0.4em] text-slate-500">
+                            <label className="block text-[10px] uppercase tracking-[0.4em] text-slate-500 dark:text-slate-400">
                               Label
                               <input
                                 type="text"
@@ -1007,12 +1011,12 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                                 onChange={(event) =>
                                   handleMarkerChange(marker.id, 'label', event.target.value)
                                 }
-                                className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-3 py-2 text-xs text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                                className="mt-2 w-full rounded-xl border border-white/70 bg-white/80 px-3 py-2 text-xs text-slate-900 placeholder:text-slate-500 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/40 dark:border-slate-800/70 dark:bg-slate-950/70 dark:text-slate-100 dark:placeholder:text-slate-500 dark:focus:border-amber-400 dark:focus:ring-amber-400/30"
                                 placeholder="Secret Door"
                               />
                             </label>
                             <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_140px]">
-                              <label className="block text-[10px] uppercase tracking-[0.4em] text-slate-500">
+                              <label className="block text-[10px] uppercase tracking-[0.4em] text-slate-500 dark:text-slate-400">
                                 Notes
                                 <textarea
                                   value={marker.notes}
@@ -1020,11 +1024,11 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                                     handleMarkerChange(marker.id, 'notes', event.target.value)
                                   }
                                   rows={2}
-                                  className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-3 py-2 text-xs text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                                  className="mt-2 w-full rounded-xl border border-white/70 bg-white/80 px-3 py-2 text-xs text-slate-900 placeholder:text-slate-500 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/40 dark:border-slate-800/70 dark:bg-slate-950/70 dark:text-slate-100 dark:placeholder:text-slate-500 dark:focus:border-amber-400 dark:focus:ring-amber-400/30"
                                   placeholder="Trap trigger, treasure cache, etc."
                                 />
                               </label>
-                              <label className="block text-[10px] uppercase tracking-[0.4em] text-slate-500">
+                              <label className="block text-[10px] uppercase tracking-[0.4em] text-slate-500 dark:text-slate-400">
                                 Color
                                 <input
                                   type="text"
@@ -1032,7 +1036,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                                   onChange={(event) =>
                                     handleMarkerChange(marker.id, 'color', event.target.value)
                                   }
-                                  className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-3 py-2 text-xs text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                                  className="mt-2 w-full rounded-xl border border-white/70 bg-white/80 px-3 py-2 text-xs text-slate-900 placeholder:text-slate-500 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/40 dark:border-slate-800/70 dark:bg-slate-950/70 dark:text-slate-100 dark:placeholder:text-slate-500 dark:focus:border-amber-400 dark:focus:ring-amber-400/30"
                                   placeholder="#facc15"
                                 />
                               </label>
@@ -1041,7 +1045,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                               <button
                                 type="button"
                                 onClick={() => handleRemoveMarker(marker.id)}
-                                className="rounded-full border border-rose-400/60 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.3em] text-rose-200 transition hover:bg-rose-400/20"
+                                className="rounded-full border border-rose-400/70 bg-rose-200/50 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.3em] text-rose-700 transition hover:bg-rose-200/70 dark:border-rose-400/40 dark:bg-rose-500/20 dark:text-rose-100 dark:hover:bg-rose-500/30"
                               >
                                 Remove
                               </button>
@@ -1052,7 +1056,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                     );
                   })}
                   {markers.length === 0 && (
-                    <div className="rounded-2xl border border-dashed border-slate-700/70 px-4 py-8 text-center text-xs text-slate-500">
+                    <div className="rounded-2xl border border-dashed border-slate-300/70 px-4 py-8 text-center text-xs text-slate-600 dark:border-slate-700/70 dark:text-slate-400">
                       No markers yet. Add a marker to start placing points of interest.
                     </div>
                   )}
@@ -1063,17 +1067,17 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
           </div>
         </div>
       </main>
-      <footer className="mt-0.5 border-t border-slate-800/70 px-5 py-1.5">
+      <footer className="relative mt-0.5 border-t border-white/60 bg-white/70 px-5 py-1.5 shadow-lg shadow-amber-500/10 dark:border-slate-800/70 dark:bg-slate-950/70">
         <div className="flex flex-wrap items-center justify-between gap-2">
           <button
             type="button"
             onClick={handleBack}
-            className="rounded-full border border-slate-700/70 px-4 py-1.5 text-[11px] font-semibold uppercase tracking-[0.3em] text-slate-300 transition hover:border-teal-400/60 hover:text-teal-200"
+            className="rounded-full border border-slate-300/70 bg-white/70 px-4 py-1.5 text-[11px] font-semibold uppercase tracking-[0.3em] text-slate-700 transition hover:border-amber-400/70 hover:text-amber-600 dark:border-slate-700/70 dark:bg-slate-900/70 dark:text-slate-300 dark:hover:border-amber-400/70 dark:hover:text-amber-200"
           >
             {step === 0 ? 'Cancel' : 'Back'}
           </button>
           <div className="flex flex-wrap items-center gap-3">
-            {error && <p className="text-xs font-semibold text-rose-300">{error}</p>}
+            {error && <p className="text-xs font-semibold text-rose-500 dark:text-rose-300">{error}</p>}
             {step < steps.length - 1 ? (
               <button
                 type="button"
@@ -1081,8 +1085,8 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                 onClick={handleContinue}
                 className={`rounded-full border px-5 py-1.5 text-[11px] font-semibold uppercase tracking-[0.3em] transition ${
                   allowNext
-                    ? 'border-teal-400/60 bg-teal-500/80 text-slate-900 hover:bg-teal-400/90'
-                    : 'cursor-not-allowed border-slate-800/70 bg-slate-900/70 text-slate-500'
+                    ? 'border-amber-400/70 bg-amber-300/80 text-slate-900 hover:bg-amber-300/90 dark:border-amber-400/50 dark:bg-amber-400/20 dark:text-amber-100 dark:hover:bg-amber-400/30'
+                    : 'cursor-not-allowed border-slate-300/70 bg-white/70 text-slate-400 dark:border-slate-800/70 dark:bg-slate-950/70 dark:text-slate-500'
                 }`}
               >
                 Next
@@ -1094,8 +1098,8 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                 disabled={creating}
                 className={`rounded-full border px-5 py-1.5 text-[11px] font-semibold uppercase tracking-[0.3em] transition ${
                   creating
-                    ? 'cursor-wait border-slate-800/70 bg-slate-900/70 text-slate-500'
-                    : 'border-teal-400/60 bg-teal-500/80 text-slate-900 hover:bg-teal-400/90'
+                    ? 'cursor-wait border-slate-300/70 bg-white/70 text-slate-500 dark:border-slate-800/70 dark:bg-slate-950/70 dark:text-slate-500'
+                    : 'border-amber-400/70 bg-amber-300/80 text-slate-900 hover:bg-amber-300/90 dark:border-amber-400/50 dark:bg-amber-400/20 dark:text-amber-100 dark:hover:bg-amber-400/30'
                 }`}
               >
                 {creating ? 'Creating…' : 'Create Map'}
@@ -1105,6 +1109,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
         </div>
       </footer>
     </div>
+  </div>
   );
 };
 

--- a/apps/pages/src/components/MapFolderList.tsx
+++ b/apps/pages/src/components/MapFolderList.tsx
@@ -77,23 +77,23 @@ const MapFolderList: React.FC<MapFolderListProps> = ({
   };
 
   return (
-    <div className="rounded-2xl border border-slate-800/70 bg-slate-900/70 p-5">
+    <div className="rounded-3xl border border-white/60 bg-white/70 p-6 shadow-2xl shadow-amber-500/20 backdrop-blur-xl transition dark:border-slate-800/70 dark:bg-slate-950/70 dark:shadow-black/40">
       <div className="mb-6 flex flex-wrap items-center justify-between gap-4">
         <div>
-          <p className="text-xs uppercase tracking-[0.4em] text-slate-400">Maps</p>
-          <h3 className="text-2xl font-bold text-white">Campaign Atlas</h3>
-          <p className="text-sm text-slate-400">Organize maps into folders to keep your encounters tidy.</p>
+          <p className="text-xs uppercase tracking-[0.4em] text-slate-600 dark:text-slate-400">Maps</p>
+          <h3 className="text-2xl font-bold text-slate-900 dark:text-white">Campaign Atlas</h3>
+          <p className="text-sm text-slate-600 dark:text-slate-400">Organize maps into folders to keep your encounters tidy.</p>
         </div>
         <button
           type="button"
           onClick={onCreateMap}
-          className="rounded-xl border border-teal-400/60 bg-teal-500/80 px-5 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-teal-400/90"
+          className="rounded-xl border border-amber-400/70 bg-amber-300/80 px-5 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-amber-300/90 dark:border-amber-400/50 dark:bg-amber-400/20 dark:text-amber-100 dark:hover:bg-amber-400/30"
         >
           New Map
         </button>
       </div>
       {grouped.length === 0 ? (
-        <div className="rounded-xl border border-dashed border-slate-700/70 px-6 py-12 text-center text-sm text-slate-400">
+        <div className="rounded-2xl border border-dashed border-slate-300/70 px-6 py-12 text-center text-sm text-slate-500 dark:border-slate-700/70 dark:text-slate-400">
           No maps yet. Create a map to start building your world.
         </div>
       ) : (
@@ -101,7 +101,7 @@ const MapFolderList: React.FC<MapFolderListProps> = ({
           {grouped.map((group) => {
             const expanded = expandedGroups[group.name];
             return (
-              <div key={group.name} className="rounded-2xl border border-slate-800/70 bg-slate-950/70 shadow-lg">
+              <div key={group.name} className="rounded-2xl border border-white/60 bg-white/70 shadow-lg shadow-amber-500/15 dark:border-slate-800/70 dark:bg-slate-950/70 dark:shadow-black/40">
                 <div className="flex items-start justify-between gap-3 px-5 py-4 sm:items-center">
                   <button
                     type="button"
@@ -109,12 +109,14 @@ const MapFolderList: React.FC<MapFolderListProps> = ({
                     className="flex w-full flex-1 items-center justify-between gap-4 text-left"
                   >
                     <div>
-                      <p className="text-lg font-semibold text-white">{group.name}</p>
-                      <p className="text-[10px] uppercase tracking-[0.4em] text-slate-500">{group.maps.length} Maps</p>
+                      <p className="text-lg font-semibold text-slate-900 dark:text-white">{group.name}</p>
+                      <p className="text-[10px] uppercase tracking-[0.4em] text-slate-500 dark:text-slate-400">{group.maps.length} Maps</p>
                     </div>
                     <span
-                      className={`inline-flex h-8 w-8 items-center justify-center rounded-full border border-slate-700/70 text-xs font-bold text-slate-300 transition ${
-                        expanded ? 'bg-teal-500/10 text-teal-200' : 'bg-slate-900'
+                      className={`inline-flex h-8 w-8 items-center justify-center rounded-full border text-xs font-bold transition ${
+                        expanded
+                          ? 'border-amber-400/70 bg-amber-300/40 text-amber-700 dark:border-amber-400/50 dark:bg-amber-400/20 dark:text-amber-100'
+                          : 'border-slate-300/70 bg-white/80 text-slate-500 dark:border-slate-700/70 dark:bg-slate-900/70 dark:text-slate-300'
                       }`}
                       aria-hidden="true"
                     >
@@ -123,7 +125,7 @@ const MapFolderList: React.FC<MapFolderListProps> = ({
                   </button>
                   <button
                     type="button"
-                    className="rounded-full border border-rose-400/60 bg-rose-500/20 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.3em] text-rose-200 transition hover:bg-rose-500/30"
+                    className="rounded-full border border-rose-400/70 bg-rose-200/50 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.3em] text-rose-700 transition hover:bg-rose-200/70 dark:border-rose-400/40 dark:bg-rose-500/20 dark:text-rose-100 dark:hover:bg-rose-500/30"
                     onClick={(event) => {
                       event.stopPropagation();
                       onDeleteGroup(group.name, group.maps);
@@ -135,7 +137,7 @@ const MapFolderList: React.FC<MapFolderListProps> = ({
                   </button>
                 </div>
                 {expanded && (
-                  <div className="grid gap-4 border-t border-slate-800/60 px-5 py-5 sm:grid-cols-2 xl:grid-cols-3">
+                  <div className="grid gap-4 border-t border-white/60 px-5 py-5 sm:grid-cols-2 xl:grid-cols-3 dark:border-slate-800/60">
                     {group.maps.map((map) => {
                       const description = getMetadataString(map.metadata, 'description');
                       const notes = getMetadataString(map.metadata, 'notes');
@@ -153,16 +155,16 @@ const MapFolderList: React.FC<MapFolderListProps> = ({
                               onSelect(map);
                             }
                           }}
-                          className={`group relative overflow-hidden rounded-2xl border px-5 py-6 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-teal-400/60 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 ${
+                          className={`group relative overflow-hidden rounded-2xl border px-5 py-6 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400/60 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-950 ${
                             selectedMapId === map.id
-                              ? 'border-teal-400 bg-teal-500/10 shadow-[0_0_0_1px_rgba(45,212,191,0.4)]'
-                              : 'border-slate-800/60 bg-slate-950/60 hover:border-teal-400/60 hover:shadow-[0_0_0_1px_rgba(45,212,191,0.3)]'
+                              ? 'border-amber-400/80 bg-amber-200/40 shadow-[0_0_0_1px_rgba(251,191,36,0.35)] dark:border-amber-400/60 dark:bg-amber-400/15'
+                              : 'border-white/60 bg-white/70 hover:border-amber-400/70 hover:shadow-[0_0_0_1px_rgba(251,191,36,0.25)] dark:border-slate-800/60 dark:bg-slate-950/60 dark:hover:border-amber-400/70'
                           }`}
                         >
                           <div className="absolute right-4 top-4 flex items-center gap-2">
                             <button
                               type="button"
-                              className="rounded-full border border-rose-400/60 bg-rose-500/20 px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.3em] text-rose-200 transition hover:bg-rose-500/30"
+                              className="rounded-full border border-rose-400/70 bg-rose-200/50 px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.3em] text-rose-700 transition hover:bg-rose-200/70 dark:border-rose-400/40 dark:bg-rose-500/20 dark:text-rose-100 dark:hover:bg-rose-500/30"
                               onClick={(event) => {
                                 event.stopPropagation();
                                 onDeleteMap(map);
@@ -174,28 +176,28 @@ const MapFolderList: React.FC<MapFolderListProps> = ({
                               ✕
                             </button>
                           </div>
-                          <div className="mb-4 flex items-center justify-between text-xs uppercase tracking-[0.4em] text-slate-500">
+                          <div className="mb-4 flex items-center justify-between text-xs uppercase tracking-[0.4em] text-slate-500 dark:text-slate-400">
                             <span>Map</span>
                             <span>
                               {map.width ?? '—'} × {map.height ?? '—'}
                             </span>
                           </div>
-                          <h4 className="text-lg font-semibold text-white">{map.name}</h4>
-                          {description && <p className="mt-2 text-sm text-slate-300">{description}</p>}
-                          {notes && !description && <p className="mt-2 text-sm text-slate-400">{notes}</p>}
+                          <h4 className="text-lg font-semibold text-slate-900 dark:text-white">{map.name}</h4>
+                          {description && <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">{description}</p>}
+                          {notes && !description && <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">{notes}</p>}
                           {tags.length > 0 && (
                             <div className="mt-4 flex flex-wrap gap-2">
                               {tags.map((tag) => (
                                 <span
                                   key={tag}
-                                  className="inline-flex items-center rounded-full border border-slate-700/70 bg-slate-900/70 px-2 py-1 text-[10px] uppercase tracking-[0.3em] text-slate-300"
+                                  className="inline-flex items-center rounded-full border border-white/60 bg-white/70 px-2 py-1 text-[10px] uppercase tracking-[0.3em] text-slate-600 dark:border-slate-800/70 dark:bg-slate-950/60 dark:text-slate-300"
                                 >
                                   {tag}
                                 </span>
                               ))}
                             </div>
                           )}
-                          <div className="pointer-events-none absolute inset-0 rounded-2xl border border-white/5 transition group-hover:border-white/10" />
+                          <div className="pointer-events-none absolute inset-0 rounded-2xl border border-white/30 transition group-hover:border-amber-300/60 dark:border-white/5" />
                           <div className="pointer-events-none absolute inset-0 opacity-0 transition group-hover:opacity-100">
                             <div
                               className="absolute inset-0 bg-cover bg-center opacity-20"

--- a/apps/pages/src/components/MapMaskCanvas.tsx
+++ b/apps/pages/src/components/MapMaskCanvas.tsx
@@ -88,7 +88,7 @@ const MapMaskCanvas: React.FC<MapMaskCanvasProps> = ({
     canvas.width = maskWidth;
     canvas.height = maskHeight;
     context.clearRect(0, 0, maskWidth, maskHeight);
-    context.fillStyle = 'rgba(15, 23, 42, 0.8)';
+    context.fillStyle = 'rgba(15, 23, 42, 0.82)';
     context.fillRect(0, 0, maskWidth, maskHeight);
     context.globalCompositeOperation = 'destination-out';
     revealedRegionIds.forEach((regionId) => {
@@ -112,7 +112,7 @@ const MapMaskCanvas: React.FC<MapMaskCanvasProps> = ({
       const polygon = polygonById.get(hoverRegion);
       if (polygon && polygon.length) {
         context.beginPath();
-        context.fillStyle = 'rgba(99, 102, 241, 0.25)';
+        context.fillStyle = 'rgba(251, 191, 36, 0.28)';
         polygon.forEach((point, index) => {
           const x = point.x * maskWidth;
           const y = point.y * maskHeight;
@@ -155,7 +155,7 @@ const MapMaskCanvas: React.FC<MapMaskCanvasProps> = ({
   const displayHeight = imageSize?.height || height || 768;
 
   return (
-    <div className="relative w-full overflow-hidden rounded-lg border border-slate-200 bg-slate-900/60 shadow-inner dark:border-slate-700">
+    <div className="relative w-full overflow-hidden rounded-3xl border border-white/60 bg-white/70 shadow-inner shadow-amber-500/10 transition dark:border-slate-800/70 dark:bg-slate-950/70">
       {imageUrl ? (
         <img
           src={imageUrl}
@@ -164,7 +164,7 @@ const MapMaskCanvas: React.FC<MapMaskCanvasProps> = ({
           style={{ maxHeight: '70vh', objectFit: 'contain' }}
         />
       ) : (
-        <div className="flex h-64 items-center justify-center text-sm text-slate-400">
+        <div className="flex h-64 items-center justify-center text-sm text-slate-500 dark:text-slate-400">
           Upload a map to begin
         </div>
       )}

--- a/apps/pages/src/components/MarkerPanel.tsx
+++ b/apps/pages/src/components/MarkerPanel.tsx
@@ -13,16 +13,16 @@ const MarkerPanel: React.FC<MarkerPanelProps> = ({ markers, onRemove, onUpdate }
       {markers.map((marker) => (
         <div
           key={marker.id}
-          className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm dark:border-slate-700 dark:bg-slate-800"
+          className="rounded-2xl border border-white/60 bg-white/70 px-4 py-3 text-sm shadow shadow-amber-500/10 transition dark:border-slate-800/70 dark:bg-slate-950/60"
         >
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-2">
+          <div className="flex items-center justify-between gap-3">
+            <div className="flex items-center gap-3">
               <span
-                className="inline-block h-2.5 w-2.5 rounded-full"
+                className="inline-block h-3 w-3 rounded-full border border-white/80 shadow dark:border-slate-800"
                 style={{ backgroundColor: marker.color || '#facc15' }}
               />
               <div>
-                <p className="font-medium">{marker.label}</p>
+                <p className="font-semibold text-slate-900 dark:text-slate-100">{marker.label}</p>
                 <p className="text-xs text-slate-500 dark:text-slate-400">
                   ({Math.round((marker.x ?? 0) * 100)}%, {Math.round((marker.y ?? 0) * 100)}%)
                 </p>
@@ -30,23 +30,29 @@ const MarkerPanel: React.FC<MarkerPanelProps> = ({ markers, onRemove, onUpdate }
             </div>
             <div className="flex items-center gap-2">
               <button
-                className="rounded-full border border-slate-300 px-2 py-1 text-xs text-slate-600 hover:bg-slate-100 dark:border-slate-600 dark:text-slate-300 dark:hover:bg-slate-700"
+                className="rounded-full border border-amber-400/70 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.3em] text-amber-700 transition hover:bg-amber-300/40 dark:border-amber-400/50 dark:text-amber-200 dark:hover:bg-amber-400/20"
                 onClick={() => onUpdate?.(marker)}
               >
                 Edit
               </button>
               <button
-                className="rounded-full bg-rose-500 px-2 py-1 text-xs text-white hover:bg-rose-600"
+                className="rounded-full border border-rose-400/70 bg-rose-200/50 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.3em] text-rose-700 transition hover:bg-rose-200/70 dark:border-rose-400/40 dark:bg-rose-500/20 dark:text-rose-100 dark:hover:bg-rose-500/30"
                 onClick={() => onRemove?.(marker.id)}
               >
                 Remove
               </button>
             </div>
           </div>
-          {marker.description && <p className="mt-2 text-xs opacity-75">{marker.description}</p>}
+          {marker.description && (
+            <p className="mt-2 text-xs text-slate-600 dark:text-slate-400">{marker.description}</p>
+          )}
         </div>
       ))}
-      {markers.length === 0 && <p className="text-sm text-slate-500">No markers placed.</p>}
+      {markers.length === 0 && (
+        <p className="rounded-2xl border border-dashed border-slate-300/70 px-4 py-6 text-center text-sm text-slate-500 dark:border-slate-700/70 dark:text-slate-400">
+          No markers placed.
+        </p>
+      )}
     </div>
   );
 };

--- a/apps/pages/src/components/RegionList.tsx
+++ b/apps/pages/src/components/RegionList.tsx
@@ -10,32 +10,36 @@ interface RegionListProps {
 
 const RegionList: React.FC<RegionListProps> = ({ regions, revealedRegionIds, onToggleRegion, onSelectRegion }) => {
   return (
-    <div className="space-y-2">
+    <div className="space-y-3">
       {regions.map((region) => {
         const revealed = revealedRegionIds.includes(region.id);
         return (
           <div
             key={region.id}
-            className={`flex items-start justify-between rounded-lg border px-3 py-2 text-sm shadow-sm transition hover:border-primary/60 hover:shadow ${
+            className={`group flex items-start justify-between gap-4 rounded-2xl border px-4 py-3 text-sm shadow transition ${
               revealed
-                ? 'border-emerald-400/60 bg-emerald-100/20 text-emerald-900 dark:border-emerald-500/40 dark:bg-emerald-500/10 dark:text-emerald-100'
-                : 'border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-800'
+                ? 'border-amber-400/80 bg-amber-200/60 text-slate-900 shadow-amber-500/20 dark:border-amber-400/50 dark:bg-amber-400/15 dark:text-amber-100'
+                : 'border-white/60 bg-white/70 text-slate-700 shadow-amber-500/10 hover:border-amber-400/70 hover:text-amber-600 dark:border-slate-800/70 dark:bg-slate-950/60 dark:text-slate-300 dark:hover:border-amber-400/70 dark:hover:text-amber-200'
             }`}
           >
-            <div>
+            <div className="min-w-0">
               <button
-                className="font-medium hover:underline"
+                className="text-left text-sm font-semibold text-slate-900 transition hover:text-amber-600 hover:underline dark:text-slate-100 dark:hover:text-amber-200"
                 onClick={() => onSelectRegion?.(region)}
               >
                 {region.name}
               </button>
-              {region.notes && <p className="mt-1 text-xs opacity-75">{region.notes}</p>}
+              {region.notes && (
+                <p className="mt-1 text-xs text-slate-600 dark:text-slate-400">
+                  {region.notes}
+                </p>
+              )}
             </div>
             <button
-              className={`rounded-full px-3 py-1 text-xs font-semibold ${
+              className={`rounded-full border px-4 py-1 text-xs font-semibold uppercase tracking-[0.25em] transition ${
                 revealed
-                  ? 'bg-emerald-500 text-white hover:bg-emerald-600'
-                  : 'bg-primary text-white hover:bg-primary-dark'
+                  ? 'border-amber-500/70 bg-amber-400/70 text-slate-900 hover:bg-amber-400/80 dark:border-amber-400/60 dark:bg-amber-400/30 dark:text-amber-100 dark:hover:bg-amber-400/40'
+                  : 'border-slate-300/70 bg-white/80 text-slate-700 hover:border-amber-400/70 hover:text-amber-600 dark:border-slate-700/70 dark:bg-slate-900/70 dark:text-slate-300 dark:hover:border-amber-400/70 dark:hover:text-amber-200'
               }`}
               onClick={() => onToggleRegion?.(region, !revealed)}
             >
@@ -45,7 +49,9 @@ const RegionList: React.FC<RegionListProps> = ({ regions, revealedRegionIds, onT
         );
       })}
       {regions.length === 0 && (
-        <p className="text-sm text-slate-500 dark:text-slate-400">No regions defined yet.</p>
+        <p className="rounded-2xl border border-dashed border-slate-300/70 px-4 py-6 text-center text-sm text-slate-500 dark:border-slate-700/70 dark:text-slate-400">
+          No regions defined yet.
+        </p>
       )}
     </div>
   );

--- a/apps/pages/src/components/SessionViewer.tsx
+++ b/apps/pages/src/components/SessionViewer.tsx
@@ -165,26 +165,27 @@ const SessionViewer: React.FC<SessionViewerProps> = ({
   const resolvedMarkers = useMemo(() => Object.values(state.markers || {}), [state.markers]);
 
   return (
-    <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
-      <div className="lg:col-span-2 space-y-4">
-        <div className="flex items-center justify-between">
+    <div className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,1.7fr)_minmax(0,1fr)]">
+      <div className="space-y-4 lg:col-span-1">
+        <div className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-white/60 bg-white/70 px-5 py-4 shadow-lg shadow-amber-500/15 transition dark:border-slate-800/70 dark:bg-slate-950/70 dark:shadow-black/40">
           <div>
-            <h2 className="text-lg font-semibold">{session.name}</h2>
-            <p className="text-sm text-slate-500 dark:text-slate-400">
-              Connection: <span className="font-medium text-primary">{connectionState}</span>
+            <h2 className="text-xl font-semibold text-slate-900 dark:text-white">{session.name}</h2>
+            <p className="text-xs uppercase tracking-[0.35em] text-slate-500 dark:text-slate-400">
+              Connection:&nbsp;
+              <span className="font-semibold text-amber-600 dark:text-amber-200">{connectionState}</span>
             </p>
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2">
             {mode === 'dm' && (
               <>
                 <button
-                  className="rounded-full border border-slate-300 px-3 py-1 text-xs font-medium hover:bg-slate-100 dark:border-slate-600 dark:hover:bg-slate-700"
+                  className="rounded-full border border-amber-400/70 bg-amber-200/70 px-4 py-1.5 text-[11px] font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-amber-200/90 dark:border-amber-400/40 dark:bg-amber-400/20 dark:text-amber-100 dark:hover:bg-amber-400/30"
                   onClick={onSaveSession}
                 >
                   Save Snapshot
                 </button>
                 <button
-                  className="rounded-full border border-rose-500 px-3 py-1 text-xs font-medium text-rose-500 hover:bg-rose-500/10"
+                  className="rounded-full border border-rose-400/70 bg-rose-200/50 px-4 py-1.5 text-[11px] font-semibold uppercase tracking-[0.3em] text-rose-700 transition hover:bg-rose-200/70 dark:border-rose-400/40 dark:bg-rose-500/20 dark:text-rose-100 dark:hover:bg-rose-500/30"
                   onClick={onEndSession}
                 >
                   End Session
@@ -192,7 +193,7 @@ const SessionViewer: React.FC<SessionViewerProps> = ({
               </>
             )}
             <button
-              className="rounded-full border border-slate-300 px-3 py-1 text-xs font-medium hover:bg-slate-100 dark:border-slate-600 dark:hover:bg-slate-700"
+              className="rounded-full border border-slate-300/70 bg-white/70 px-4 py-1.5 text-[11px] font-semibold uppercase tracking-[0.3em] text-slate-700 transition hover:border-amber-400/70 hover:text-amber-600 dark:border-slate-700/70 dark:bg-slate-900/70 dark:text-slate-300 dark:hover:border-amber-400/70 dark:hover:text-amber-200"
               onClick={onLeave}
             >
               Leave
@@ -212,29 +213,37 @@ const SessionViewer: React.FC<SessionViewerProps> = ({
         />
       </div>
       <div className="space-y-6">
-        <section>
-          <h3 className="mb-2 text-sm font-semibold uppercase tracking-wide text-slate-500">Players</h3>
-          <ul className="space-y-1 text-sm">
+        <section className="rounded-2xl border border-white/60 bg-white/70 p-4 shadow shadow-amber-500/10 dark:border-slate-800/70 dark:bg-slate-950/60">
+          <h3 className="mb-3 text-xs font-semibold uppercase tracking-[0.4em] text-slate-600 dark:text-slate-400">Players</h3>
+          <ul className="space-y-2 text-sm">
             {state.players.map((player) => (
-              <li key={player.id} className="rounded border border-slate-200 px-3 py-1 dark:border-slate-700">
-                <span className="font-medium">{player.name}</span>
-                <span className="ml-2 text-xs uppercase text-slate-500">{player.role}</span>
+              <li key={player.id} className="flex items-center justify-between rounded-xl border border-white/60 bg-white/80 px-3 py-2 dark:border-slate-800/70 dark:bg-slate-950/70">
+                <span className="font-semibold text-slate-900 dark:text-slate-100">{player.name}</span>
+                <span className="text-[10px] uppercase tracking-[0.35em] text-slate-500 dark:text-slate-400">{player.role}</span>
               </li>
             ))}
-            {state.players.length === 0 && <li className="text-xs text-slate-500">Waiting for players…</li>}
+            {state.players.length === 0 && (
+              <li className="rounded-xl border border-dashed border-slate-300/70 px-3 py-4 text-center text-xs text-slate-500 dark:border-slate-700/70 dark:text-slate-400">
+                Waiting for players…
+              </li>
+            )}
           </ul>
         </section>
-        <section>
-          <h3 className="mb-2 text-sm font-semibold uppercase tracking-wide text-slate-500">Regions</h3>
+        <section className="rounded-2xl border border-white/60 bg-white/70 p-4 shadow shadow-amber-500/10 dark:border-slate-800/70 dark:bg-slate-950/60">
+          <h3 className="mb-3 text-xs font-semibold uppercase tracking-[0.4em] text-slate-600 dark:text-slate-400">Regions</h3>
           <RegionList
             regions={regions}
             revealedRegionIds={state.revealedRegions}
             onToggleRegion={mode === 'dm' ? handleToggleRegion : undefined}
           />
         </section>
-        <section>
-          <h3 className="mb-2 text-sm font-semibold uppercase tracking-wide text-slate-500">Markers</h3>
-          <MarkerPanel markers={resolvedMarkers} onRemove={mode === 'dm' ? handleRemoveMarker : undefined} onUpdate={mode === 'dm' ? handleUpdateMarker : undefined} />
+        <section className="rounded-2xl border border-white/60 bg-white/70 p-4 shadow shadow-amber-500/10 dark:border-slate-800/70 dark:bg-slate-950/60">
+          <h3 className="mb-3 text-xs font-semibold uppercase tracking-[0.4em] text-slate-600 dark:text-slate-400">Markers</h3>
+          <MarkerPanel
+            markers={resolvedMarkers}
+            onRemove={mode === 'dm' ? handleRemoveMarker : undefined}
+            onUpdate={mode === 'dm' ? handleUpdateMarker : undefined}
+          />
         </section>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- restyled the in-app session components to use the landing page’s amber/white treatment and updated list cards, buttons, and empty states
- refreshed the map management and creation wizard surfaces with light/dark aware backgrounds and accent colors that mirror the brand palette
- adjusted map canvas overlays and highlights so hover and marker states use the same warm color cues

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd8a2b9bb8832387dce0eb25597ab6