### PR TITLE
Align authenticated views with landing page theming

### DIFF
--- a/apps/pages/src/components/MapMaskCanvas.tsx
+++ b/apps/pages/src/components/MapMaskCanvas.tsx
@@ -155,7 +155,7 @@ const MapMaskCanvas: React.FC<MapMaskCanvasProps> = ({
   const displayHeight = imageSize?.height || height || 768;
 
   return (
-    <div className="relative w-full overflow-hidden rounded-lg border border-slate-200 bg-slate-900/60 shadow-inner dark:border-slate-700">
+    <div className="relative w-full overflow-hidden rounded-3xl border border-white/60 bg-white/70 shadow-inner shadow-amber-500/10 backdrop-blur-sm transition dark:border-slate-800/70 dark:bg-slate-950/70 dark:shadow-black/40">
       {imageUrl ? (
         <img
           src={imageUrl}
@@ -164,7 +164,7 @@ const MapMaskCanvas: React.FC<MapMaskCanvasProps> = ({
           style={{ maxHeight: '70vh', objectFit: 'contain' }}
         />
       ) : (
-        <div className="flex h-64 items-center justify-center text-sm text-slate-400">
+        <div className="flex h-64 items-center justify-center text-sm text-slate-600 dark:text-slate-400">
           Upload a map to begin
         </div>
       )}
@@ -182,7 +182,7 @@ const MapMaskCanvas: React.FC<MapMaskCanvasProps> = ({
         <button
           key={marker.id}
           onClick={() => onSelectMarker?.(marker.id)}
-          className="absolute flex -translate-x-1/2 -translate-y-full items-center gap-1 rounded-full border border-white/50 bg-white/80 px-2 py-1 text-xs font-medium text-slate-900 shadow dark:border-slate-800 dark:bg-slate-900/90 dark:text-slate-100"
+          className="absolute flex -translate-x-1/2 -translate-y-full items-center gap-2 rounded-full border border-white/70 bg-white/80 px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-slate-900 shadow-lg shadow-amber-500/20 transition hover:border-amber-400/60 dark:border-slate-700 dark:bg-slate-900/90 dark:text-slate-100 dark:hover:border-amber-400/50"
           style={{
             left: `${(marker.x ?? 0) * 100}%`,
             top: `${(marker.y ?? 0) * 100}%`,

--- a/apps/pages/src/components/MarkerPanel.tsx
+++ b/apps/pages/src/components/MarkerPanel.tsx
@@ -13,7 +13,7 @@ const MarkerPanel: React.FC<MarkerPanelProps> = ({ markers, onRemove, onUpdate }
       {markers.map((marker) => (
         <div
           key={marker.id}
-          className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm dark:border-slate-700 dark:bg-slate-800"
+          className="rounded-2xl border border-white/60 bg-white/70 px-4 py-3 text-sm shadow-lg shadow-amber-500/10 backdrop-blur-sm transition dark:border-slate-800/70 dark:bg-slate-950/70 dark:text-slate-100 dark:shadow-black/30"
         >
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
@@ -22,31 +22,31 @@ const MarkerPanel: React.FC<MarkerPanelProps> = ({ markers, onRemove, onUpdate }
                 style={{ backgroundColor: marker.color || '#facc15' }}
               />
               <div>
-                <p className="font-medium">{marker.label}</p>
-                <p className="text-xs text-slate-500 dark:text-slate-400">
+                <p className="text-sm font-semibold text-slate-800 dark:text-slate-100">{marker.label}</p>
+                <p className="text-xs uppercase tracking-[0.3em] text-slate-500 dark:text-slate-400">
                   ({Math.round((marker.x ?? 0) * 100)}%, {Math.round((marker.y ?? 0) * 100)}%)
                 </p>
               </div>
             </div>
             <div className="flex items-center gap-2">
               <button
-                className="rounded-full border border-slate-300 px-2 py-1 text-xs text-slate-600 hover:bg-slate-100 dark:border-slate-600 dark:text-slate-300 dark:hover:bg-slate-700"
+                className="inline-flex items-center gap-2 rounded-full border border-amber-400/60 bg-amber-200/60 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-amber-200/80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-400 dark:border-amber-400/40 dark:bg-amber-400/15 dark:text-amber-100 dark:hover:bg-amber-400/25"
                 onClick={() => onUpdate?.(marker)}
               >
                 Edit
               </button>
               <button
-                className="rounded-full bg-rose-500 px-2 py-1 text-xs text-white hover:bg-rose-600"
+                className="inline-flex items-center gap-2 rounded-full border border-rose-400/60 bg-rose-200/60 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.3em] text-rose-700 transition hover:bg-rose-200/80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-400 dark:border-rose-400/40 dark:bg-rose-500/20 dark:text-rose-100 dark:hover:bg-rose-500/30"
                 onClick={() => onRemove?.(marker.id)}
               >
                 Remove
               </button>
             </div>
           </div>
-          {marker.description && <p className="mt-2 text-xs opacity-75">{marker.description}</p>}
+          {marker.description && <p className="mt-2 text-xs text-slate-600 dark:text-slate-300">{marker.description}</p>}
         </div>
       ))}
-      {markers.length === 0 && <p className="text-sm text-slate-500">No markers placed.</p>}
+      {markers.length === 0 && <p className="text-sm text-slate-500 dark:text-slate-400">No markers placed.</p>}
     </div>
   );
 };

--- a/apps/pages/src/components/RegionList.tsx
+++ b/apps/pages/src/components/RegionList.tsx
@@ -10,32 +10,32 @@ interface RegionListProps {
 
 const RegionList: React.FC<RegionListProps> = ({ regions, revealedRegionIds, onToggleRegion, onSelectRegion }) => {
   return (
-    <div className="space-y-2">
+    <div className="space-y-3">
       {regions.map((region) => {
         const revealed = revealedRegionIds.includes(region.id);
         return (
           <div
             key={region.id}
-            className={`flex items-start justify-between rounded-lg border px-3 py-2 text-sm shadow-sm transition hover:border-primary/60 hover:shadow ${
+            className={`flex items-start justify-between gap-4 rounded-2xl border px-4 py-3 text-sm shadow-lg shadow-amber-500/10 transition hover:border-amber-400/70 hover:shadow-amber-500/20 backdrop-blur-sm ${
               revealed
-                ? 'border-emerald-400/60 bg-emerald-100/20 text-emerald-900 dark:border-emerald-500/40 dark:bg-emerald-500/10 dark:text-emerald-100'
-                : 'border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-800'
+                ? 'border-emerald-300/70 bg-emerald-200/40 text-emerald-900 dark:border-emerald-400/50 dark:bg-emerald-400/15 dark:text-emerald-100'
+                : 'border-white/60 bg-white/70 text-slate-700 dark:border-slate-800/70 dark:bg-slate-950/70 dark:text-slate-100'
             }`}
           >
             <div>
               <button
-                className="font-medium hover:underline"
+                className="text-sm font-semibold text-slate-900 underline-offset-4 hover:text-amber-600 hover:underline dark:text-white dark:hover:text-amber-200"
                 onClick={() => onSelectRegion?.(region)}
               >
                 {region.name}
               </button>
-              {region.notes && <p className="mt-1 text-xs opacity-75">{region.notes}</p>}
+              {region.notes && <p className="mt-1 text-xs text-slate-600 dark:text-slate-300">{region.notes}</p>}
             </div>
             <button
-              className={`rounded-full px-3 py-1 text-xs font-semibold ${
+              className={`inline-flex items-center gap-2 rounded-full px-4 py-1.5 text-[10px] font-semibold uppercase tracking-[0.3em] transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 ${
                 revealed
-                  ? 'bg-emerald-500 text-white hover:bg-emerald-600'
-                  : 'bg-primary text-white hover:bg-primary-dark'
+                  ? 'border border-emerald-400/70 bg-emerald-300/60 text-emerald-900 hover:bg-emerald-300/80 focus-visible:outline-emerald-400 dark:border-emerald-400/50 dark:bg-emerald-400/15 dark:text-emerald-100 dark:hover:bg-emerald-400/25'
+                  : 'border border-amber-400/70 bg-amber-300/80 text-slate-900 hover:bg-amber-300/90 focus-visible:outline-amber-400 dark:border-amber-400/50 dark:bg-amber-400/15 dark:text-amber-100 dark:hover:bg-amber-400/25'
               }`}
               onClick={() => onToggleRegion?.(region, !revealed)}
             >

--- a/apps/pages/src/components/SessionViewer.tsx
+++ b/apps/pages/src/components/SessionViewer.tsx
@@ -164,27 +164,66 @@ const SessionViewer: React.FC<SessionViewerProps> = ({
 
   const resolvedMarkers = useMemo(() => Object.values(state.markers || {}), [state.markers]);
 
+  const connectionBadgeClass = useMemo(() => {
+    const base =
+      'inline-flex items-center gap-2 rounded-full px-4 py-1.5 text-[10px] font-semibold uppercase tracking-[0.3em] shadow transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2';
+    switch (connectionState) {
+      case 'open':
+        return (
+          base +
+          ' border border-emerald-400/70 bg-emerald-300/60 text-emerald-900 focus-visible:outline-emerald-400 dark:border-emerald-400/50 dark:bg-emerald-400/15 dark:text-emerald-100'
+        );
+      case 'connecting':
+        return (
+          base +
+          ' border border-amber-400/70 bg-amber-300/80 text-slate-900 focus-visible:outline-amber-400 dark:border-amber-400/50 dark:bg-amber-400/15 dark:text-amber-100'
+        );
+      case 'closed':
+        return (
+          base +
+          ' border border-rose-400/70 bg-rose-200/60 text-rose-700 focus-visible:outline-rose-400 dark:border-rose-400/40 dark:bg-rose-500/20 dark:text-rose-100'
+        );
+      default:
+        return (
+          base +
+          ' border border-white/60 bg-white/70 text-slate-700 focus-visible:outline-slate-400 dark:border-slate-700 dark:bg-slate-900/70 dark:text-slate-200'
+        );
+    }
+  }, [connectionState]);
+
+  const connectionLabel = useMemo(() => {
+    switch (connectionState) {
+      case 'open':
+        return 'Live';
+      case 'connecting':
+        return 'Connecting';
+      case 'closed':
+        return 'Disconnected';
+      default:
+        return 'Idle';
+    }
+  }, [connectionState]);
+
   return (
-    <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
-      <div className="lg:col-span-2 space-y-4">
-        <div className="flex items-center justify-between">
+    <div className="grid gap-6 lg:grid-cols-[minmax(0,1.8fr)_minmax(0,1fr)]">
+      <section className="space-y-5">
+        <div className="flex flex-wrap items-center justify-between gap-4 rounded-3xl border border-white/60 bg-white/70 px-5 py-4 shadow-lg shadow-amber-500/20 backdrop-blur-sm dark:border-slate-800/70 dark:bg-slate-950/70 dark:shadow-black/40">
           <div>
-            <h2 className="text-lg font-semibold">{session.name}</h2>
-            <p className="text-sm text-slate-500 dark:text-slate-400">
-              Connection: <span className="font-medium text-primary">{connectionState}</span>
-            </p>
+            <p className="text-xs uppercase tracking-[0.5em] text-amber-600 dark:text-amber-200">Live Session</p>
+            <h2 className="text-2xl font-black uppercase tracking-wide text-slate-900 dark:text-white">{session.name}</h2>
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className={connectionBadgeClass}>{connectionLabel}</span>
             {mode === 'dm' && (
               <>
                 <button
-                  className="rounded-full border border-slate-300 px-3 py-1 text-xs font-medium hover:bg-slate-100 dark:border-slate-600 dark:hover:bg-slate-700"
+                  className="inline-flex items-center gap-2 rounded-full border border-teal-400/70 bg-teal-300/60 px-4 py-2 text-[10px] font-semibold uppercase tracking-[0.3em] text-teal-900 transition hover:bg-teal-300/80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-teal-400 dark:border-teal-400/50 dark:bg-teal-400/15 dark:text-teal-100 dark:hover:bg-teal-400/25"
                   onClick={onSaveSession}
                 >
                   Save Snapshot
                 </button>
                 <button
-                  className="rounded-full border border-rose-500 px-3 py-1 text-xs font-medium text-rose-500 hover:bg-rose-500/10"
+                  className="inline-flex items-center gap-2 rounded-full border border-rose-400/70 bg-rose-200/60 px-4 py-2 text-[10px] font-semibold uppercase tracking-[0.3em] text-rose-700 transition hover:bg-rose-200/80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-400 dark:border-rose-400/40 dark:bg-rose-500/20 dark:text-rose-100 dark:hover:bg-rose-500/30"
                   onClick={onEndSession}
                 >
                   End Session
@@ -192,10 +231,10 @@ const SessionViewer: React.FC<SessionViewerProps> = ({
               </>
             )}
             <button
-              className="rounded-full border border-slate-300 px-3 py-1 text-xs font-medium hover:bg-slate-100 dark:border-slate-600 dark:hover:bg-slate-700"
+              className="inline-flex items-center gap-2 rounded-full border border-white/70 bg-white/60 px-4 py-2 text-[10px] font-semibold uppercase tracking-[0.3em] text-slate-700 transition hover:border-amber-400/60 hover:text-amber-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-400 dark:border-slate-700 dark:bg-slate-900/70 dark:text-slate-200 dark:hover:border-amber-400/50 dark:hover:text-amber-200"
               onClick={onLeave}
             >
-              Leave
+              Leave Session
             </button>
           </div>
         </div>
@@ -210,33 +249,48 @@ const SessionViewer: React.FC<SessionViewerProps> = ({
           onToggleRegion={handleToggleRegion}
           onPlaceMarker={mode === 'dm' ? handlePlaceMarker : undefined}
         />
-      </div>
-      <div className="space-y-6">
-        <section>
-          <h3 className="mb-2 text-sm font-semibold uppercase tracking-wide text-slate-500">Players</h3>
-          <ul className="space-y-1 text-sm">
+      </section>
+      <aside className="space-y-5">
+        <section className="rounded-3xl border border-white/60 bg-white/70 p-5 shadow-lg shadow-amber-500/20 backdrop-blur-sm dark:border-slate-800/70 dark:bg-slate-950/70 dark:shadow-black/40">
+          <h3 className="text-xs uppercase tracking-[0.4em] text-slate-600 dark:text-slate-400">Players</h3>
+          <ul className="mt-3 space-y-2 text-sm">
             {state.players.map((player) => (
-              <li key={player.id} className="rounded border border-slate-200 px-3 py-1 dark:border-slate-700">
-                <span className="font-medium">{player.name}</span>
-                <span className="ml-2 text-xs uppercase text-slate-500">{player.role}</span>
+              <li
+                key={player.id}
+                className="flex items-center justify-between rounded-2xl border border-white/60 bg-white/70 px-4 py-2 text-sm text-slate-800 shadow-sm shadow-amber-500/10 dark:border-slate-800/70 dark:bg-slate-950/70 dark:text-slate-100"
+              >
+                <span className="font-semibold">{player.name}</span>
+                <span className="text-[10px] uppercase tracking-[0.3em] text-slate-500 dark:text-slate-400">{player.role}</span>
               </li>
             ))}
-            {state.players.length === 0 && <li className="text-xs text-slate-500">Waiting for players…</li>}
+            {state.players.length === 0 && (
+              <li className="rounded-2xl border border-dashed border-white/60 bg-white/40 px-4 py-3 text-xs text-slate-500 dark:border-slate-800/70 dark:bg-slate-900/40 dark:text-slate-400">
+                Waiting for players…
+              </li>
+            )}
           </ul>
         </section>
-        <section>
-          <h3 className="mb-2 text-sm font-semibold uppercase tracking-wide text-slate-500">Regions</h3>
-          <RegionList
-            regions={regions}
-            revealedRegionIds={state.revealedRegions}
-            onToggleRegion={mode === 'dm' ? handleToggleRegion : undefined}
-          />
+        <section className="rounded-3xl border border-white/60 bg-white/70 p-5 shadow-lg shadow-amber-500/20 backdrop-blur-sm dark:border-slate-800/70 dark:bg-slate-950/70 dark:shadow-black/40">
+          <h3 className="text-xs uppercase tracking-[0.4em] text-slate-600 dark:text-slate-400">Regions</h3>
+          <div className="mt-3">
+            <RegionList
+              regions={regions}
+              revealedRegionIds={state.revealedRegions}
+              onToggleRegion={mode === 'dm' ? handleToggleRegion : undefined}
+            />
+          </div>
         </section>
-        <section>
-          <h3 className="mb-2 text-sm font-semibold uppercase tracking-wide text-slate-500">Markers</h3>
-          <MarkerPanel markers={resolvedMarkers} onRemove={mode === 'dm' ? handleRemoveMarker : undefined} onUpdate={mode === 'dm' ? handleUpdateMarker : undefined} />
+        <section className="rounded-3xl border border-white/60 bg-white/70 p-5 shadow-lg shadow-amber-500/20 backdrop-blur-sm dark:border-slate-800/70 dark:bg-slate-950/70 dark:shadow-black/40">
+          <h3 className="text-xs uppercase tracking-[0.4em] text-slate-600 dark:text-slate-400">Markers</h3>
+          <div className="mt-3">
+            <MarkerPanel
+              markers={resolvedMarkers}
+              onRemove={mode === 'dm' ? handleRemoveMarker : undefined}
+              onUpdate={mode === 'dm' ? handleUpdateMarker : undefined}
+            />
+          </div>
         </section>
-      </div>
+      </aside>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- refresh the session viewer layout with glassmorphism surfaces, themed controls, and a status badge that matches the landing page aesthetic
- restyle the region and marker panels so buttons, typography, and empty states use the same amber/rose accents as the rest of the app
- update the map canvas frame and marker badges to share the translucent surfaces used across the experience

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd8a2b9bb8832387dce0eb25597ab6