### PR TITLE
Align app theming with landing experience

### DIFF
--- a/apps/pages/src/components/MapCreationWizard.tsx
+++ b/apps/pages/src/components/MapCreationWizard.tsx
@@ -690,18 +690,18 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex flex-col bg-slate-950/95 backdrop-blur-sm">
-      <header className="mb-0.5 border-b border-slate-800/70 px-5 py-3">
+    <div className="fixed inset-0 z-50 flex flex-col bg-gradient-to-br from-slate-950/95 via-slate-900/90 to-slate-950/95 backdrop-blur-xl">
+      <header className="mb-0.5 border-b border-amber-400/20 bg-slate-950/40 px-6 py-4 shadow-[inset_0_-1px_0_rgba(251,191,36,0.15)]">
         <div className="flex flex-wrap items-center justify-between gap-4">
           <div>
-            <p className="text-xs uppercase tracking-[0.4em] text-teal-300">New Map Wizard</p>
+            <p className="text-xs uppercase tracking-[0.4em] text-amber-300">New Map Wizard</p>
             <h2 className="text-2xl font-bold text-white">{steps[step].title}</h2>
-            <p className="text-sm text-slate-400">{steps[step].description}</p>
+            <p className="text-sm text-slate-300">{steps[step].description}</p>
           </div>
           <button
             type="button"
             onClick={onClose}
-            className="rounded-full border border-slate-700/70 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-300 transition hover:border-rose-400/60 hover:text-rose-200"
+            className="rounded-full border border-white/30 bg-white/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-amber-100 transition hover:border-rose-400/50 hover:bg-rose-400/10 hover:text-rose-100"
           >
             Exit Wizard
           </button>
@@ -715,10 +715,10 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                 key={item.title}
                 className={`flex items-center gap-3 rounded-full border px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] transition ${
                   isActive
-                    ? 'border-teal-400/70 bg-teal-500/20 text-teal-100'
+                    ? 'border-amber-400/70 bg-amber-300/20 text-amber-100'
                     : isComplete
-                    ? 'border-slate-700/70 bg-slate-800/80 text-slate-200'
-                    : 'border-slate-800/70 bg-slate-900/80 text-slate-500'
+                    ? 'border-white/30 bg-white/10 text-slate-100'
+                    : 'border-white/20 bg-white/5 text-slate-400'
                 }`}
               >
                 <span className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-current">
@@ -739,12 +739,12 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
           <div className="flex h-full flex-1 flex-col overflow-x-visible overflow-y-hidden px-[10vw]">
           {step === 0 && (
             <div className="flex flex-1 items-center justify-center">
-              <div className="w-full max-w-4xl rounded-3xl border border-slate-800/70 bg-slate-900/70 p-8 text-center">
+              <div className="w-full max-w-4xl rounded-3xl border border-white/20 bg-white/10 p-10 text-center shadow-2xl shadow-amber-500/15 backdrop-blur-2xl dark:border-slate-800/70 dark:bg-slate-950/70 dark:shadow-black/40">
                 <div
                   onDragEnter={(event) => event.preventDefault()}
                   onDragOver={(event) => event.preventDefault()}
                   onDrop={handleDrop}
-                  className="group relative flex min-h-[200px] flex-col items-center justify-center rounded-2xl border-2 border-dashed border-slate-700/70 bg-slate-950/70 px-6 py-8 transition hover:border-teal-400/60"
+                  className="group relative flex min-h-[220px] flex-col items-center justify-center rounded-2xl border-2 border-dashed border-amber-300/70 bg-white/70 px-6 py-8 text-slate-900 transition hover:border-amber-400/80 dark:border-amber-400/40 dark:bg-slate-950/70 dark:text-amber-100"
                 >
                   <input
                     ref={fileInputRef}
@@ -758,23 +758,23 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                       }
                     }}
                   />
-                  <p className="text-sm uppercase tracking-[0.4em] text-slate-500">Drag &amp; Drop</p>
-                  <h3 className="mt-3 text-2xl font-semibold text-white">Drop your map image here</h3>
-                  <p className="mt-2 max-w-xl text-sm text-slate-400">
+                  <p className="text-sm uppercase tracking-[0.4em] text-amber-500 dark:text-amber-200">Drag &amp; Drop</p>
+                  <h3 className="mt-3 text-2xl font-semibold text-slate-900 dark:text-white">Drop your map image here</h3>
+                  <p className="mt-2 max-w-xl text-sm text-slate-600 dark:text-slate-300">
                     We accept PNG, JPG, WEBP, and other common image formats. Drop the file or browse your computer to get started.
                   </p>
                   <button
                     type="button"
                     onClick={handleBrowse}
-                    className="mt-5 rounded-full border border-teal-400/60 bg-teal-500/80 px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-teal-400/90"
+                    className="mt-6 rounded-full border border-amber-400/70 bg-amber-300/80 px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-slate-900 shadow-sm transition hover:bg-amber-300/90 dark:border-amber-400/50 dark:bg-amber-400/20 dark:text-amber-100 dark:hover:bg-amber-400/30"
                   >
                     Browse Files
                   </button>
                 </div>
                 {previewUrl && (
                   <div className="mt-6">
-                    <p className="text-xs uppercase tracking-[0.4em] text-teal-300">Preview</p>
-                    <div className="mt-3 overflow-hidden rounded-2xl border border-slate-800/70">
+                    <p className="text-xs uppercase tracking-[0.4em] text-amber-400">Preview</p>
+                    <div className="mt-3 overflow-hidden rounded-2xl border border-white/30 bg-white/10 shadow-lg shadow-amber-500/10 dark:border-slate-800/70 dark:bg-slate-950/70">
                       <img
                         src={previewUrl}
                         alt="Uploaded map preview"
@@ -782,7 +782,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                       />
                     </div>
                     {imageDimensions && (
-                      <p className="mt-2 text-xs uppercase tracking-[0.4em] text-slate-500">
+                      <p className="mt-2 text-xs uppercase tracking-[0.4em] text-slate-400">
                         {imageDimensions.width} × {imageDimensions.height} pixels
                       </p>
                     )}
@@ -793,63 +793,63 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
           )}
           {step === 1 && (
             <div className="flex flex-1 items-stretch justify-center">
-              <div className="flex h-full w-full flex-col rounded-3xl border border-slate-800/70 bg-slate-900/70 p-8">
+              <div className="flex h-full w-full flex-col rounded-3xl border border-white/20 bg-white/10 p-8 shadow-2xl shadow-amber-500/10 backdrop-blur-2xl dark:border-slate-800/70 dark:bg-slate-950/70">
                 <div className="grid flex-1 min-h-0 gap-6 md:grid-cols-[minmax(0,1fr)_260px]">
                   <div className="flex flex-col gap-5">
                     <div>
-                      <label className="block text-xs uppercase tracking-[0.4em] text-slate-400">Map Name</label>
+                      <label className="block text-xs uppercase tracking-[0.4em] text-amber-200">Map Name</label>
                       <input
                         type="text"
                         value={name}
                         onChange={(event) => setName(event.target.value)}
-                        className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                        className="mt-2 w-full rounded-xl border border-white/20 bg-white/10 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-500 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/30 dark:border-slate-800/70 dark:bg-slate-950/70 dark:text-slate-100"
                         placeholder="Ancient Ruins"
                       />
                     </div>
                     <div>
-                      <label className="block text-xs uppercase tracking-[0.4em] text-slate-400">Description</label>
+                      <label className="block text-xs uppercase tracking-[0.4em] text-amber-200">Description</label>
                       <textarea
                         value={description}
                         onChange={(event) => setDescription(event.target.value)}
                         rows={3}
-                        className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                        className="mt-2 w-full rounded-xl border border-white/20 bg-white/10 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-500 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/30 dark:border-slate-800/70 dark:bg-slate-950/70"
                         placeholder="Give a brief overview of the map."
                       />
                     </div>
                     <div>
-                      <label className="block text-xs uppercase tracking-[0.4em] text-slate-400">Grouping</label>
+                      <label className="block text-xs uppercase tracking-[0.4em] text-amber-200">Grouping</label>
                       <input
                         type="text"
                         value={grouping}
                         onChange={(event) => setGrouping(event.target.value)}
-                        className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                        className="mt-2 w-full rounded-xl border border-white/20 bg-white/10 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-500 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/30 dark:border-slate-800/70 dark:bg-slate-950/70"
                         placeholder="Dungeon Delves"
                       />
                     </div>
                     <div>
-                      <label className="block text-xs uppercase tracking-[0.4em] text-slate-400">Notes</label>
+                      <label className="block text-xs uppercase tracking-[0.4em] text-amber-200">Notes</label>
                       <textarea
                         value={notes}
                         onChange={(event) => setNotes(event.target.value)}
                         rows={3}
-                        className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                        className="mt-2 w-full rounded-xl border border-white/20 bg-white/10 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-500 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/30 dark:border-slate-800/70 dark:bg-slate-950/70"
                         placeholder="DM-only reminders or encounter tips"
                       />
                     </div>
                     <div>
-                      <label className="block text-xs uppercase tracking-[0.4em] text-slate-400">Tags</label>
+                      <label className="block text-xs uppercase tracking-[0.4em] text-amber-200">Tags</label>
                       <input
                         type="text"
                         value={tagsInput}
                         onChange={(event) => setTagsInput(event.target.value)}
-                        className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                        className="mt-2 w-full rounded-xl border border-white/20 bg-white/10 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-500 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/30 dark:border-slate-800/70 dark:bg-slate-950/70"
                         placeholder="forest, ruins, night"
                       />
-                      <p className="mt-2 text-xs text-slate-500">Separate tags with commas to help search and filtering.</p>
+                      <p className="mt-2 text-xs text-slate-400">Separate tags with commas to help search and filtering.</p>
                     </div>
                   </div>
                   <div className="flex h-full flex-col gap-4">
-                    <div className="flex flex-1 items-center justify-center overflow-hidden rounded-2xl border border-slate-800/70 bg-slate-950/70">
+                    <div className="flex flex-1 items-center justify-center overflow-hidden rounded-2xl border border-white/20 bg-white/5">
                       {previewUrl ? (
                         <img
                           src={previewUrl}
@@ -857,14 +857,14 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                           className="max-h-full w-full object-contain"
                         />
                       ) : (
-                        <p className="text-xs uppercase tracking-[0.4em] text-slate-500">
+                        <p className="text-xs uppercase tracking-[0.4em] text-slate-400">
                           Upload a map image to preview it here.
                         </p>
                       )}
                     </div>
-                    <div className="rounded-2xl border border-slate-800/70 bg-slate-950/70 p-4">
-                      <p className="text-xs uppercase tracking-[0.4em] text-slate-400">Tips</p>
-                      <ul className="mt-2 space-y-2 text-xs text-slate-400">
+                    <div className="rounded-2xl border border-white/20 bg-white/5 p-4">
+                      <p className="text-xs uppercase tracking-[0.4em] text-amber-200">Tips</p>
+                      <ul className="mt-2 space-y-2 text-xs text-slate-300">
                         <li>Keep names short but descriptive for quick reference during sessions.</li>
                         <li>Use notes to capture secrets, traps, or DM-only reminders.</li>
                         <li>Tags help you filter maps later in the campaign dashboard.</li>
@@ -877,11 +877,11 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
           )}
           {step === 2 && (
             <div className="flex h-full min-h-0 flex-1 justify-center">
-              <div className="flex h-full min-h-0 w-full rounded-3xl border border-slate-800/70 bg-slate-900/70 p-4">
+              <div className="flex h-full min-h-0 w-full rounded-3xl border border-white/20 bg-white/10 p-4 shadow-2xl shadow-amber-500/10 backdrop-blur-2xl dark:border-slate-800/70 dark:bg-slate-950/70">
                 <div
                   ref={defineRoomContainerRef}
-                  className={`flex h-full min-h-0 w-full flex-col overflow-visible rounded-2xl border border-slate-800/70 bg-slate-950/80 ${
-                    canLaunchRoomsEditor ? '' : 'items-center justify-center text-sm text-slate-500'
+                  className={`flex h-full min-h-0 w-full flex-col overflow-visible rounded-2xl border border-white/15 bg-slate-950/80 ${
+                    canLaunchRoomsEditor ? '' : 'items-center justify-center text-sm text-slate-400'
                   }`}
                 >
                   {!canLaunchRoomsEditor && (
@@ -892,11 +892,11 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
             </div>
           )}
 {step === 3 && (
-            <div className="grid h-full min-h-0 gap-6 lg:grid-cols-[minmax(0,1fr)_340px]">
-              <div
-                ref={mapAreaRef}
-                className="relative flex h-full min-h-0 max-h-full items-center justify-center overflow-hidden rounded-3xl border border-slate-800/70 bg-slate-900/70"
-              >
+              <div className="grid h-full min-h-0 gap-6 lg:grid-cols-[minmax(0,1fr)_340px]">
+                <div
+                  ref={mapAreaRef}
+                  className="relative flex h-full min-h-0 max-h-full items-center justify-center overflow-hidden rounded-3xl border border-white/20 bg-white/10 shadow-2xl shadow-amber-500/10 backdrop-blur-2xl dark:border-slate-800/70 dark:bg-slate-950/70"
+                >
                 {previewUrl ? (
                   <>
                     <img
@@ -918,7 +918,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                             markerDisplayMetrics,
                           ),
                         )}
-                        className="group absolute -translate-x-1/2 -translate-y-1/2 rounded-full border border-white/40 bg-slate-950/80 px-3 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-white shadow-lg transition hover:border-teal-300/80 hover:text-teal-100"
+                        className="group absolute -translate-x-1/2 -translate-y-1/2 rounded-full border border-white/40 bg-slate-950/80 px-3 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-amber-100 shadow-lg transition hover:border-amber-300/80 hover:text-white"
                       >
                         {marker.label || 'Marker'}
                       </button>
@@ -930,27 +930,27 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                     )}
                   </>
                 ) : (
-                  <div className="flex h-full w-full items-center justify-center text-sm text-slate-400">
+                  <div className="flex h-full w-full items-center justify-center text-sm text-slate-300">
                     Upload a map image to place markers.
                   </div>
                 )}
               </div>
-              <div className="flex h-full min-h-0 flex-col rounded-3xl border border-slate-800/70 bg-slate-900/70">
-                <div className="border-b border-slate-800/70 p-4">
+              <div className="flex h-full min-h-0 flex-col rounded-3xl border border-white/20 bg-white/10 shadow-2xl shadow-amber-500/10 backdrop-blur-2xl dark:border-slate-800/70 dark:bg-slate-950/70">
+                <div className="border-b border-white/15 p-4 dark:border-slate-800/60">
                   <div className="flex items-center justify-between gap-3">
                     <div>
-                      <p className="text-xs uppercase tracking-[0.4em] text-slate-400">Markers</p>
-                      <h3 className="text-lg font-semibold text-white">Drag &amp; Drop Points</h3>
+                      <p className="text-xs uppercase tracking-[0.4em] text-amber-200">Markers</p>
+                      <h3 className="text-lg font-semibold text-amber-100">Drag &amp; Drop Points</h3>
                     </div>
                     <button
                       type="button"
                       onClick={handleAddMarker}
-                      className="rounded-full border border-teal-400/60 bg-teal-500/80 px-4 py-2 text-[10px] font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-teal-400/90"
+                      className="rounded-full border border-amber-400/70 bg-amber-300/80 px-4 py-2 text-[10px] font-semibold uppercase tracking-[0.3em] text-slate-900 shadow-sm transition hover:bg-amber-300/90 dark:border-amber-400/50 dark:bg-amber-400/20 dark:text-amber-100 dark:hover:bg-amber-400/30"
                     >
                       Add Marker
                     </button>
                   </div>
-                  <p className="mt-2 text-xs text-slate-500">
+                  <p className="mt-2 text-xs text-slate-300">
                     Create markers and drag them directly onto the map. Use notes to capture quick reminders.
                   </p>
                 </div>
@@ -962,8 +962,8 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                         key={marker.id}
                         className={`rounded-2xl border px-4 py-3 transition ${
                           isExpanded
-                            ? 'border-teal-400/60 bg-slate-950/80'
-                            : 'border-slate-800/70 bg-slate-950/70'
+                            ? 'border-amber-400/60 bg-white/10 dark:bg-slate-950/70'
+                            : 'border-white/20 bg-white/5 dark:border-slate-800/70 dark:bg-slate-950/70'
                         }`}
                       >
                         <button
@@ -975,14 +975,14 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                           aria-expanded={isExpanded}
                         >
                           <div>
-                            <p className="text-sm font-semibold text-white">{marker.label || 'Marker'}</p>
-                            <div className="mt-1 flex flex-wrap items-center gap-3 text-[10px] uppercase tracking-[0.35em] text-slate-500">
+                            <p className="text-sm font-semibold text-amber-100">{marker.label || 'Marker'}</p>
+                            <div className="mt-1 flex flex-wrap items-center gap-3 text-[10px] uppercase tracking-[0.35em] text-slate-400">
                               <span>
                                 Position: {Math.round(marker.x * 100)}% × {Math.round(marker.y * 100)}%
                               </span>
                               <span className="flex items-center gap-2">
                                 <span
-                                  className="h-3 w-3 rounded-full border border-slate-700/70"
+                                  className="h-3 w-3 rounded-full border border-white/30"
                                   style={{ backgroundColor: marker.color || '#facc15' }}
                                 />
                                 <span>{marker.color}</span>
@@ -991,7 +991,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                           </div>
                           <span
                             className={`text-[10px] uppercase tracking-[0.35em] ${
-                              isExpanded ? 'text-teal-200' : 'text-slate-400'
+                              isExpanded ? 'text-amber-200' : 'text-slate-400'
                             }`}
                           >
                             {isExpanded ? 'Hide' : 'Edit'}
@@ -999,7 +999,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                         </button>
                         {isExpanded && (
                           <div className="mt-3 space-y-3">
-                            <label className="block text-[10px] uppercase tracking-[0.4em] text-slate-500">
+                            <label className="block text-[10px] uppercase tracking-[0.4em] text-amber-200">
                               Label
                               <input
                                 type="text"
@@ -1007,12 +1007,12 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                                 onChange={(event) =>
                                   handleMarkerChange(marker.id, 'label', event.target.value)
                                 }
-                                className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-3 py-2 text-xs text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                                className="mt-2 w-full rounded-xl border border-white/20 bg-white/10 px-3 py-2 text-xs text-slate-100 placeholder:text-slate-500 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/30 dark:border-slate-800/70 dark:bg-slate-950/70"
                                 placeholder="Secret Door"
                               />
                             </label>
                             <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_140px]">
-                              <label className="block text-[10px] uppercase tracking-[0.4em] text-slate-500">
+                              <label className="block text-[10px] uppercase tracking-[0.4em] text-amber-200">
                                 Notes
                                 <textarea
                                   value={marker.notes}
@@ -1020,11 +1020,11 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                                     handleMarkerChange(marker.id, 'notes', event.target.value)
                                   }
                                   rows={2}
-                                  className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-3 py-2 text-xs text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                                  className="mt-2 w-full rounded-xl border border-white/20 bg-white/10 px-3 py-2 text-xs text-slate-100 placeholder:text-slate-500 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/30 dark:border-slate-800/70 dark:bg-slate-950/70"
                                   placeholder="Trap trigger, treasure cache, etc."
                                 />
                               </label>
-                              <label className="block text-[10px] uppercase tracking-[0.4em] text-slate-500">
+                              <label className="block text-[10px] uppercase tracking-[0.4em] text-amber-200">
                                 Color
                                 <input
                                   type="text"
@@ -1032,7 +1032,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                                   onChange={(event) =>
                                     handleMarkerChange(marker.id, 'color', event.target.value)
                                   }
-                                  className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-3 py-2 text-xs text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                                  className="mt-2 w-full rounded-xl border border-white/20 bg-white/10 px-3 py-2 text-xs text-slate-100 placeholder:text-slate-500 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/30 dark:border-slate-800/70 dark:bg-slate-950/70"
                                   placeholder="#facc15"
                                 />
                               </label>
@@ -1041,7 +1041,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                               <button
                                 type="button"
                                 onClick={() => handleRemoveMarker(marker.id)}
-                                className="rounded-full border border-rose-400/60 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.3em] text-rose-200 transition hover:bg-rose-400/20"
+                                className="rounded-full border border-rose-400/70 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.3em] text-rose-200 transition hover:bg-rose-400/20"
                               >
                                 Remove
                               </button>
@@ -1052,7 +1052,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                     );
                   })}
                   {markers.length === 0 && (
-                    <div className="rounded-2xl border border-dashed border-slate-700/70 px-4 py-8 text-center text-xs text-slate-500">
+                    <div className="rounded-2xl border border-dashed border-white/30 px-4 py-8 text-center text-xs text-slate-400">
                       No markers yet. Add a marker to start placing points of interest.
                     </div>
                   )}
@@ -1063,12 +1063,12 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
           </div>
         </div>
       </main>
-      <footer className="mt-0.5 border-t border-slate-800/70 px-5 py-1.5">
+      <footer className="mt-0.5 border-t border-amber-400/20 bg-slate-950/40 px-6 py-2">
         <div className="flex flex-wrap items-center justify-between gap-2">
           <button
             type="button"
             onClick={handleBack}
-            className="rounded-full border border-slate-700/70 px-4 py-1.5 text-[11px] font-semibold uppercase tracking-[0.3em] text-slate-300 transition hover:border-teal-400/60 hover:text-teal-200"
+            className="rounded-full border border-white/30 bg-white/10 px-4 py-1.5 text-[11px] font-semibold uppercase tracking-[0.3em] text-amber-100 transition hover:border-amber-400/60 hover:text-white"
           >
             {step === 0 ? 'Cancel' : 'Back'}
           </button>
@@ -1081,8 +1081,8 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                 onClick={handleContinue}
                 className={`rounded-full border px-5 py-1.5 text-[11px] font-semibold uppercase tracking-[0.3em] transition ${
                   allowNext
-                    ? 'border-teal-400/60 bg-teal-500/80 text-slate-900 hover:bg-teal-400/90'
-                    : 'cursor-not-allowed border-slate-800/70 bg-slate-900/70 text-slate-500'
+                    ? 'border-amber-400/70 bg-amber-300/80 text-slate-900 hover:bg-amber-300/90'
+                    : 'cursor-not-allowed border-white/20 bg-white/5 text-slate-500'
                 }`}
               >
                 Next
@@ -1094,8 +1094,8 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                 disabled={creating}
                 className={`rounded-full border px-5 py-1.5 text-[11px] font-semibold uppercase tracking-[0.3em] transition ${
                   creating
-                    ? 'cursor-wait border-slate-800/70 bg-slate-900/70 text-slate-500'
-                    : 'border-teal-400/60 bg-teal-500/80 text-slate-900 hover:bg-teal-400/90'
+                    ? 'cursor-wait border-white/20 bg-white/5 text-slate-500'
+                    : 'border-amber-400/70 bg-amber-300/80 text-slate-900 hover:bg-amber-300/90'
                 }`}
               >
                 {creating ? 'Creating…' : 'Create Map'}

--- a/apps/pages/src/components/MapFolderList.tsx
+++ b/apps/pages/src/components/MapFolderList.tsx
@@ -77,23 +77,23 @@ const MapFolderList: React.FC<MapFolderListProps> = ({
   };
 
   return (
-    <div className="rounded-2xl border border-slate-800/70 bg-slate-900/70 p-5">
+    <div className="rounded-3xl border border-white/60 bg-white/75 p-6 shadow-2xl shadow-amber-500/15 backdrop-blur-xl dark:border-slate-800/70 dark:bg-slate-950/70 dark:shadow-black/40">
       <div className="mb-6 flex flex-wrap items-center justify-between gap-4">
         <div>
-          <p className="text-xs uppercase tracking-[0.4em] text-slate-400">Maps</p>
-          <h3 className="text-2xl font-bold text-white">Campaign Atlas</h3>
-          <p className="text-sm text-slate-400">Organize maps into folders to keep your encounters tidy.</p>
+          <p className="text-xs uppercase tracking-[0.4em] text-slate-600 dark:text-slate-400">Maps</p>
+          <h3 className="text-2xl font-bold text-slate-900 dark:text-white">Campaign Atlas</h3>
+          <p className="text-sm text-slate-600 dark:text-slate-400">Organize maps into folders to keep your encounters tidy.</p>
         </div>
         <button
           type="button"
           onClick={onCreateMap}
-          className="rounded-xl border border-teal-400/60 bg-teal-500/80 px-5 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-teal-400/90"
+          className="rounded-xl border border-amber-400/70 bg-amber-300/80 px-5 py-2 text-[11px] font-semibold uppercase tracking-[0.3em] text-slate-900 shadow-sm transition hover:bg-amber-300/90 dark:border-amber-400/50 dark:bg-amber-400/20 dark:text-amber-100 dark:hover:bg-amber-400/30"
         >
           New Map
         </button>
       </div>
       {grouped.length === 0 ? (
-        <div className="rounded-xl border border-dashed border-slate-700/70 px-6 py-12 text-center text-sm text-slate-400">
+        <div className="rounded-xl border border-dashed border-white/60 bg-white/60 px-6 py-12 text-center text-sm text-slate-600 dark:border-slate-800/70 dark:bg-slate-950/60 dark:text-slate-400">
           No maps yet. Create a map to start building your world.
         </div>
       ) : (
@@ -101,7 +101,7 @@ const MapFolderList: React.FC<MapFolderListProps> = ({
           {grouped.map((group) => {
             const expanded = expandedGroups[group.name];
             return (
-              <div key={group.name} className="rounded-2xl border border-slate-800/70 bg-slate-950/70 shadow-lg">
+              <div key={group.name} className="rounded-2xl border border-white/60 bg-white/60 shadow-lg shadow-amber-500/10 dark:border-slate-800/70 dark:bg-slate-950/70 dark:shadow-black/40">
                 <div className="flex items-start justify-between gap-3 px-5 py-4 sm:items-center">
                   <button
                     type="button"
@@ -109,12 +109,14 @@ const MapFolderList: React.FC<MapFolderListProps> = ({
                     className="flex w-full flex-1 items-center justify-between gap-4 text-left"
                   >
                     <div>
-                      <p className="text-lg font-semibold text-white">{group.name}</p>
-                      <p className="text-[10px] uppercase tracking-[0.4em] text-slate-500">{group.maps.length} Maps</p>
+                      <p className="text-lg font-semibold text-slate-900 dark:text-white">{group.name}</p>
+                      <p className="text-[10px] uppercase tracking-[0.4em] text-slate-500 dark:text-slate-400">{group.maps.length} Maps</p>
                     </div>
                     <span
-                      className={`inline-flex h-8 w-8 items-center justify-center rounded-full border border-slate-700/70 text-xs font-bold text-slate-300 transition ${
-                        expanded ? 'bg-teal-500/10 text-teal-200' : 'bg-slate-900'
+                      className={`inline-flex h-9 w-9 items-center justify-center rounded-full border text-xs font-bold transition ${
+                        expanded
+                          ? 'border-amber-400/70 bg-amber-300/70 text-slate-900 dark:border-amber-400/50 dark:bg-amber-400/20 dark:text-amber-100'
+                          : 'border-white/60 bg-white/70 text-slate-600 dark:border-slate-700 dark:bg-slate-950/70 dark:text-slate-300'
                       }`}
                       aria-hidden="true"
                     >
@@ -123,7 +125,7 @@ const MapFolderList: React.FC<MapFolderListProps> = ({
                   </button>
                   <button
                     type="button"
-                    className="rounded-full border border-rose-400/60 bg-rose-500/20 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.3em] text-rose-200 transition hover:bg-rose-500/30"
+                    className="rounded-full border border-rose-400/70 bg-rose-200/70 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.3em] text-rose-700 transition hover:bg-rose-200/80 dark:border-rose-400/40 dark:bg-rose-500/20 dark:text-rose-100 dark:hover:bg-rose-500/30"
                     onClick={(event) => {
                       event.stopPropagation();
                       onDeleteGroup(group.name, group.maps);
@@ -135,7 +137,7 @@ const MapFolderList: React.FC<MapFolderListProps> = ({
                   </button>
                 </div>
                 {expanded && (
-                  <div className="grid gap-4 border-t border-slate-800/60 px-5 py-5 sm:grid-cols-2 xl:grid-cols-3">
+                  <div className="grid gap-4 border-t border-white/60 px-5 py-5 sm:grid-cols-2 xl:grid-cols-3 dark:border-slate-800/60">
                     {group.maps.map((map) => {
                       const description = getMetadataString(map.metadata, 'description');
                       const notes = getMetadataString(map.metadata, 'notes');
@@ -153,16 +155,16 @@ const MapFolderList: React.FC<MapFolderListProps> = ({
                               onSelect(map);
                             }
                           }}
-                          className={`group relative overflow-hidden rounded-2xl border px-5 py-6 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-teal-400/60 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 ${
+                          className={`group relative overflow-hidden rounded-2xl border px-5 py-6 text-left shadow transition focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400/60 focus-visible:ring-offset-2 focus-visible:ring-offset-white/70 dark:focus-visible:ring-offset-slate-950 ${
                             selectedMapId === map.id
-                              ? 'border-teal-400 bg-teal-500/10 shadow-[0_0_0_1px_rgba(45,212,191,0.4)]'
-                              : 'border-slate-800/60 bg-slate-950/60 hover:border-teal-400/60 hover:shadow-[0_0_0_1px_rgba(45,212,191,0.3)]'
+                              ? 'border-amber-400/80 bg-amber-100/70 shadow-amber-500/30 dark:border-amber-400/60 dark:bg-amber-400/10'
+                              : 'border-white/60 bg-white/70 hover:border-amber-400/70 hover:shadow-amber-500/20 dark:border-slate-800/70 dark:bg-slate-950/70 dark:hover:border-amber-400/60'
                           }`}
                         >
                           <div className="absolute right-4 top-4 flex items-center gap-2">
                             <button
                               type="button"
-                              className="rounded-full border border-rose-400/60 bg-rose-500/20 px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.3em] text-rose-200 transition hover:bg-rose-500/30"
+                              className="rounded-full border border-rose-400/70 bg-rose-200/70 px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.3em] text-rose-700 transition hover:bg-rose-200/80 dark:border-rose-400/40 dark:bg-rose-500/20 dark:text-rose-100 dark:hover:bg-rose-500/30"
                               onClick={(event) => {
                                 event.stopPropagation();
                                 onDeleteMap(map);
@@ -174,21 +176,21 @@ const MapFolderList: React.FC<MapFolderListProps> = ({
                               ✕
                             </button>
                           </div>
-                          <div className="mb-4 flex items-center justify-between text-xs uppercase tracking-[0.4em] text-slate-500">
+                          <div className="mb-4 flex items-center justify-between text-[10px] uppercase tracking-[0.4em] text-slate-500 dark:text-slate-400">
                             <span>Map</span>
                             <span>
                               {map.width ?? '—'} × {map.height ?? '—'}
                             </span>
                           </div>
-                          <h4 className="text-lg font-semibold text-white">{map.name}</h4>
-                          {description && <p className="mt-2 text-sm text-slate-300">{description}</p>}
-                          {notes && !description && <p className="mt-2 text-sm text-slate-400">{notes}</p>}
+                          <h4 className="text-lg font-semibold text-slate-900 dark:text-white">{map.name}</h4>
+                          {description && <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">{description}</p>}
+                          {notes && !description && <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">{notes}</p>}
                           {tags.length > 0 && (
                             <div className="mt-4 flex flex-wrap gap-2">
                               {tags.map((tag) => (
                                 <span
                                   key={tag}
-                                  className="inline-flex items-center rounded-full border border-slate-700/70 bg-slate-900/70 px-2 py-1 text-[10px] uppercase tracking-[0.3em] text-slate-300"
+                                  className="inline-flex items-center rounded-full border border-white/60 bg-white/70 px-2 py-1 text-[10px] uppercase tracking-[0.3em] text-slate-600 dark:border-slate-700 dark:bg-slate-950/70 dark:text-slate-300"
                                 >
                                   {tag}
                                 </span>
@@ -198,10 +200,10 @@ const MapFolderList: React.FC<MapFolderListProps> = ({
                           <div className="pointer-events-none absolute inset-0 rounded-2xl border border-white/5 transition group-hover:border-white/10" />
                           <div className="pointer-events-none absolute inset-0 opacity-0 transition group-hover:opacity-100">
                             <div
-                              className="absolute inset-0 bg-cover bg-center opacity-20"
+                              className="absolute inset-0 bg-cover bg-center opacity-25"
                               style={{ backgroundImage: `url(${apiClient.buildMapDisplayUrl(map.id)})` }}
                             />
-                            <div className="absolute inset-0 bg-gradient-to-t from-slate-950 via-transparent to-transparent" />
+                            <div className="absolute inset-0 bg-gradient-to-t from-amber-500/20 via-transparent to-transparent dark:from-slate-950/80" />
                           </div>
                         </div>
                       );

--- a/apps/pages/src/components/MapMaskCanvas.tsx
+++ b/apps/pages/src/components/MapMaskCanvas.tsx
@@ -155,7 +155,7 @@ const MapMaskCanvas: React.FC<MapMaskCanvasProps> = ({
   const displayHeight = imageSize?.height || height || 768;
 
   return (
-    <div className="relative w-full overflow-hidden rounded-lg border border-slate-200 bg-slate-900/60 shadow-inner dark:border-slate-700">
+    <div className="relative w-full overflow-hidden rounded-3xl border border-white/60 bg-white/75 shadow-inner shadow-amber-500/10 backdrop-blur-xl dark:border-slate-800/70 dark:bg-slate-950/70 dark:shadow-black/40">
       {imageUrl ? (
         <img
           src={imageUrl}
@@ -164,7 +164,7 @@ const MapMaskCanvas: React.FC<MapMaskCanvasProps> = ({
           style={{ maxHeight: '70vh', objectFit: 'contain' }}
         />
       ) : (
-        <div className="flex h-64 items-center justify-center text-sm text-slate-400">
+        <div className="flex h-64 items-center justify-center text-sm text-slate-600 dark:text-slate-400">
           Upload a map to begin
         </div>
       )}
@@ -182,7 +182,7 @@ const MapMaskCanvas: React.FC<MapMaskCanvasProps> = ({
         <button
           key={marker.id}
           onClick={() => onSelectMarker?.(marker.id)}
-          className="absolute flex -translate-x-1/2 -translate-y-full items-center gap-1 rounded-full border border-white/50 bg-white/80 px-2 py-1 text-xs font-medium text-slate-900 shadow dark:border-slate-800 dark:bg-slate-900/90 dark:text-slate-100"
+          className="absolute flex -translate-x-1/2 -translate-y-full items-center gap-1 rounded-full border border-amber-400/60 bg-white/80 px-2 py-1 text-xs font-medium text-slate-900 shadow-md shadow-amber-500/20 transition dark:border-amber-400/40 dark:bg-slate-950/80 dark:text-amber-100"
           style={{
             left: `${(marker.x ?? 0) * 100}%`,
             top: `${(marker.y ?? 0) * 100}%`,

--- a/apps/pages/src/components/MarkerPanel.tsx
+++ b/apps/pages/src/components/MarkerPanel.tsx
@@ -13,7 +13,7 @@ const MarkerPanel: React.FC<MarkerPanelProps> = ({ markers, onRemove, onUpdate }
       {markers.map((marker) => (
         <div
           key={marker.id}
-          className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm dark:border-slate-700 dark:bg-slate-800"
+          className="rounded-2xl border border-white/60 bg-white/75 px-3 py-3 text-sm shadow-sm shadow-amber-500/10 backdrop-blur-xl dark:border-slate-800/70 dark:bg-slate-950/70 dark:shadow-black/40"
         >
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
@@ -22,7 +22,7 @@ const MarkerPanel: React.FC<MarkerPanelProps> = ({ markers, onRemove, onUpdate }
                 style={{ backgroundColor: marker.color || '#facc15' }}
               />
               <div>
-                <p className="font-medium">{marker.label}</p>
+                <p className="font-semibold text-slate-900 dark:text-white">{marker.label}</p>
                 <p className="text-xs text-slate-500 dark:text-slate-400">
                   ({Math.round((marker.x ?? 0) * 100)}%, {Math.round((marker.y ?? 0) * 100)}%)
                 </p>
@@ -30,13 +30,13 @@ const MarkerPanel: React.FC<MarkerPanelProps> = ({ markers, onRemove, onUpdate }
             </div>
             <div className="flex items-center gap-2">
               <button
-                className="rounded-full border border-slate-300 px-2 py-1 text-xs text-slate-600 hover:bg-slate-100 dark:border-slate-600 dark:text-slate-300 dark:hover:bg-slate-700"
+                className="rounded-full border border-amber-400/70 bg-amber-200/60 px-2 py-1 text-[11px] font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-amber-200/80 dark:border-amber-400/40 dark:bg-amber-400/20 dark:text-amber-100 dark:hover:bg-amber-400/30"
                 onClick={() => onUpdate?.(marker)}
               >
                 Edit
               </button>
               <button
-                className="rounded-full bg-rose-500 px-2 py-1 text-xs text-white hover:bg-rose-600"
+                className="rounded-full border border-rose-400/70 bg-rose-200/70 px-2 py-1 text-[11px] font-semibold uppercase tracking-[0.3em] text-rose-700 transition hover:bg-rose-200/80 dark:border-rose-400/40 dark:bg-rose-500/20 dark:text-rose-100 dark:hover:bg-rose-500/30"
                 onClick={() => onRemove?.(marker.id)}
               >
                 Remove
@@ -46,7 +46,7 @@ const MarkerPanel: React.FC<MarkerPanelProps> = ({ markers, onRemove, onUpdate }
           {marker.description && <p className="mt-2 text-xs opacity-75">{marker.description}</p>}
         </div>
       ))}
-      {markers.length === 0 && <p className="text-sm text-slate-500">No markers placed.</p>}
+      {markers.length === 0 && <p className="text-sm text-slate-600 dark:text-slate-400">No markers placed.</p>}
     </div>
   );
 };

--- a/apps/pages/src/components/RegionList.tsx
+++ b/apps/pages/src/components/RegionList.tsx
@@ -10,21 +10,21 @@ interface RegionListProps {
 
 const RegionList: React.FC<RegionListProps> = ({ regions, revealedRegionIds, onToggleRegion, onSelectRegion }) => {
   return (
-    <div className="space-y-2">
+    <div className="space-y-3">
       {regions.map((region) => {
         const revealed = revealedRegionIds.includes(region.id);
         return (
           <div
             key={region.id}
-            className={`flex items-start justify-between rounded-lg border px-3 py-2 text-sm shadow-sm transition hover:border-primary/60 hover:shadow ${
+            className={`flex items-start justify-between gap-4 rounded-2xl border px-4 py-3 text-sm shadow transition ${
               revealed
-                ? 'border-emerald-400/60 bg-emerald-100/20 text-emerald-900 dark:border-emerald-500/40 dark:bg-emerald-500/10 dark:text-emerald-100'
-                : 'border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-800'
+                ? 'border-amber-300/80 bg-amber-100/70 text-slate-900 dark:border-amber-400/40 dark:bg-amber-400/10 dark:text-amber-100'
+                : 'border-white/60 bg-white/70 text-slate-900 hover:border-amber-400/70 hover:shadow-lg dark:border-slate-800/70 dark:bg-slate-950/70 dark:text-slate-100 dark:hover:border-amber-400/50'
             }`}
           >
             <div>
               <button
-                className="font-medium hover:underline"
+                className="font-semibold text-slate-900 hover:underline dark:text-white"
                 onClick={() => onSelectRegion?.(region)}
               >
                 {region.name}
@@ -32,10 +32,10 @@ const RegionList: React.FC<RegionListProps> = ({ regions, revealedRegionIds, onT
               {region.notes && <p className="mt-1 text-xs opacity-75">{region.notes}</p>}
             </div>
             <button
-              className={`rounded-full px-3 py-1 text-xs font-semibold ${
+              className={`rounded-full px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.3em] transition ${
                 revealed
-                  ? 'bg-emerald-500 text-white hover:bg-emerald-600'
-                  : 'bg-primary text-white hover:bg-primary-dark'
+                  ? 'border border-rose-400/70 bg-rose-200/70 text-rose-700 hover:bg-rose-200/80 dark:border-rose-400/40 dark:bg-rose-500/20 dark:text-rose-100 dark:hover:bg-rose-500/30'
+                  : 'border border-amber-400/70 bg-amber-300/80 text-slate-900 hover:bg-amber-300/90 dark:border-amber-400/50 dark:bg-amber-400/20 dark:text-amber-100 dark:hover:bg-amber-400/30'
               }`}
               onClick={() => onToggleRegion?.(region, !revealed)}
             >

--- a/apps/pages/src/components/SessionViewer.tsx
+++ b/apps/pages/src/components/SessionViewer.tsx
@@ -166,37 +166,42 @@ const SessionViewer: React.FC<SessionViewerProps> = ({
 
   return (
     <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
-      <div className="lg:col-span-2 space-y-4">
-        <div className="flex items-center justify-between">
-          <div>
-            <h2 className="text-lg font-semibold">{session.name}</h2>
-            <p className="text-sm text-slate-500 dark:text-slate-400">
-              Connection: <span className="font-medium text-primary">{connectionState}</span>
-            </p>
-          </div>
-          <div className="flex items-center gap-2">
-            {mode === 'dm' && (
-              <>
-                <button
-                  className="rounded-full border border-slate-300 px-3 py-1 text-xs font-medium hover:bg-slate-100 dark:border-slate-600 dark:hover:bg-slate-700"
-                  onClick={onSaveSession}
-                >
-                  Save Snapshot
-                </button>
-                <button
-                  className="rounded-full border border-rose-500 px-3 py-1 text-xs font-medium text-rose-500 hover:bg-rose-500/10"
-                  onClick={onEndSession}
-                >
-                  End Session
-                </button>
-              </>
-            )}
-            <button
-              className="rounded-full border border-slate-300 px-3 py-1 text-xs font-medium hover:bg-slate-100 dark:border-slate-600 dark:hover:bg-slate-700"
-              onClick={onLeave}
-            >
-              Leave
-            </button>
+      <div className="space-y-4 lg:col-span-2">
+        <div className="rounded-3xl border border-white/60 bg-white/75 px-5 py-4 shadow-lg shadow-amber-500/10 backdrop-blur-xl dark:border-slate-800/70 dark:bg-slate-950/70 dark:shadow-black/40">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <h2 className="text-xl font-semibold text-slate-900 dark:text-white">{session.name}</h2>
+              <p className="text-xs uppercase tracking-[0.4em] text-slate-600 dark:text-slate-400">
+                Connection
+                <span className="ml-2 inline-flex items-center rounded-full border border-amber-400/60 bg-amber-200/60 px-2 py-0.5 text-[11px] font-semibold tracking-wide text-slate-900 dark:border-amber-400/40 dark:bg-amber-400/20 dark:text-amber-100">
+                  {connectionState}
+                </span>
+              </p>
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+              {mode === 'dm' && (
+                <>
+                  <button
+                    className="rounded-full border border-white/60 bg-white/70 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.3em] text-slate-700 shadow-sm transition hover:border-amber-400/70 hover:text-amber-600 dark:border-slate-700 dark:bg-slate-950/70 dark:text-slate-200 dark:hover:border-amber-400/50 dark:hover:text-amber-200"
+                    onClick={onSaveSession}
+                  >
+                    Save Snapshot
+                  </button>
+                  <button
+                    className="rounded-full border border-rose-400/70 bg-rose-200/60 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.3em] text-rose-700 transition hover:bg-rose-200/80 dark:border-rose-400/40 dark:bg-rose-500/20 dark:text-rose-100 dark:hover:bg-rose-500/30"
+                    onClick={onEndSession}
+                  >
+                    End Session
+                  </button>
+                </>
+              )}
+              <button
+                className="rounded-full border border-white/60 bg-white/70 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.3em] text-slate-700 shadow-sm transition hover:border-amber-400/70 hover:text-amber-600 dark:border-slate-700 dark:bg-slate-950/70 dark:text-slate-200 dark:hover:border-amber-400/50 dark:hover:text-amber-200"
+                onClick={onLeave}
+              >
+                Leave
+              </button>
+            </div>
           </div>
         </div>
         <MapMaskCanvas
@@ -212,28 +217,28 @@ const SessionViewer: React.FC<SessionViewerProps> = ({
         />
       </div>
       <div className="space-y-6">
-        <section>
-          <h3 className="mb-2 text-sm font-semibold uppercase tracking-wide text-slate-500">Players</h3>
-          <ul className="space-y-1 text-sm">
+        <section className="rounded-3xl border border-white/60 bg-white/75 p-4 shadow-lg shadow-amber-500/10 backdrop-blur-xl dark:border-slate-800/70 dark:bg-slate-950/70 dark:shadow-black/40">
+          <h3 className="mb-3 text-xs font-semibold uppercase tracking-[0.4em] text-slate-600 dark:text-slate-400">Players</h3>
+          <ul className="space-y-2 text-sm">
             {state.players.map((player) => (
-              <li key={player.id} className="rounded border border-slate-200 px-3 py-1 dark:border-slate-700">
-                <span className="font-medium">{player.name}</span>
-                <span className="ml-2 text-xs uppercase text-slate-500">{player.role}</span>
+              <li key={player.id} className="rounded-xl border border-white/60 bg-white/70 px-3 py-2 shadow-sm dark:border-slate-800/70 dark:bg-slate-950/70">
+                <span className="font-medium text-slate-900 dark:text-white">{player.name}</span>
+                <span className="ml-2 text-[10px] uppercase tracking-[0.3em] text-slate-500 dark:text-slate-400">{player.role}</span>
               </li>
             ))}
-            {state.players.length === 0 && <li className="text-xs text-slate-500">Waiting for players…</li>}
+            {state.players.length === 0 && <li className="text-xs text-slate-500 dark:text-slate-400">Waiting for players…</li>}
           </ul>
         </section>
-        <section>
-          <h3 className="mb-2 text-sm font-semibold uppercase tracking-wide text-slate-500">Regions</h3>
+        <section className="rounded-3xl border border-white/60 bg-white/75 p-4 shadow-lg shadow-amber-500/10 backdrop-blur-xl dark:border-slate-800/70 dark:bg-slate-950/70 dark:shadow-black/40">
+          <h3 className="mb-3 text-xs font-semibold uppercase tracking-[0.4em] text-slate-600 dark:text-slate-400">Regions</h3>
           <RegionList
             regions={regions}
             revealedRegionIds={state.revealedRegions}
             onToggleRegion={mode === 'dm' ? handleToggleRegion : undefined}
           />
         </section>
-        <section>
-          <h3 className="mb-2 text-sm font-semibold uppercase tracking-wide text-slate-500">Markers</h3>
+        <section className="rounded-3xl border border-white/60 bg-white/75 p-4 shadow-lg shadow-amber-500/10 backdrop-blur-xl dark:border-slate-800/70 dark:bg-slate-950/70 dark:shadow-black/40">
+          <h3 className="mb-3 text-xs font-semibold uppercase tracking-[0.4em] text-slate-600 dark:text-slate-400">Markers</h3>
           <MarkerPanel markers={resolvedMarkers} onRemove={mode === 'dm' ? handleRemoveMarker : undefined} onUpdate={mode === 'dm' ? handleUpdateMarker : undefined} />
         </section>
       </div>

--- a/apps/pages/tailwind.config.cjs
+++ b/apps/pages/tailwind.config.cjs
@@ -5,9 +5,9 @@ module.exports = {
     extend: {
       colors: {
         primary: {
-          DEFAULT: '#6366f1',
-          light: '#818cf8',
-          dark: '#4f46e5',
+          DEFAULT: '#f59e0b',
+          light: '#fbbf24',
+          dark: '#d97706',
         },
       },
     },


### PR DESCRIPTION
## Summary
- restyled the session dashboard containers and controls to match the landing page glassmorphism and amber accents
- refreshed map management panels, region and marker lists, and the map viewer overlays with consistent warm theming
- tuned the map creation wizard flow and primary Tailwind palette to reuse the landing page color scheme

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd95e046448323b9288244b0f0c5d7