### PR TITLE
Align authenticated UI theming with landing page

### DIFF
--- a/apps/pages/src/components/MarkerPanel.tsx
+++ b/apps/pages/src/components/MarkerPanel.tsx
@@ -13,16 +13,17 @@ const MarkerPanel: React.FC<MarkerPanelProps> = ({ markers, onRemove, onUpdate }
       {markers.map((marker) => (
         <div
           key={marker.id}
-          className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm dark:border-slate-700 dark:bg-slate-800"
+          className="rounded-2xl border border-white/60 bg-white/60 px-4 py-3 text-sm shadow-lg shadow-amber-500/10 backdrop-blur dark:border-slate-800/70 dark:bg-slate-950/60"
         >
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-2">
+          <div className="flex items-center justify-between gap-3">
+            <div className="flex items-center gap-3">
               <span
-                className="inline-block h-2.5 w-2.5 rounded-full"
+                className="inline-block h-3 w-3 rounded-full border border-white/70 shadow-inner dark:border-slate-900"
                 style={{ backgroundColor: marker.color || '#facc15' }}
+                aria-hidden
               />
               <div>
-                <p className="font-medium">{marker.label}</p>
+                <p className="font-semibold text-slate-900 dark:text-white">{marker.label}</p>
                 <p className="text-xs text-slate-500 dark:text-slate-400">
                   ({Math.round((marker.x ?? 0) * 100)}%, {Math.round((marker.y ?? 0) * 100)}%)
                 </p>
@@ -30,23 +31,27 @@ const MarkerPanel: React.FC<MarkerPanelProps> = ({ markers, onRemove, onUpdate }
             </div>
             <div className="flex items-center gap-2">
               <button
-                className="rounded-full border border-slate-300 px-2 py-1 text-xs text-slate-600 hover:bg-slate-100 dark:border-slate-600 dark:text-slate-300 dark:hover:bg-slate-700"
+                className="inline-flex items-center gap-1 rounded-full border border-amber-400/60 bg-amber-300/70 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.35em] text-slate-900 transition hover:bg-amber-300/90 dark:border-amber-400/40 dark:bg-amber-400/15 dark:text-amber-100 dark:hover:bg-amber-400/25"
                 onClick={() => onUpdate?.(marker)}
               >
                 Edit
               </button>
               <button
-                className="rounded-full bg-rose-500 px-2 py-1 text-xs text-white hover:bg-rose-600"
+                className="inline-flex items-center gap-1 rounded-full border border-rose-400/70 bg-rose-200/60 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.35em] text-rose-700 transition hover:bg-rose-200/80 dark:border-rose-400/40 dark:bg-rose-500/20 dark:text-rose-100 dark:hover:bg-rose-500/30"
                 onClick={() => onRemove?.(marker.id)}
               >
                 Remove
               </button>
             </div>
           </div>
-          {marker.description && <p className="mt-2 text-xs opacity-75">{marker.description}</p>}
+          {marker.description && (
+            <p className="mt-2 text-xs text-slate-600 dark:text-slate-400">{marker.description}</p>
+          )}
         </div>
       ))}
-      {markers.length === 0 && <p className="text-sm text-slate-500">No markers placed.</p>}
+      {markers.length === 0 && (
+        <p className="text-sm text-slate-500 dark:text-slate-400">No markers placed.</p>
+      )}
     </div>
   );
 };

--- a/apps/pages/src/components/RegionList.tsx
+++ b/apps/pages/src/components/RegionList.tsx
@@ -10,37 +10,45 @@ interface RegionListProps {
 
 const RegionList: React.FC<RegionListProps> = ({ regions, revealedRegionIds, onToggleRegion, onSelectRegion }) => {
   return (
-    <div className="space-y-2">
+    <div className="space-y-3">
       {regions.map((region) => {
         const revealed = revealedRegionIds.includes(region.id);
         return (
           <div
             key={region.id}
-            className={`flex items-start justify-between rounded-lg border px-3 py-2 text-sm shadow-sm transition hover:border-primary/60 hover:shadow ${
+            className={`group relative overflow-hidden rounded-2xl border px-4 py-3 text-sm backdrop-blur transition shadow-lg ${
               revealed
-                ? 'border-emerald-400/60 bg-emerald-100/20 text-emerald-900 dark:border-emerald-500/40 dark:bg-emerald-500/10 dark:text-emerald-100'
-                : 'border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-800'
+                ? 'border-emerald-400/70 bg-emerald-200/40 text-emerald-800 shadow-emerald-500/20 dark:border-emerald-400/40 dark:bg-emerald-500/15 dark:text-emerald-100'
+                : 'border-white/60 bg-white/60 text-slate-700 shadow-amber-500/5 hover:border-amber-400/60 hover:shadow-amber-500/20 dark:border-slate-800/70 dark:bg-slate-950/60 dark:text-slate-200 dark:hover:border-amber-400/50'
             }`}
           >
-            <div>
+            <div className="pr-4">
               <button
-                className="font-medium hover:underline"
+                className="font-semibold text-slate-900 hover:text-amber-600 hover:underline dark:text-white dark:hover:text-amber-200"
                 onClick={() => onSelectRegion?.(region)}
               >
                 {region.name}
               </button>
-              {region.notes && <p className="mt-1 text-xs opacity-75">{region.notes}</p>}
+              {region.notes && (
+                <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">{region.notes}</p>
+              )}
             </div>
             <button
-              className={`rounded-full px-3 py-1 text-xs font-semibold ${
+              className={`inline-flex items-center rounded-full border px-4 py-1 text-[10px] font-semibold uppercase tracking-[0.35em] transition ${
                 revealed
-                  ? 'bg-emerald-500 text-white hover:bg-emerald-600'
-                  : 'bg-primary text-white hover:bg-primary-dark'
+                  ? 'border-emerald-500/70 bg-emerald-400/60 text-emerald-900 hover:bg-emerald-400/80 dark:border-emerald-400/60 dark:bg-emerald-400/10 dark:text-emerald-100 dark:hover:bg-emerald-400/20'
+                  : 'border-amber-400/60 bg-amber-300/70 text-slate-900 hover:bg-amber-300/90 dark:border-amber-400/50 dark:bg-amber-400/15 dark:text-amber-100 dark:hover:bg-amber-400/25'
               }`}
               onClick={() => onToggleRegion?.(region, !revealed)}
             >
               {revealed ? 'Hide' : 'Reveal'}
             </button>
+            <div
+              aria-hidden
+              className={`pointer-events-none absolute inset-0 bg-gradient-to-br from-amber-200/20 to-transparent opacity-0 transition duration-300 ${
+                revealed ? 'group-hover:opacity-0' : 'group-hover:opacity-100'
+              } dark:from-amber-400/10`}
+            />
           </div>
         );
       })}

--- a/apps/pages/src/components/SessionViewer.tsx
+++ b/apps/pages/src/components/SessionViewer.tsx
@@ -165,26 +165,30 @@ const SessionViewer: React.FC<SessionViewerProps> = ({
   const resolvedMarkers = useMemo(() => Object.values(state.markers || {}), [state.markers]);
 
   return (
-    <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
-      <div className="lg:col-span-2 space-y-4">
-        <div className="flex items-center justify-between">
+    <div className="grid grid-cols-1 gap-6 text-slate-900 dark:text-slate-100 lg:grid-cols-3">
+      <div className="space-y-4 lg:col-span-2">
+        <div className="flex flex-wrap items-center justify-between gap-3 rounded-3xl border border-white/60 bg-white/60 px-5 py-4 shadow-lg shadow-amber-500/10 backdrop-blur dark:border-slate-800/70 dark:bg-slate-950/60 dark:shadow-black/40">
           <div>
-            <h2 className="text-lg font-semibold">{session.name}</h2>
-            <p className="text-sm text-slate-500 dark:text-slate-400">
-              Connection: <span className="font-medium text-primary">{connectionState}</span>
+            <p className="text-[11px] font-semibold uppercase tracking-[0.45em] text-slate-500 dark:text-slate-400">Active Session</p>
+            <h2 className="mt-1 text-2xl font-bold text-slate-900 dark:text-white">{session.name}</h2>
+            <p className="mt-2 flex items-center gap-2 text-xs uppercase tracking-[0.35em] text-slate-500 dark:text-slate-400">
+              Connection
+              <span className="inline-flex items-center rounded-full border border-amber-400/70 bg-amber-200/70 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.4em] text-amber-700 dark:border-amber-400/40 dark:bg-amber-400/10 dark:text-amber-200">
+                {connectionState}
+              </span>
             </p>
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2">
             {mode === 'dm' && (
               <>
                 <button
-                  className="rounded-full border border-slate-300 px-3 py-1 text-xs font-medium hover:bg-slate-100 dark:border-slate-600 dark:hover:bg-slate-700"
+                  className="inline-flex items-center gap-2 rounded-full border border-amber-400/70 bg-amber-200/70 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.35em] text-slate-900 transition hover:bg-amber-200/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-400 dark:border-amber-400/40 dark:bg-amber-400/10 dark:text-amber-100 dark:hover:bg-amber-400/20"
                   onClick={onSaveSession}
                 >
                   Save Snapshot
                 </button>
                 <button
-                  className="rounded-full border border-rose-500 px-3 py-1 text-xs font-medium text-rose-500 hover:bg-rose-500/10"
+                  className="inline-flex items-center gap-2 rounded-full border border-rose-400/70 bg-rose-200/60 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.35em] text-rose-700 transition hover:bg-rose-200/80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-400 dark:border-rose-400/40 dark:bg-rose-500/20 dark:text-rose-100 dark:hover:bg-rose-500/30"
                   onClick={onEndSession}
                 >
                   End Session
@@ -192,49 +196,62 @@ const SessionViewer: React.FC<SessionViewerProps> = ({
               </>
             )}
             <button
-              className="rounded-full border border-slate-300 px-3 py-1 text-xs font-medium hover:bg-slate-100 dark:border-slate-600 dark:hover:bg-slate-700"
+              className="inline-flex items-center gap-2 rounded-full border border-white/60 bg-white/50 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.35em] text-slate-700 transition hover:border-amber-400/70 hover:text-amber-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-400 dark:border-slate-700 dark:bg-slate-900/70 dark:text-slate-200 dark:hover:border-amber-400/60 dark:hover:text-amber-200"
               onClick={onLeave}
             >
               Leave
             </button>
           </div>
         </div>
-        <MapMaskCanvas
-          imageUrl={mapImageUrl}
-          width={mapWidth}
-          height={mapHeight}
-          regions={regions}
-          revealedRegionIds={state.revealedRegions}
-          markers={state.markers}
-          mode={mode}
-          onToggleRegion={handleToggleRegion}
-          onPlaceMarker={mode === 'dm' ? handlePlaceMarker : undefined}
-        />
+        <div className="overflow-hidden rounded-3xl border border-white/60 bg-white/50 p-3 shadow-2xl shadow-amber-500/10 backdrop-blur-lg dark:border-slate-800/70 dark:bg-slate-950/60 dark:shadow-black/40">
+          <MapMaskCanvas
+            imageUrl={mapImageUrl}
+            width={mapWidth}
+            height={mapHeight}
+            regions={regions}
+            revealedRegionIds={state.revealedRegions}
+            markers={state.markers}
+            mode={mode}
+            onToggleRegion={handleToggleRegion}
+            onPlaceMarker={mode === 'dm' ? handlePlaceMarker : undefined}
+          />
+        </div>
       </div>
-      <div className="space-y-6">
-        <section>
-          <h3 className="mb-2 text-sm font-semibold uppercase tracking-wide text-slate-500">Players</h3>
-          <ul className="space-y-1 text-sm">
+      <div className="space-y-5">
+        <section className="rounded-3xl border border-white/60 bg-white/55 p-4 shadow-lg shadow-amber-500/10 backdrop-blur dark:border-slate-800/70 dark:bg-slate-950/60 dark:shadow-black/40">
+          <h3 className="mb-3 text-xs font-semibold uppercase tracking-[0.45em] text-slate-500 dark:text-slate-400">Players</h3>
+          <ul className="space-y-2 text-sm">
             {state.players.map((player) => (
-              <li key={player.id} className="rounded border border-slate-200 px-3 py-1 dark:border-slate-700">
-                <span className="font-medium">{player.name}</span>
-                <span className="ml-2 text-xs uppercase text-slate-500">{player.role}</span>
+              <li
+                key={player.id}
+                className="flex items-center justify-between rounded-2xl border border-white/60 bg-white/60 px-3 py-2 text-slate-700 shadow-sm dark:border-slate-800/70 dark:bg-slate-900/60 dark:text-slate-100"
+              >
+                <span className="font-semibold text-slate-900 dark:text-white">{player.name}</span>
+                <span className="rounded-full border border-amber-400/60 bg-amber-200/70 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.35em] text-amber-700 dark:border-amber-400/40 dark:bg-amber-400/10 dark:text-amber-200">
+                  {player.role}
+                </span>
               </li>
             ))}
-            {state.players.length === 0 && <li className="text-xs text-slate-500">Waiting for players…</li>}
+            {state.players.length === 0 && (
+              <li className="text-xs text-slate-500 dark:text-slate-400">Waiting for players…</li>
+            )}
           </ul>
         </section>
-        <section>
-          <h3 className="mb-2 text-sm font-semibold uppercase tracking-wide text-slate-500">Regions</h3>
+        <section className="rounded-3xl border border-white/60 bg-white/55 p-4 shadow-lg shadow-amber-500/10 backdrop-blur dark:border-slate-800/70 dark:bg-slate-950/60 dark:shadow-black/40">
+          <h3 className="mb-3 text-xs font-semibold uppercase tracking-[0.45em] text-slate-500 dark:text-slate-400">Regions</h3>
           <RegionList
             regions={regions}
             revealedRegionIds={state.revealedRegions}
             onToggleRegion={mode === 'dm' ? handleToggleRegion : undefined}
           />
         </section>
-        <section>
-          <h3 className="mb-2 text-sm font-semibold uppercase tracking-wide text-slate-500">Markers</h3>
-          <MarkerPanel markers={resolvedMarkers} onRemove={mode === 'dm' ? handleRemoveMarker : undefined} onUpdate={mode === 'dm' ? handleUpdateMarker : undefined} />
+        <section className="rounded-3xl border border-white/60 bg-white/55 p-4 shadow-lg shadow-amber-500/10 backdrop-blur dark:border-slate-800/70 dark:bg-slate-950/60 dark:shadow-black/40">
+          <h3 className="mb-3 text-xs font-semibold uppercase tracking-[0.45em] text-slate-500 dark:text-slate-400">Markers</h3>
+          <MarkerPanel
+            markers={resolvedMarkers}
+            onRemove={mode === 'dm' ? handleRemoveMarker : undefined}
+            onUpdate={mode === 'dm' ? handleUpdateMarker : undefined}
+          />
         </section>
       </div>
     </div>

--- a/apps/pages/src/components/Toolbar.tsx
+++ b/apps/pages/src/components/Toolbar.tsx
@@ -44,15 +44,15 @@ const Toolbar: React.FC<ToolbarProps> = ({
   };
 
   return (
-    <div className="flex flex-col gap-4 rounded-lg border border-slate-200 bg-white/80 p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900/70">
+    <div className="flex flex-col gap-5 rounded-2xl border border-white/60 bg-white/60 p-5 shadow-xl shadow-amber-500/10 backdrop-blur dark:border-slate-800/70 dark:bg-slate-950/60 dark:shadow-black/40">
       <div className="flex items-center justify-between" role="group" aria-label="Selection tools">
-        <div className="flex gap-2">
+        <div className="flex flex-wrap gap-2">
           <button
             type="button"
-            className={`rounded-md px-3 py-2 text-sm font-medium transition ${
+            className={`rounded-xl border px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] transition ${
               activeTool === 'magneticLasso'
-                ? 'bg-indigo-600 text-white shadow'
-                : 'bg-slate-100 text-slate-700 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700'
+                ? 'border-amber-400/70 bg-amber-300/80 text-slate-900 shadow-lg shadow-amber-500/30'
+                : 'border-white/60 bg-white/50 text-slate-700 hover:border-amber-400/60 hover:text-amber-600 dark:border-slate-700 dark:bg-slate-900/70 dark:text-slate-200 dark:hover:border-amber-400/50 dark:hover:text-amber-200'
             }`}
             aria-pressed={activeTool === 'magneticLasso'}
             onClick={() => onToolChange('magneticLasso')}
@@ -61,10 +61,10 @@ const Toolbar: React.FC<ToolbarProps> = ({
           </button>
           <button
             type="button"
-            className={`rounded-md px-3 py-2 text-sm font-medium transition ${
+            className={`rounded-xl border px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] transition ${
               activeTool === 'smartWand'
-                ? 'bg-indigo-600 text-white shadow'
-                : 'bg-slate-100 text-slate-700 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700'
+                ? 'border-amber-400/70 bg-amber-300/80 text-slate-900 shadow-lg shadow-amber-500/30'
+                : 'border-white/60 bg-white/50 text-slate-700 hover:border-amber-400/60 hover:text-amber-600 dark:border-slate-700 dark:bg-slate-900/70 dark:text-slate-200 dark:hover:border-amber-400/50 dark:hover:text-amber-200'
             }`}
             aria-pressed={activeTool === 'smartWand'}
             onClick={() => onToolChange('smartWand')}
@@ -73,7 +73,7 @@ const Toolbar: React.FC<ToolbarProps> = ({
           </button>
         </div>
       </div>
-      <div className="grid grid-cols-1 gap-3" aria-label="Advanced selection settings">
+      <div className="grid grid-cols-1 gap-4" aria-label="Advanced selection settings">
         <label className="flex flex-col gap-1 text-sm font-medium text-slate-700 dark:text-slate-200">
           Edge contrast emphasis
           <input
@@ -82,6 +82,7 @@ const Toolbar: React.FC<ToolbarProps> = ({
             max={1}
             step={0.05}
             value={clamp(settings.edgeContrast, 0, 1)}
+            className="h-1 w-full cursor-pointer appearance-none rounded-full bg-slate-200 accent-amber-500 dark:bg-slate-700"
             onChange={(event) => updateSetting('edgeContrast', parseFloat(event.currentTarget.value))}
             aria-label="Edge contrast emphasis"
           />
@@ -97,6 +98,7 @@ const Toolbar: React.FC<ToolbarProps> = ({
             max={1}
             step={0.05}
             value={clamp(settings.snapStrength, 0, 1)}
+            className="h-1 w-full cursor-pointer appearance-none rounded-full bg-slate-200 accent-amber-500 dark:bg-slate-700"
             onChange={(event) => updateSetting('snapStrength', parseFloat(event.currentTarget.value))}
             aria-label="Snap strength"
           />
@@ -104,25 +106,28 @@ const Toolbar: React.FC<ToolbarProps> = ({
             Controls how aggressively polygons snap to the cost pyramid edges.
           </span>
         </label>
-        <label className="flex items-center gap-2 text-sm font-medium text-slate-700 dark:text-slate-200">
+        <label className="flex items-center gap-3 text-sm font-medium text-slate-700 dark:text-slate-200">
           <input
             type="checkbox"
+            className="h-4 w-4 rounded border-amber-400/60 text-amber-500 focus:ring-amber-400 dark:border-amber-400/40 dark:bg-slate-900"
             checked={settings.autoEntranceLock}
             onChange={(event) => updateSetting('autoEntranceLock', event.currentTarget.checked)}
           />
           Auto-lock detected entrances
         </label>
-        <label className="flex items-center gap-2 text-sm font-medium text-slate-700 dark:text-slate-200">
+        <label className="flex items-center gap-3 text-sm font-medium text-slate-700 dark:text-slate-200">
           <input
             type="checkbox"
+            className="h-4 w-4 rounded border-amber-400/60 text-amber-500 focus:ring-amber-400 dark:border-amber-400/40 dark:bg-slate-900"
             checked={settings.livePreview}
             onChange={(event) => updateSetting('livePreview', event.currentTarget.checked)}
           />
           Live preview updates
         </label>
-        <label className="flex items-center gap-2 text-sm font-medium text-slate-700 dark:text-slate-200">
+        <label className="flex items-center gap-3 text-sm font-medium text-slate-700 dark:text-slate-200">
           <input
             type="checkbox"
+            className="h-4 w-4 rounded border-amber-400/60 text-amber-500 focus:ring-amber-400 dark:border-amber-400/40 dark:bg-slate-900"
             checked={settings.showDebugOverlay}
             onChange={(event) => updateSetting('showDebugOverlay', event.currentTarget.checked)}
           />


### PR DESCRIPTION
## Summary
- restyled the session viewer header, map frame, and support panels to reuse the landing page glassmorphism and amber accents
- updated the region and marker panels to share the same translucent surfaces and accent buttons as the landing experience
- refreshed the map creation toolbar controls to adopt the shared palette and typography

## Testing
- npm test *(fails: missing optional jsdom dependency prompted by vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68dd8a2b9bb8832387dce0eb25597ab6