### PR TITLE
Align console theme with landing page palette

### DIFF
--- a/apps/pages/src/components/MapCreationWizard.tsx
+++ b/apps/pages/src/components/MapCreationWizard.tsx
@@ -694,7 +694,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
       <header className="mb-0.5 border-b border-slate-800/70 px-5 py-3">
         <div className="flex flex-wrap items-center justify-between gap-4">
           <div>
-            <p className="text-xs uppercase tracking-[0.4em] text-teal-300">New Map Wizard</p>
+            <p className="text-xs uppercase tracking-[0.4em] text-amber-300">New Map Wizard</p>
             <h2 className="text-2xl font-bold text-white">{steps[step].title}</h2>
             <p className="text-sm text-slate-400">{steps[step].description}</p>
           </div>
@@ -715,9 +715,9 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                 key={item.title}
                 className={`flex items-center gap-3 rounded-full border px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] transition ${
                   isActive
-                    ? 'border-teal-400/70 bg-teal-500/20 text-teal-100'
+                    ? 'border-amber-400/60 bg-amber-500/10 text-amber-100 shadow shadow-amber-500/20'
                     : isComplete
-                    ? 'border-slate-700/70 bg-slate-800/80 text-slate-200'
+                    ? 'border-amber-400/40 bg-amber-500/5 text-amber-200'
                     : 'border-slate-800/70 bg-slate-900/80 text-slate-500'
                 }`}
               >
@@ -744,7 +744,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                   onDragEnter={(event) => event.preventDefault()}
                   onDragOver={(event) => event.preventDefault()}
                   onDrop={handleDrop}
-                  className="group relative flex min-h-[200px] flex-col items-center justify-center rounded-2xl border-2 border-dashed border-slate-700/70 bg-slate-950/70 px-6 py-8 transition hover:border-teal-400/60"
+                  className="group relative flex min-h-[200px] flex-col items-center justify-center rounded-2xl border-2 border-dashed border-slate-700/70 bg-slate-950/70 px-6 py-8 transition hover:border-amber-400/60"
                 >
                   <input
                     ref={fileInputRef}
@@ -766,14 +766,14 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                   <button
                     type="button"
                     onClick={handleBrowse}
-                    className="mt-5 rounded-full border border-teal-400/60 bg-teal-500/80 px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-teal-400/90"
+                    className="mt-5 rounded-full border border-amber-400/60 bg-gradient-to-r from-amber-500 via-orange-500 to-rose-500 px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-white shadow-lg shadow-amber-500/20 transition hover:from-amber-400 hover:via-orange-400 hover:to-rose-400"
                   >
                     Browse Files
                   </button>
                 </div>
                 {previewUrl && (
                   <div className="mt-6">
-                    <p className="text-xs uppercase tracking-[0.4em] text-teal-300">Preview</p>
+                    <p className="text-xs uppercase tracking-[0.4em] text-amber-300">Preview</p>
                     <div className="mt-3 overflow-hidden rounded-2xl border border-slate-800/70">
                       <img
                         src={previewUrl}
@@ -802,7 +802,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                         type="text"
                         value={name}
                         onChange={(event) => setName(event.target.value)}
-                        className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                        className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/40"
                         placeholder="Ancient Ruins"
                       />
                     </div>
@@ -812,7 +812,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                         value={description}
                         onChange={(event) => setDescription(event.target.value)}
                         rows={3}
-                        className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                        className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/40"
                         placeholder="Give a brief overview of the map."
                       />
                     </div>
@@ -822,7 +822,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                         type="text"
                         value={grouping}
                         onChange={(event) => setGrouping(event.target.value)}
-                        className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                        className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/40"
                         placeholder="Dungeon Delves"
                       />
                     </div>
@@ -832,7 +832,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                         value={notes}
                         onChange={(event) => setNotes(event.target.value)}
                         rows={3}
-                        className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                        className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/40"
                         placeholder="DM-only reminders or encounter tips"
                       />
                     </div>
@@ -842,7 +842,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                         type="text"
                         value={tagsInput}
                         onChange={(event) => setTagsInput(event.target.value)}
-                        className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                        className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/40"
                         placeholder="forest, ruins, night"
                       />
                       <p className="mt-2 text-xs text-slate-500">Separate tags with commas to help search and filtering.</p>
@@ -918,7 +918,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                             markerDisplayMetrics,
                           ),
                         )}
-                        className="group absolute -translate-x-1/2 -translate-y-1/2 rounded-full border border-white/40 bg-slate-950/80 px-3 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-white shadow-lg transition hover:border-teal-300/80 hover:text-teal-100"
+                        className="group absolute -translate-x-1/2 -translate-y-1/2 rounded-full border border-white/40 bg-slate-950/80 px-3 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-white shadow-lg transition hover:border-amber-300/80 hover:text-amber-100"
                       >
                         {marker.label || 'Marker'}
                       </button>
@@ -945,7 +945,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                     <button
                       type="button"
                       onClick={handleAddMarker}
-                      className="rounded-full border border-teal-400/60 bg-teal-500/80 px-4 py-2 text-[10px] font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-teal-400/90"
+                      className="rounded-full border border-amber-400/60 bg-gradient-to-r from-amber-500 via-orange-500 to-rose-500 px-4 py-2 text-[10px] font-semibold uppercase tracking-[0.3em] text-white shadow-lg shadow-amber-500/20 transition hover:from-amber-400 hover:via-orange-400 hover:to-rose-400"
                     >
                       Add Marker
                     </button>
@@ -962,7 +962,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                         key={marker.id}
                         className={`rounded-2xl border px-4 py-3 transition ${
                           isExpanded
-                            ? 'border-teal-400/60 bg-slate-950/80'
+                            ? 'border-amber-400/60 bg-slate-950/80 shadow shadow-amber-500/10'
                             : 'border-slate-800/70 bg-slate-950/70'
                         }`}
                       >
@@ -991,7 +991,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                           </div>
                           <span
                             className={`text-[10px] uppercase tracking-[0.35em] ${
-                              isExpanded ? 'text-teal-200' : 'text-slate-400'
+                              isExpanded ? 'text-amber-200' : 'text-slate-400'
                             }`}
                           >
                             {isExpanded ? 'Hide' : 'Edit'}
@@ -1007,7 +1007,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                                 onChange={(event) =>
                                   handleMarkerChange(marker.id, 'label', event.target.value)
                                 }
-                                className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-3 py-2 text-xs text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                                className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-3 py-2 text-xs text-slate-100 placeholder:text-slate-600 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/40"
                                 placeholder="Secret Door"
                               />
                             </label>
@@ -1020,7 +1020,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                                     handleMarkerChange(marker.id, 'notes', event.target.value)
                                   }
                                   rows={2}
-                                  className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-3 py-2 text-xs text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                                  className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-3 py-2 text-xs text-slate-100 placeholder:text-slate-600 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/40"
                                   placeholder="Trap trigger, treasure cache, etc."
                                 />
                               </label>
@@ -1032,7 +1032,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                                   onChange={(event) =>
                                     handleMarkerChange(marker.id, 'color', event.target.value)
                                   }
-                                  className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-3 py-2 text-xs text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                                  className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-3 py-2 text-xs text-slate-100 placeholder:text-slate-600 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/40"
                                   placeholder="#facc15"
                                 />
                               </label>
@@ -1068,7 +1068,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
           <button
             type="button"
             onClick={handleBack}
-            className="rounded-full border border-slate-700/70 px-4 py-1.5 text-[11px] font-semibold uppercase tracking-[0.3em] text-slate-300 transition hover:border-teal-400/60 hover:text-teal-200"
+            className="rounded-full border border-slate-700/70 px-4 py-1.5 text-[11px] font-semibold uppercase tracking-[0.3em] text-slate-300 transition hover:border-amber-400/60 hover:text-amber-200"
           >
             {step === 0 ? 'Cancel' : 'Back'}
           </button>
@@ -1081,7 +1081,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                 onClick={handleContinue}
                 className={`rounded-full border px-5 py-1.5 text-[11px] font-semibold uppercase tracking-[0.3em] transition ${
                   allowNext
-                    ? 'border-teal-400/60 bg-teal-500/80 text-slate-900 hover:bg-teal-400/90'
+                    ? 'border-amber-400/60 bg-gradient-to-r from-amber-500 via-orange-500 to-rose-500 text-white shadow shadow-amber-500/20 hover:from-amber-400 hover:via-orange-400 hover:to-rose-400'
                     : 'cursor-not-allowed border-slate-800/70 bg-slate-900/70 text-slate-500'
                 }`}
               >
@@ -1095,7 +1095,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                 className={`rounded-full border px-5 py-1.5 text-[11px] font-semibold uppercase tracking-[0.3em] transition ${
                   creating
                     ? 'cursor-wait border-slate-800/70 bg-slate-900/70 text-slate-500'
-                    : 'border-teal-400/60 bg-teal-500/80 text-slate-900 hover:bg-teal-400/90'
+                    : 'border-amber-400/60 bg-gradient-to-r from-amber-500 via-orange-500 to-rose-500 text-white shadow shadow-amber-500/20 hover:from-amber-400 hover:via-orange-400 hover:to-rose-400'
                 }`}
               >
                 {creating ? 'Creating…' : 'Create Map'}

--- a/apps/pages/src/components/MapFolderList.tsx
+++ b/apps/pages/src/components/MapFolderList.tsx
@@ -77,17 +77,17 @@ const MapFolderList: React.FC<MapFolderListProps> = ({
   };
 
   return (
-    <div className="rounded-2xl border border-slate-800/70 bg-slate-900/70 p-5">
+    <div className="rounded-2xl border border-amber-500/20 bg-slate-950/70 p-5 shadow-xl shadow-amber-500/10">
       <div className="mb-6 flex flex-wrap items-center justify-between gap-4">
         <div>
-          <p className="text-xs uppercase tracking-[0.4em] text-slate-400">Maps</p>
+          <p className="text-xs uppercase tracking-[0.4em] text-amber-300">Maps</p>
           <h3 className="text-2xl font-bold text-white">Campaign Atlas</h3>
-          <p className="text-sm text-slate-400">Organize maps into folders to keep your encounters tidy.</p>
+          <p className="text-sm text-amber-200/70">Organize maps into folders to keep your encounters tidy.</p>
         </div>
         <button
           type="button"
           onClick={onCreateMap}
-          className="rounded-xl border border-teal-400/60 bg-teal-500/80 px-5 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-teal-400/90"
+          className="rounded-xl border border-amber-400/60 bg-gradient-to-r from-amber-500 via-orange-500 to-rose-500 px-5 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-white shadow-lg shadow-amber-500/20 transition hover:from-amber-400 hover:via-orange-400 hover:to-rose-400"
         >
           New Map
         </button>
@@ -101,7 +101,7 @@ const MapFolderList: React.FC<MapFolderListProps> = ({
           {grouped.map((group) => {
             const expanded = expandedGroups[group.name];
             return (
-              <div key={group.name} className="rounded-2xl border border-slate-800/70 bg-slate-950/70 shadow-lg">
+              <div key={group.name} className="rounded-2xl border border-amber-500/20 bg-slate-950/80 shadow-lg shadow-amber-500/10">
                 <div className="flex items-start justify-between gap-3 px-5 py-4 sm:items-center">
                   <button
                     type="button"
@@ -110,11 +110,11 @@ const MapFolderList: React.FC<MapFolderListProps> = ({
                   >
                     <div>
                       <p className="text-lg font-semibold text-white">{group.name}</p>
-                      <p className="text-[10px] uppercase tracking-[0.4em] text-slate-500">{group.maps.length} Maps</p>
+                      <p className="text-[10px] uppercase tracking-[0.4em] text-amber-300/80">{group.maps.length} Maps</p>
                     </div>
                     <span
-                      className={`inline-flex h-8 w-8 items-center justify-center rounded-full border border-slate-700/70 text-xs font-bold text-slate-300 transition ${
-                        expanded ? 'bg-teal-500/10 text-teal-200' : 'bg-slate-900'
+                      className={`inline-flex h-8 w-8 items-center justify-center rounded-full border border-amber-400/30 text-xs font-bold text-amber-100 transition ${
+                        expanded ? 'bg-amber-500/10 text-amber-200' : 'bg-slate-900'
                       }`}
                       aria-hidden="true"
                     >
@@ -135,7 +135,7 @@ const MapFolderList: React.FC<MapFolderListProps> = ({
                   </button>
                 </div>
                 {expanded && (
-                  <div className="grid gap-4 border-t border-slate-800/60 px-5 py-5 sm:grid-cols-2 xl:grid-cols-3">
+                  <div className="grid gap-4 border-t border-amber-500/20 px-5 py-5 sm:grid-cols-2 xl:grid-cols-3">
                     {group.maps.map((map) => {
                       const description = getMetadataString(map.metadata, 'description');
                       const notes = getMetadataString(map.metadata, 'notes');
@@ -153,10 +153,10 @@ const MapFolderList: React.FC<MapFolderListProps> = ({
                               onSelect(map);
                             }
                           }}
-                          className={`group relative overflow-hidden rounded-2xl border px-5 py-6 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-teal-400/60 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 ${
+                          className={`group relative overflow-hidden rounded-2xl border px-5 py-6 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400/60 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 ${
                             selectedMapId === map.id
-                              ? 'border-teal-400 bg-teal-500/10 shadow-[0_0_0_1px_rgba(45,212,191,0.4)]'
-                              : 'border-slate-800/60 bg-slate-950/60 hover:border-teal-400/60 hover:shadow-[0_0_0_1px_rgba(45,212,191,0.3)]'
+                              ? 'border-amber-400 bg-amber-500/10 shadow-[0_0_0_1px_rgba(245,158,11,0.4)]'
+                              : 'border-amber-500/10 bg-slate-950/60 hover:border-amber-400/60 hover:shadow-[0_0_0_1px_rgba(245,158,11,0.3)]'
                           }`}
                         >
                           <div className="absolute right-4 top-4 flex items-center gap-2">
@@ -174,21 +174,21 @@ const MapFolderList: React.FC<MapFolderListProps> = ({
                               ✕
                             </button>
                           </div>
-                          <div className="mb-4 flex items-center justify-between text-xs uppercase tracking-[0.4em] text-slate-500">
+                          <div className="mb-4 flex items-center justify-between text-xs uppercase tracking-[0.4em] text-amber-200/80">
                             <span>Map</span>
                             <span>
                               {map.width ?? '—'} × {map.height ?? '—'}
                             </span>
                           </div>
                           <h4 className="text-lg font-semibold text-white">{map.name}</h4>
-                          {description && <p className="mt-2 text-sm text-slate-300">{description}</p>}
-                          {notes && !description && <p className="mt-2 text-sm text-slate-400">{notes}</p>}
+                          {description && <p className="mt-2 text-sm text-amber-100/80">{description}</p>}
+                          {notes && !description && <p className="mt-2 text-sm text-amber-100/60">{notes}</p>}
                           {tags.length > 0 && (
                             <div className="mt-4 flex flex-wrap gap-2">
                               {tags.map((tag) => (
                                 <span
                                   key={tag}
-                                  className="inline-flex items-center rounded-full border border-slate-700/70 bg-slate-900/70 px-2 py-1 text-[10px] uppercase tracking-[0.3em] text-slate-300"
+                                  className="inline-flex items-center rounded-full border border-amber-400/30 bg-slate-900/70 px-2 py-1 text-[10px] uppercase tracking-[0.3em] text-amber-200"
                                 >
                                   {tag}
                                 </span>

--- a/apps/pages/src/components/MarkerPanel.tsx
+++ b/apps/pages/src/components/MarkerPanel.tsx
@@ -13,7 +13,7 @@ const MarkerPanel: React.FC<MarkerPanelProps> = ({ markers, onRemove, onUpdate }
       {markers.map((marker) => (
         <div
           key={marker.id}
-          className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm dark:border-slate-700 dark:bg-slate-800"
+          className="rounded-xl border border-amber-200/70 bg-white/80 px-3 py-2 text-sm shadow-sm shadow-amber-500/10 transition-colors dark:border-amber-500/30 dark:bg-slate-950/60"
         >
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
@@ -23,20 +23,20 @@ const MarkerPanel: React.FC<MarkerPanelProps> = ({ markers, onRemove, onUpdate }
               />
               <div>
                 <p className="font-medium">{marker.label}</p>
-                <p className="text-xs text-slate-500 dark:text-slate-400">
+                <p className="text-xs text-slate-500 dark:text-amber-200/70">
                   ({Math.round((marker.x ?? 0) * 100)}%, {Math.round((marker.y ?? 0) * 100)}%)
                 </p>
               </div>
             </div>
             <div className="flex items-center gap-2">
               <button
-                className="rounded-full border border-slate-300 px-2 py-1 text-xs text-slate-600 hover:bg-slate-100 dark:border-slate-600 dark:text-slate-300 dark:hover:bg-slate-700"
+                className="rounded-full border border-amber-300/70 px-2 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-amber-700 transition hover:bg-amber-50/70 dark:border-amber-500/40 dark:text-amber-200 dark:hover:bg-amber-500/10"
                 onClick={() => onUpdate?.(marker)}
               >
                 Edit
               </button>
               <button
-                className="rounded-full bg-rose-500 px-2 py-1 text-xs text-white hover:bg-rose-600"
+                className="rounded-full bg-rose-500 px-2 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-white transition hover:bg-rose-600"
                 onClick={() => onRemove?.(marker.id)}
               >
                 Remove
@@ -46,7 +46,7 @@ const MarkerPanel: React.FC<MarkerPanelProps> = ({ markers, onRemove, onUpdate }
           {marker.description && <p className="mt-2 text-xs opacity-75">{marker.description}</p>}
         </div>
       ))}
-      {markers.length === 0 && <p className="text-sm text-slate-500">No markers placed.</p>}
+      {markers.length === 0 && <p className="text-sm text-amber-600 dark:text-amber-200/70">No markers placed.</p>}
     </div>
   );
 };

--- a/apps/pages/src/components/RegionList.tsx
+++ b/apps/pages/src/components/RegionList.tsx
@@ -16,15 +16,15 @@ const RegionList: React.FC<RegionListProps> = ({ regions, revealedRegionIds, onT
         return (
           <div
             key={region.id}
-            className={`flex items-start justify-between rounded-lg border px-3 py-2 text-sm shadow-sm transition hover:border-primary/60 hover:shadow ${
+            className={`flex items-start justify-between rounded-xl border px-3 py-2 text-sm shadow-sm shadow-amber-500/10 transition hover:border-primary/60 hover:shadow-lg ${
               revealed
-                ? 'border-emerald-400/60 bg-emerald-100/20 text-emerald-900 dark:border-emerald-500/40 dark:bg-emerald-500/10 dark:text-emerald-100'
-                : 'border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-800'
+                ? 'border-amber-400/70 bg-amber-100/20 text-amber-900 dark:border-amber-400/40 dark:bg-amber-500/10 dark:text-amber-100'
+                : 'border-amber-200/40 bg-white/80 dark:border-amber-500/20 dark:bg-slate-950/60'
             }`}
           >
             <div>
               <button
-                className="font-medium hover:underline"
+                className="font-semibold text-slate-800 hover:text-amber-700 hover:underline dark:text-amber-50 dark:hover:text-amber-200"
                 onClick={() => onSelectRegion?.(region)}
               >
                 {region.name}
@@ -34,8 +34,8 @@ const RegionList: React.FC<RegionListProps> = ({ regions, revealedRegionIds, onT
             <button
               className={`rounded-full px-3 py-1 text-xs font-semibold ${
                 revealed
-                  ? 'bg-emerald-500 text-white hover:bg-emerald-600'
-                  : 'bg-primary text-white hover:bg-primary-dark'
+                  ? 'bg-rose-500 text-white hover:bg-rose-600'
+                  : 'bg-gradient-to-r from-amber-500 via-orange-500 to-rose-500 text-white shadow shadow-amber-500/20 hover:from-amber-400 hover:via-orange-400 hover:to-rose-400'
               }`}
               onClick={() => onToggleRegion?.(region, !revealed)}
             >

--- a/apps/pages/src/components/SessionViewer.tsx
+++ b/apps/pages/src/components/SessionViewer.tsx
@@ -169,22 +169,22 @@ const SessionViewer: React.FC<SessionViewerProps> = ({
       <div className="lg:col-span-2 space-y-4">
         <div className="flex items-center justify-between">
           <div>
-            <h2 className="text-lg font-semibold">{session.name}</h2>
-            <p className="text-sm text-slate-500 dark:text-slate-400">
-              Connection: <span className="font-medium text-primary">{connectionState}</span>
+            <h2 className="text-lg font-semibold text-slate-900 dark:text-white">{session.name}</h2>
+            <p className="text-sm text-amber-700 dark:text-amber-200/80">
+              Connection: <span className="font-semibold text-primary">{connectionState}</span>
             </p>
           </div>
           <div className="flex items-center gap-2">
             {mode === 'dm' && (
               <>
                 <button
-                  className="rounded-full border border-slate-300 px-3 py-1 text-xs font-medium hover:bg-slate-100 dark:border-slate-600 dark:hover:bg-slate-700"
+                  className="rounded-full border border-amber-300/70 bg-white/80 px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-amber-700 transition hover:bg-amber-50/70 dark:border-amber-500/40 dark:bg-slate-900/60 dark:text-amber-200 dark:hover:bg-amber-500/10"
                   onClick={onSaveSession}
                 >
                   Save Snapshot
                 </button>
                 <button
-                  className="rounded-full border border-rose-500 px-3 py-1 text-xs font-medium text-rose-500 hover:bg-rose-500/10"
+                  className="rounded-full border border-rose-500 px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-rose-100 transition hover:bg-rose-500/20"
                   onClick={onEndSession}
                 >
                   End Session
@@ -192,7 +192,7 @@ const SessionViewer: React.FC<SessionViewerProps> = ({
               </>
             )}
             <button
-              className="rounded-full border border-slate-300 px-3 py-1 text-xs font-medium hover:bg-slate-100 dark:border-slate-600 dark:hover:bg-slate-700"
+              className="rounded-full border border-amber-300/70 bg-white/80 px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-amber-700 transition hover:bg-amber-50/70 dark:border-amber-500/40 dark:bg-slate-900/60 dark:text-amber-200 dark:hover:bg-amber-500/10"
               onClick={onLeave}
             >
               Leave
@@ -213,19 +213,19 @@ const SessionViewer: React.FC<SessionViewerProps> = ({
       </div>
       <div className="space-y-6">
         <section>
-          <h3 className="mb-2 text-sm font-semibold uppercase tracking-wide text-slate-500">Players</h3>
+          <h3 className="mb-2 text-sm font-semibold uppercase tracking-[0.4em] text-amber-400">Players</h3>
           <ul className="space-y-1 text-sm">
             {state.players.map((player) => (
-              <li key={player.id} className="rounded border border-slate-200 px-3 py-1 dark:border-slate-700">
-                <span className="font-medium">{player.name}</span>
-                <span className="ml-2 text-xs uppercase text-slate-500">{player.role}</span>
+              <li key={player.id} className="rounded-xl border border-amber-200/50 bg-white/70 px-3 py-1 text-slate-800 shadow-sm shadow-amber-500/10 dark:border-amber-500/30 dark:bg-slate-950/60 dark:text-amber-50">
+                <span className="font-semibold">{player.name}</span>
+                <span className="ml-2 text-xs uppercase tracking-[0.2em] text-amber-500 dark:text-amber-200/80">{player.role}</span>
               </li>
             ))}
-            {state.players.length === 0 && <li className="text-xs text-slate-500">Waiting for players…</li>}
+            {state.players.length === 0 && <li className="text-xs text-amber-600 dark:text-amber-200/70">Waiting for players…</li>}
           </ul>
         </section>
         <section>
-          <h3 className="mb-2 text-sm font-semibold uppercase tracking-wide text-slate-500">Regions</h3>
+          <h3 className="mb-2 text-sm font-semibold uppercase tracking-[0.4em] text-amber-400">Regions</h3>
           <RegionList
             regions={regions}
             revealedRegionIds={state.revealedRegions}
@@ -233,7 +233,7 @@ const SessionViewer: React.FC<SessionViewerProps> = ({
           />
         </section>
         <section>
-          <h3 className="mb-2 text-sm font-semibold uppercase tracking-wide text-slate-500">Markers</h3>
+          <h3 className="mb-2 text-sm font-semibold uppercase tracking-[0.4em] text-amber-400">Markers</h3>
           <MarkerPanel markers={resolvedMarkers} onRemove={mode === 'dm' ? handleRemoveMarker : undefined} onUpdate={mode === 'dm' ? handleUpdateMarker : undefined} />
         </section>
       </div>

--- a/apps/pages/src/components/Toolbar.tsx
+++ b/apps/pages/src/components/Toolbar.tsx
@@ -44,15 +44,15 @@ const Toolbar: React.FC<ToolbarProps> = ({
   };
 
   return (
-    <div className="flex flex-col gap-4 rounded-lg border border-slate-200 bg-white/80 p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900/70">
+    <div className="flex flex-col gap-4 rounded-2xl border border-amber-200/60 bg-white/80 p-4 shadow-lg shadow-amber-500/10 transition-colors dark:border-amber-500/30 dark:bg-slate-950/70">
       <div className="flex items-center justify-between" role="group" aria-label="Selection tools">
         <div className="flex gap-2">
           <button
             type="button"
-            className={`rounded-md px-3 py-2 text-sm font-medium transition ${
+            className={`rounded-xl border px-3 py-2 text-sm font-semibold uppercase tracking-[0.2em] transition ${
               activeTool === 'magneticLasso'
-                ? 'bg-indigo-600 text-white shadow'
-                : 'bg-slate-100 text-slate-700 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700'
+                ? 'border-transparent bg-gradient-to-r from-amber-500 via-orange-500 to-rose-500 text-white shadow-lg shadow-amber-500/30'
+                : 'border-amber-200/60 bg-white/80 text-amber-700 hover:border-amber-300/70 hover:bg-amber-50/70 dark:border-amber-500/30 dark:bg-slate-900/60 dark:text-amber-200 dark:hover:bg-amber-500/10'
             }`}
             aria-pressed={activeTool === 'magneticLasso'}
             onClick={() => onToolChange('magneticLasso')}
@@ -61,10 +61,10 @@ const Toolbar: React.FC<ToolbarProps> = ({
           </button>
           <button
             type="button"
-            className={`rounded-md px-3 py-2 text-sm font-medium transition ${
+            className={`rounded-xl border px-3 py-2 text-sm font-semibold uppercase tracking-[0.2em] transition ${
               activeTool === 'smartWand'
-                ? 'bg-indigo-600 text-white shadow'
-                : 'bg-slate-100 text-slate-700 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700'
+                ? 'border-transparent bg-gradient-to-r from-amber-500 via-orange-500 to-rose-500 text-white shadow-lg shadow-amber-500/30'
+                : 'border-amber-200/60 bg-white/80 text-amber-700 hover:border-amber-300/70 hover:bg-amber-50/70 dark:border-amber-500/30 dark:bg-slate-900/60 dark:text-amber-200 dark:hover:bg-amber-500/10'
             }`}
             aria-pressed={activeTool === 'smartWand'}
             onClick={() => onToolChange('smartWand')}
@@ -74,7 +74,7 @@ const Toolbar: React.FC<ToolbarProps> = ({
         </div>
       </div>
       <div className="grid grid-cols-1 gap-3" aria-label="Advanced selection settings">
-        <label className="flex flex-col gap-1 text-sm font-medium text-slate-700 dark:text-slate-200">
+        <label className="flex flex-col gap-1 text-sm font-semibold text-slate-700 dark:text-amber-100">
           Edge contrast emphasis
           <input
             type="range"
@@ -85,11 +85,11 @@ const Toolbar: React.FC<ToolbarProps> = ({
             onChange={(event) => updateSetting('edgeContrast', parseFloat(event.currentTarget.value))}
             aria-label="Edge contrast emphasis"
           />
-          <span className="text-xs font-normal text-slate-500 dark:text-slate-400">
+          <span className="text-xs font-normal text-slate-500 dark:text-amber-200/70">
             Higher values increase the CLAHE contrast boost for the worker pipeline.
           </span>
         </label>
-        <label className="flex flex-col gap-1 text-sm font-medium text-slate-700 dark:text-slate-200">
+        <label className="flex flex-col gap-1 text-sm font-semibold text-slate-700 dark:text-amber-100">
           Snap strength
           <input
             type="range"
@@ -100,11 +100,11 @@ const Toolbar: React.FC<ToolbarProps> = ({
             onChange={(event) => updateSetting('snapStrength', parseFloat(event.currentTarget.value))}
             aria-label="Snap strength"
           />
-          <span className="text-xs font-normal text-slate-500 dark:text-slate-400">
+          <span className="text-xs font-normal text-slate-500 dark:text-amber-200/70">
             Controls how aggressively polygons snap to the cost pyramid edges.
           </span>
         </label>
-        <label className="flex items-center gap-2 text-sm font-medium text-slate-700 dark:text-slate-200">
+        <label className="flex items-center gap-2 text-sm font-semibold text-slate-700 dark:text-amber-100">
           <input
             type="checkbox"
             checked={settings.autoEntranceLock}
@@ -112,7 +112,7 @@ const Toolbar: React.FC<ToolbarProps> = ({
           />
           Auto-lock detected entrances
         </label>
-        <label className="flex items-center gap-2 text-sm font-medium text-slate-700 dark:text-slate-200">
+        <label className="flex items-center gap-2 text-sm font-semibold text-slate-700 dark:text-amber-100">
           <input
             type="checkbox"
             checked={settings.livePreview}
@@ -120,7 +120,7 @@ const Toolbar: React.FC<ToolbarProps> = ({
           />
           Live preview updates
         </label>
-        <label className="flex items-center gap-2 text-sm font-medium text-slate-700 dark:text-slate-200">
+        <label className="flex items-center gap-2 text-sm font-semibold text-slate-700 dark:text-amber-100">
           <input
             type="checkbox"
             checked={settings.showDebugOverlay}

--- a/apps/pages/tailwind.config.cjs
+++ b/apps/pages/tailwind.config.cjs
@@ -5,9 +5,14 @@ module.exports = {
     extend: {
       colors: {
         primary: {
-          DEFAULT: '#6366f1',
-          light: '#818cf8',
-          dark: '#4f46e5',
+          DEFAULT: '#f59e0b',
+          light: '#fbbf24',
+          dark: '#d97706',
+        },
+        accent: {
+          DEFAULT: '#f97316',
+          soft: '#fed7aa',
+          deep: '#ea580c',
         },
       },
     },


### PR DESCRIPTION
## Summary
- refresh the Tailwind palette to use the landing page amber and orange tones across the app
- retheme post-login components (toolbar, session viewer, lists, panels) to share the new warm gradient styling
- update the map creation wizard visuals so every step and button matches the landing experience without altering layout or flow

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd95e046448323b9288244b0f0c5d7