### PR TITLE
Align console theming with warm landing palette

### DIFF
--- a/apps/pages/src/components/MapCreationWizard.tsx
+++ b/apps/pages/src/components/MapCreationWizard.tsx
@@ -690,18 +690,22 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex flex-col bg-slate-950/95 backdrop-blur-sm">
-      <header className="mb-0.5 border-b border-slate-800/70 px-5 py-3">
+    <div className="fixed inset-0 z-50 flex flex-col overflow-hidden bg-slate-950/95 backdrop-blur-xl relative">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_12%_-10%,rgba(251,191,36,0.25),transparent_45%),radial-gradient(circle_at_82%_10%,rgba(248,113,113,0.18),transparent_40%),radial-gradient(circle_at_12%_92%,rgba(244,114,182,0.12),transparent_50%)]"
+      />
+      <header className="relative z-10 mb-0.5 border-b border-amber-400/20 bg-slate-950/60 px-5 py-4 backdrop-blur">
         <div className="flex flex-wrap items-center justify-between gap-4">
           <div>
-            <p className="text-xs uppercase tracking-[0.4em] text-teal-300">New Map Wizard</p>
+            <p className="text-xs uppercase tracking-[0.4em] text-amber-200/80">New Map Wizard</p>
             <h2 className="text-2xl font-bold text-white">{steps[step].title}</h2>
-            <p className="text-sm text-slate-400">{steps[step].description}</p>
+            <p className="text-sm text-slate-300">{steps[step].description}</p>
           </div>
           <button
             type="button"
             onClick={onClose}
-            className="rounded-full border border-slate-700/70 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-300 transition hover:border-rose-400/60 hover:text-rose-200"
+            className="rounded-full border border-slate-700/70 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-200 transition hover:border-rose-400/60 hover:text-rose-200"
           >
             Exit Wizard
           </button>
@@ -715,10 +719,10 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                 key={item.title}
                 className={`flex items-center gap-3 rounded-full border px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] transition ${
                   isActive
-                    ? 'border-teal-400/70 bg-teal-500/20 text-teal-100'
+                    ? 'border-amber-400/80 bg-amber-300/20 text-amber-100'
                     : isComplete
-                    ? 'border-slate-700/70 bg-slate-800/80 text-slate-200'
-                    : 'border-slate-800/70 bg-slate-900/80 text-slate-500'
+                    ? 'border-amber-400/30 bg-amber-400/10 text-amber-200'
+                    : 'border-slate-700/70 bg-slate-900/80 text-slate-400'
                 }`}
               >
                 <span className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-current">
@@ -730,7 +734,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
           })}
         </div>
       </header>
-      <main className="flex-1 overflow-x-visible overflow-y-auto py-4">
+      <main className="relative z-10 flex-1 overflow-x-visible overflow-y-auto py-4">
         <div className="flex h-full">
           <div
             ref={brushSliderHostRef}
@@ -739,12 +743,12 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
           <div className="flex h-full flex-1 flex-col overflow-x-visible overflow-y-hidden px-[10vw]">
           {step === 0 && (
             <div className="flex flex-1 items-center justify-center">
-              <div className="w-full max-w-4xl rounded-3xl border border-slate-800/70 bg-slate-900/70 p-8 text-center">
+              <div className="w-full max-w-4xl rounded-3xl border border-amber-400/20 bg-slate-900/60 p-8 text-center shadow-2xl shadow-amber-500/10">
                 <div
                   onDragEnter={(event) => event.preventDefault()}
                   onDragOver={(event) => event.preventDefault()}
                   onDrop={handleDrop}
-                  className="group relative flex min-h-[200px] flex-col items-center justify-center rounded-2xl border-2 border-dashed border-slate-700/70 bg-slate-950/70 px-6 py-8 transition hover:border-teal-400/60"
+                  className="group relative flex min-h-[200px] flex-col items-center justify-center rounded-2xl border-2 border-dashed border-amber-400/30 bg-slate-950/70 px-6 py-8 transition hover:border-amber-400/60"
                 >
                   <input
                     ref={fileInputRef}
@@ -758,23 +762,23 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                       }
                     }}
                   />
-                  <p className="text-sm uppercase tracking-[0.4em] text-slate-500">Drag &amp; Drop</p>
+                  <p className="text-sm uppercase tracking-[0.4em] text-amber-200/70">Drag &amp; Drop</p>
                   <h3 className="mt-3 text-2xl font-semibold text-white">Drop your map image here</h3>
-                  <p className="mt-2 max-w-xl text-sm text-slate-400">
+                  <p className="mt-2 max-w-xl text-sm text-slate-300">
                     We accept PNG, JPG, WEBP, and other common image formats. Drop the file or browse your computer to get started.
                   </p>
                   <button
                     type="button"
                     onClick={handleBrowse}
-                    className="mt-5 rounded-full border border-teal-400/60 bg-teal-500/80 px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-teal-400/90"
+                    className="mt-5 rounded-full bg-gradient-to-r from-amber-500 via-orange-500 to-rose-500 px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-white shadow-lg shadow-orange-500/30 transition hover:shadow-amber-500/40"
                   >
                     Browse Files
                   </button>
                 </div>
                 {previewUrl && (
                   <div className="mt-6">
-                    <p className="text-xs uppercase tracking-[0.4em] text-teal-300">Preview</p>
-                    <div className="mt-3 overflow-hidden rounded-2xl border border-slate-800/70">
+                    <p className="text-xs uppercase tracking-[0.4em] text-amber-200/80">Preview</p>
+                    <div className="mt-3 overflow-hidden rounded-2xl border border-amber-400/20">
                       <img
                         src={previewUrl}
                         alt="Uploaded map preview"
@@ -782,7 +786,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                       />
                     </div>
                     {imageDimensions && (
-                      <p className="mt-2 text-xs uppercase tracking-[0.4em] text-slate-500">
+                      <p className="mt-2 text-xs uppercase tracking-[0.4em] text-slate-400">
                         {imageDimensions.width} × {imageDimensions.height} pixels
                       </p>
                     )}
@@ -793,63 +797,63 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
           )}
           {step === 1 && (
             <div className="flex flex-1 items-stretch justify-center">
-              <div className="flex h-full w-full flex-col rounded-3xl border border-slate-800/70 bg-slate-900/70 p-8">
+              <div className="flex h-full w-full flex-col rounded-3xl border border-amber-400/20 bg-slate-900/60 p-8 shadow-2xl shadow-amber-500/10">
                 <div className="grid flex-1 min-h-0 gap-6 md:grid-cols-[minmax(0,1fr)_260px]">
                   <div className="flex flex-col gap-5">
                     <div>
-                      <label className="block text-xs uppercase tracking-[0.4em] text-slate-400">Map Name</label>
+                      <label className="block text-xs uppercase tracking-[0.4em] text-amber-200/80">Map Name</label>
                       <input
                         type="text"
                         value={name}
                         onChange={(event) => setName(event.target.value)}
-                        className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                        className="mt-2 w-full rounded-xl border border-slate-700/70 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-500 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/40"
                         placeholder="Ancient Ruins"
                       />
                     </div>
                     <div>
-                      <label className="block text-xs uppercase tracking-[0.4em] text-slate-400">Description</label>
+                      <label className="block text-xs uppercase tracking-[0.4em] text-amber-200/80">Description</label>
                       <textarea
                         value={description}
                         onChange={(event) => setDescription(event.target.value)}
                         rows={3}
-                        className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                        className="mt-2 w-full rounded-xl border border-slate-700/70 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-500 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/40"
                         placeholder="Give a brief overview of the map."
                       />
                     </div>
                     <div>
-                      <label className="block text-xs uppercase tracking-[0.4em] text-slate-400">Grouping</label>
+                      <label className="block text-xs uppercase tracking-[0.4em] text-amber-200/80">Grouping</label>
                       <input
                         type="text"
                         value={grouping}
                         onChange={(event) => setGrouping(event.target.value)}
-                        className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                        className="mt-2 w-full rounded-xl border border-slate-700/70 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-500 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/40"
                         placeholder="Dungeon Delves"
                       />
                     </div>
                     <div>
-                      <label className="block text-xs uppercase tracking-[0.4em] text-slate-400">Notes</label>
+                      <label className="block text-xs uppercase tracking-[0.4em] text-amber-200/80">Notes</label>
                       <textarea
                         value={notes}
                         onChange={(event) => setNotes(event.target.value)}
                         rows={3}
-                        className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                        className="mt-2 w-full rounded-xl border border-slate-700/70 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-500 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/40"
                         placeholder="DM-only reminders or encounter tips"
                       />
                     </div>
                     <div>
-                      <label className="block text-xs uppercase tracking-[0.4em] text-slate-400">Tags</label>
+                      <label className="block text-xs uppercase tracking-[0.4em] text-amber-200/80">Tags</label>
                       <input
                         type="text"
                         value={tagsInput}
                         onChange={(event) => setTagsInput(event.target.value)}
-                        className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                        className="mt-2 w-full rounded-xl border border-slate-700/70 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-500 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/40"
                         placeholder="forest, ruins, night"
                       />
-                      <p className="mt-2 text-xs text-slate-500">Separate tags with commas to help search and filtering.</p>
+                      <p className="mt-2 text-xs text-slate-400">Separate tags with commas to help search and filtering.</p>
                     </div>
                   </div>
                   <div className="flex h-full flex-col gap-4">
-                    <div className="flex flex-1 items-center justify-center overflow-hidden rounded-2xl border border-slate-800/70 bg-slate-950/70">
+                    <div className="flex flex-1 items-center justify-center overflow-hidden rounded-2xl border border-amber-400/20 bg-slate-950/70">
                       {previewUrl ? (
                         <img
                           src={previewUrl}
@@ -857,14 +861,14 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                           className="max-h-full w-full object-contain"
                         />
                       ) : (
-                        <p className="text-xs uppercase tracking-[0.4em] text-slate-500">
+                        <p className="text-xs uppercase tracking-[0.4em] text-slate-400">
                           Upload a map image to preview it here.
                         </p>
                       )}
                     </div>
-                    <div className="rounded-2xl border border-slate-800/70 bg-slate-950/70 p-4">
-                      <p className="text-xs uppercase tracking-[0.4em] text-slate-400">Tips</p>
-                      <ul className="mt-2 space-y-2 text-xs text-slate-400">
+                  <div className="rounded-2xl border border-amber-400/20 bg-slate-950/70 p-4">
+                    <p className="text-xs uppercase tracking-[0.4em] text-amber-200/80">Tips</p>
+                    <ul className="mt-2 space-y-2 text-xs text-slate-300">
                         <li>Keep names short but descriptive for quick reference during sessions.</li>
                         <li>Use notes to capture secrets, traps, or DM-only reminders.</li>
                         <li>Tags help you filter maps later in the campaign dashboard.</li>
@@ -877,11 +881,11 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
           )}
           {step === 2 && (
             <div className="flex h-full min-h-0 flex-1 justify-center">
-              <div className="flex h-full min-h-0 w-full rounded-3xl border border-slate-800/70 bg-slate-900/70 p-4">
+              <div className="flex h-full min-h-0 w-full rounded-3xl border border-amber-400/20 bg-slate-900/60 p-4 shadow-2xl shadow-amber-500/10">
                 <div
                   ref={defineRoomContainerRef}
-                  className={`flex h-full min-h-0 w-full flex-col overflow-visible rounded-2xl border border-slate-800/70 bg-slate-950/80 ${
-                    canLaunchRoomsEditor ? '' : 'items-center justify-center text-sm text-slate-500'
+                  className={`flex h-full min-h-0 w-full flex-col overflow-visible rounded-2xl border border-amber-400/30 bg-slate-950/80 ${
+                    canLaunchRoomsEditor ? '' : 'items-center justify-center text-sm text-slate-400'
                   }`}
                 >
                   {!canLaunchRoomsEditor && (
@@ -895,7 +899,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
             <div className="grid h-full min-h-0 gap-6 lg:grid-cols-[minmax(0,1fr)_340px]">
               <div
                 ref={mapAreaRef}
-                className="relative flex h-full min-h-0 max-h-full items-center justify-center overflow-hidden rounded-3xl border border-slate-800/70 bg-slate-900/70"
+                className="relative flex h-full min-h-0 max-h-full items-center justify-center overflow-hidden rounded-3xl border border-amber-400/20 bg-slate-900/60 shadow-2xl shadow-amber-500/10"
               >
                 {previewUrl ? (
                   <>
@@ -918,7 +922,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                             markerDisplayMetrics,
                           ),
                         )}
-                        className="group absolute -translate-x-1/2 -translate-y-1/2 rounded-full border border-white/40 bg-slate-950/80 px-3 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-white shadow-lg transition hover:border-teal-300/80 hover:text-teal-100"
+                className="group absolute -translate-x-1/2 -translate-y-1/2 rounded-full border border-white/40 bg-slate-950/80 px-3 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-white shadow-lg transition hover:border-amber-300/80 hover:text-amber-100"
                       >
                         {marker.label || 'Marker'}
                       </button>
@@ -935,17 +939,17 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                   </div>
                 )}
               </div>
-              <div className="flex h-full min-h-0 flex-col rounded-3xl border border-slate-800/70 bg-slate-900/70">
-                <div className="border-b border-slate-800/70 p-4">
+              <div className="flex h-full min-h-0 flex-col rounded-3xl border border-amber-400/20 bg-slate-900/60 shadow-2xl shadow-amber-500/10">
+                <div className="border-b border-amber-400/20 p-4">
                   <div className="flex items-center justify-between gap-3">
                     <div>
-                      <p className="text-xs uppercase tracking-[0.4em] text-slate-400">Markers</p>
+                      <p className="text-xs uppercase tracking-[0.4em] text-amber-200/80">Markers</p>
                       <h3 className="text-lg font-semibold text-white">Drag &amp; Drop Points</h3>
                     </div>
                     <button
                       type="button"
                       onClick={handleAddMarker}
-                      className="rounded-full border border-teal-400/60 bg-teal-500/80 px-4 py-2 text-[10px] font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-teal-400/90"
+                      className="rounded-full bg-gradient-to-r from-amber-500 via-orange-500 to-rose-500 px-4 py-2 text-[10px] font-semibold uppercase tracking-[0.3em] text-white shadow-lg shadow-orange-500/30 transition hover:shadow-amber-500/40"
                     >
                       Add Marker
                     </button>
@@ -962,8 +966,8 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                         key={marker.id}
                         className={`rounded-2xl border px-4 py-3 transition ${
                           isExpanded
-                            ? 'border-teal-400/60 bg-slate-950/80'
-                            : 'border-slate-800/70 bg-slate-950/70'
+                            ? 'border-amber-400/70 bg-slate-950/70 shadow-[0_0_0_1px_rgba(251,191,36,0.35)]'
+                            : 'border-slate-700/70 bg-slate-950/70'
                         }`}
                       >
                         <button
@@ -991,7 +995,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                           </div>
                           <span
                             className={`text-[10px] uppercase tracking-[0.35em] ${
-                              isExpanded ? 'text-teal-200' : 'text-slate-400'
+                              isExpanded ? 'text-amber-200' : 'text-slate-400'
                             }`}
                           >
                             {isExpanded ? 'Hide' : 'Edit'}
@@ -999,7 +1003,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                         </button>
                         {isExpanded && (
                           <div className="mt-3 space-y-3">
-                            <label className="block text-[10px] uppercase tracking-[0.4em] text-slate-500">
+                            <label className="block text-[10px] uppercase tracking-[0.4em] text-amber-200/80">
                               Label
                               <input
                                 type="text"
@@ -1007,12 +1011,12 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                                 onChange={(event) =>
                                   handleMarkerChange(marker.id, 'label', event.target.value)
                                 }
-                                className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-3 py-2 text-xs text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                                className="mt-2 w-full rounded-xl border border-slate-700/70 bg-slate-950/70 px-3 py-2 text-xs text-slate-100 placeholder:text-slate-500 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/40"
                                 placeholder="Secret Door"
                               />
                             </label>
                             <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_140px]">
-                              <label className="block text-[10px] uppercase tracking-[0.4em] text-slate-500">
+                              <label className="block text-[10px] uppercase tracking-[0.4em] text-amber-200/80">
                                 Notes
                                 <textarea
                                   value={marker.notes}
@@ -1020,11 +1024,11 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                                     handleMarkerChange(marker.id, 'notes', event.target.value)
                                   }
                                   rows={2}
-                                  className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-3 py-2 text-xs text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                                  className="mt-2 w-full rounded-xl border border-slate-700/70 bg-slate-950/70 px-3 py-2 text-xs text-slate-100 placeholder:text-slate-500 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/40"
                                   placeholder="Trap trigger, treasure cache, etc."
                                 />
                               </label>
-                              <label className="block text-[10px] uppercase tracking-[0.4em] text-slate-500">
+                              <label className="block text-[10px] uppercase tracking-[0.4em] text-amber-200/80">
                                 Color
                                 <input
                                   type="text"
@@ -1032,7 +1036,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                                   onChange={(event) =>
                                     handleMarkerChange(marker.id, 'color', event.target.value)
                                   }
-                                  className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-3 py-2 text-xs text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                                  className="mt-2 w-full rounded-xl border border-slate-700/70 bg-slate-950/70 px-3 py-2 text-xs text-slate-100 placeholder:text-slate-500 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/40"
                                   placeholder="#facc15"
                                 />
                               </label>
@@ -1052,7 +1056,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                     );
                   })}
                   {markers.length === 0 && (
-                    <div className="rounded-2xl border border-dashed border-slate-700/70 px-4 py-8 text-center text-xs text-slate-500">
+                    <div className="rounded-2xl border border-dashed border-amber-400/30 px-4 py-8 text-center text-xs text-slate-400">
                       No markers yet. Add a marker to start placing points of interest.
                     </div>
                   )}
@@ -1063,12 +1067,12 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
           </div>
         </div>
       </main>
-      <footer className="mt-0.5 border-t border-slate-800/70 px-5 py-1.5">
+      <footer className="mt-0.5 border-t border-amber-400/20 px-5 py-1.5">
         <div className="flex flex-wrap items-center justify-between gap-2">
           <button
             type="button"
             onClick={handleBack}
-            className="rounded-full border border-slate-700/70 px-4 py-1.5 text-[11px] font-semibold uppercase tracking-[0.3em] text-slate-300 transition hover:border-teal-400/60 hover:text-teal-200"
+            className="rounded-full border border-slate-700/70 px-4 py-1.5 text-[11px] font-semibold uppercase tracking-[0.3em] text-slate-200 transition hover:border-amber-400/60 hover:text-amber-200"
           >
             {step === 0 ? 'Cancel' : 'Back'}
           </button>
@@ -1081,8 +1085,8 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                 onClick={handleContinue}
                 className={`rounded-full border px-5 py-1.5 text-[11px] font-semibold uppercase tracking-[0.3em] transition ${
                   allowNext
-                    ? 'border-teal-400/60 bg-teal-500/80 text-slate-900 hover:bg-teal-400/90'
-                    : 'cursor-not-allowed border-slate-800/70 bg-slate-900/70 text-slate-500'
+                    ? 'border-transparent bg-gradient-to-r from-amber-500 via-orange-500 to-rose-500 text-white shadow-lg shadow-orange-500/30 hover:shadow-amber-500/40'
+                    : 'cursor-not-allowed border-slate-700/70 bg-slate-900/70 text-slate-500'
                 }`}
               >
                 Next
@@ -1094,8 +1098,8 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                 disabled={creating}
                 className={`rounded-full border px-5 py-1.5 text-[11px] font-semibold uppercase tracking-[0.3em] transition ${
                   creating
-                    ? 'cursor-wait border-slate-800/70 bg-slate-900/70 text-slate-500'
-                    : 'border-teal-400/60 bg-teal-500/80 text-slate-900 hover:bg-teal-400/90'
+                    ? 'cursor-wait border-slate-700/70 bg-slate-900/70 text-slate-500'
+                    : 'border-transparent bg-gradient-to-r from-amber-500 via-orange-500 to-rose-500 text-white shadow-lg shadow-orange-500/30 hover:shadow-amber-500/40'
                 }`}
               >
                 {creating ? 'Creating…' : 'Create Map'}

--- a/apps/pages/src/components/MapFolderList.tsx
+++ b/apps/pages/src/components/MapFolderList.tsx
@@ -77,23 +77,23 @@ const MapFolderList: React.FC<MapFolderListProps> = ({
   };
 
   return (
-    <div className="rounded-2xl border border-slate-800/70 bg-slate-900/70 p-5">
+    <div className="rounded-3xl border border-white/60 bg-white/70 p-5 shadow-xl shadow-amber-500/10 backdrop-blur-xl dark:border-slate-800/70 dark:bg-slate-950/70 dark:shadow-black/30">
       <div className="mb-6 flex flex-wrap items-center justify-between gap-4">
         <div>
-          <p className="text-xs uppercase tracking-[0.4em] text-slate-400">Maps</p>
-          <h3 className="text-2xl font-bold text-white">Campaign Atlas</h3>
-          <p className="text-sm text-slate-400">Organize maps into folders to keep your encounters tidy.</p>
+          <p className="text-xs uppercase tracking-[0.4em] text-slate-600 dark:text-slate-400">Maps</p>
+          <h3 className="text-2xl font-bold text-slate-900 dark:text-white">Campaign Atlas</h3>
+          <p className="text-sm text-slate-600 dark:text-slate-400">Organize maps into folders to keep your encounters tidy.</p>
         </div>
         <button
           type="button"
           onClick={onCreateMap}
-          className="rounded-xl border border-teal-400/60 bg-teal-500/80 px-5 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-teal-400/90"
+          className="rounded-xl bg-gradient-to-r from-amber-500 via-orange-500 to-rose-500 px-5 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-white shadow-lg shadow-orange-500/30 transition hover:shadow-amber-500/40 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-400"
         >
           New Map
         </button>
       </div>
       {grouped.length === 0 ? (
-        <div className="rounded-xl border border-dashed border-slate-700/70 px-6 py-12 text-center text-sm text-slate-400">
+        <div className="rounded-xl border border-dashed border-slate-300/70 px-6 py-12 text-center text-sm text-slate-500 dark:border-slate-700/70 dark:text-slate-400">
           No maps yet. Create a map to start building your world.
         </div>
       ) : (
@@ -101,7 +101,7 @@ const MapFolderList: React.FC<MapFolderListProps> = ({
           {grouped.map((group) => {
             const expanded = expandedGroups[group.name];
             return (
-              <div key={group.name} className="rounded-2xl border border-slate-800/70 bg-slate-950/70 shadow-lg">
+              <div key={group.name} className="rounded-2xl border border-white/60 bg-white/70 shadow-lg shadow-amber-500/10 dark:border-slate-800/70 dark:bg-slate-950/70 dark:shadow-black/30">
                 <div className="flex items-start justify-between gap-3 px-5 py-4 sm:items-center">
                   <button
                     type="button"
@@ -109,12 +109,14 @@ const MapFolderList: React.FC<MapFolderListProps> = ({
                     className="flex w-full flex-1 items-center justify-between gap-4 text-left"
                   >
                     <div>
-                      <p className="text-lg font-semibold text-white">{group.name}</p>
-                      <p className="text-[10px] uppercase tracking-[0.4em] text-slate-500">{group.maps.length} Maps</p>
+                      <p className="text-lg font-semibold text-slate-900 dark:text-white">{group.name}</p>
+                      <p className="text-[10px] uppercase tracking-[0.4em] text-slate-500 dark:text-slate-400">{group.maps.length} Maps</p>
                     </div>
                     <span
-                      className={`inline-flex h-8 w-8 items-center justify-center rounded-full border border-slate-700/70 text-xs font-bold text-slate-300 transition ${
-                        expanded ? 'bg-teal-500/10 text-teal-200' : 'bg-slate-900'
+                      className={`inline-flex h-8 w-8 items-center justify-center rounded-full border text-xs font-bold transition ${
+                        expanded
+                          ? 'border-amber-400/70 bg-amber-200/60 text-amber-700 dark:border-amber-400/60 dark:bg-amber-400/20 dark:text-amber-100'
+                          : 'border-slate-200 bg-white text-slate-600 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300'
                       }`}
                       aria-hidden="true"
                     >
@@ -123,7 +125,7 @@ const MapFolderList: React.FC<MapFolderListProps> = ({
                   </button>
                   <button
                     type="button"
-                    className="rounded-full border border-rose-400/60 bg-rose-500/20 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.3em] text-rose-200 transition hover:bg-rose-500/30"
+                    className="rounded-full border border-rose-400/60 bg-rose-100/80 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.3em] text-rose-600 transition hover:bg-rose-200/80 dark:border-rose-400/40 dark:bg-rose-500/20 dark:text-rose-100 dark:hover:bg-rose-500/30"
                     onClick={(event) => {
                       event.stopPropagation();
                       onDeleteGroup(group.name, group.maps);
@@ -135,7 +137,7 @@ const MapFolderList: React.FC<MapFolderListProps> = ({
                   </button>
                 </div>
                 {expanded && (
-                  <div className="grid gap-4 border-t border-slate-800/60 px-5 py-5 sm:grid-cols-2 xl:grid-cols-3">
+                  <div className="grid gap-4 border-t border-white/50 px-5 py-5 sm:grid-cols-2 xl:grid-cols-3 dark:border-slate-800/60">
                     {group.maps.map((map) => {
                       const description = getMetadataString(map.metadata, 'description');
                       const notes = getMetadataString(map.metadata, 'notes');
@@ -153,16 +155,16 @@ const MapFolderList: React.FC<MapFolderListProps> = ({
                               onSelect(map);
                             }
                           }}
-                          className={`group relative overflow-hidden rounded-2xl border px-5 py-6 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-teal-400/60 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 ${
+                          className={`group relative overflow-hidden rounded-2xl border px-5 py-6 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400/60 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-950 ${
                             selectedMapId === map.id
-                              ? 'border-teal-400 bg-teal-500/10 shadow-[0_0_0_1px_rgba(45,212,191,0.4)]'
-                              : 'border-slate-800/60 bg-slate-950/60 hover:border-teal-400/60 hover:shadow-[0_0_0_1px_rgba(45,212,191,0.3)]'
+                              ? 'border-amber-400 bg-amber-200/40 shadow-[0_0_0_1px_rgba(251,191,36,0.45)] dark:bg-amber-400/10'
+                              : 'border-white/60 bg-white/60 hover:border-amber-400/70 hover:shadow-[0_0_0_1px_rgba(251,191,36,0.35)] dark:border-slate-800/70 dark:bg-slate-950/60'
                           }`}
                         >
                           <div className="absolute right-4 top-4 flex items-center gap-2">
                             <button
                               type="button"
-                              className="rounded-full border border-rose-400/60 bg-rose-500/20 px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.3em] text-rose-200 transition hover:bg-rose-500/30"
+                              className="rounded-full border border-rose-400/60 bg-rose-100/80 px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.3em] text-rose-600 transition hover:bg-rose-200/80 dark:border-rose-400/40 dark:bg-rose-500/20 dark:text-rose-100 dark:hover:bg-rose-500/30"
                               onClick={(event) => {
                                 event.stopPropagation();
                                 onDeleteMap(map);
@@ -174,21 +176,21 @@ const MapFolderList: React.FC<MapFolderListProps> = ({
                               ✕
                             </button>
                           </div>
-                          <div className="mb-4 flex items-center justify-between text-xs uppercase tracking-[0.4em] text-slate-500">
+                          <div className="mb-4 flex items-center justify-between text-xs uppercase tracking-[0.4em] text-slate-500 dark:text-slate-400">
                             <span>Map</span>
                             <span>
                               {map.width ?? '—'} × {map.height ?? '—'}
                             </span>
                           </div>
-                          <h4 className="text-lg font-semibold text-white">{map.name}</h4>
-                          {description && <p className="mt-2 text-sm text-slate-300">{description}</p>}
-                          {notes && !description && <p className="mt-2 text-sm text-slate-400">{notes}</p>}
+                          <h4 className="text-lg font-semibold text-slate-900 dark:text-white">{map.name}</h4>
+                          {description && <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">{description}</p>}
+                          {notes && !description && <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">{notes}</p>}
                           {tags.length > 0 && (
                             <div className="mt-4 flex flex-wrap gap-2">
                               {tags.map((tag) => (
                                 <span
                                   key={tag}
-                                  className="inline-flex items-center rounded-full border border-slate-700/70 bg-slate-900/70 px-2 py-1 text-[10px] uppercase tracking-[0.3em] text-slate-300"
+                                  className="inline-flex items-center rounded-full border border-amber-300/70 bg-amber-200/40 px-2 py-1 text-[10px] uppercase tracking-[0.3em] text-amber-700 dark:border-amber-400/50 dark:bg-amber-400/10 dark:text-amber-100"
                                 >
                                   {tag}
                                 </span>

--- a/apps/pages/src/components/MapMaskCanvas.tsx
+++ b/apps/pages/src/components/MapMaskCanvas.tsx
@@ -88,7 +88,7 @@ const MapMaskCanvas: React.FC<MapMaskCanvasProps> = ({
     canvas.width = maskWidth;
     canvas.height = maskHeight;
     context.clearRect(0, 0, maskWidth, maskHeight);
-    context.fillStyle = 'rgba(15, 23, 42, 0.8)';
+    context.fillStyle = 'rgba(15, 23, 42, 0.82)';
     context.fillRect(0, 0, maskWidth, maskHeight);
     context.globalCompositeOperation = 'destination-out';
     revealedRegionIds.forEach((regionId) => {
@@ -112,7 +112,7 @@ const MapMaskCanvas: React.FC<MapMaskCanvasProps> = ({
       const polygon = polygonById.get(hoverRegion);
       if (polygon && polygon.length) {
         context.beginPath();
-        context.fillStyle = 'rgba(99, 102, 241, 0.25)';
+        context.fillStyle = 'rgba(251, 191, 36, 0.28)';
         polygon.forEach((point, index) => {
           const x = point.x * maskWidth;
           const y = point.y * maskHeight;
@@ -155,7 +155,7 @@ const MapMaskCanvas: React.FC<MapMaskCanvasProps> = ({
   const displayHeight = imageSize?.height || height || 768;
 
   return (
-    <div className="relative w-full overflow-hidden rounded-lg border border-slate-200 bg-slate-900/60 shadow-inner dark:border-slate-700">
+    <div className="relative w-full overflow-hidden rounded-2xl border border-amber-400/20 bg-slate-900/60 shadow-inner shadow-amber-500/10 dark:border-slate-800/70">
       {imageUrl ? (
         <img
           src={imageUrl}
@@ -182,7 +182,7 @@ const MapMaskCanvas: React.FC<MapMaskCanvasProps> = ({
         <button
           key={marker.id}
           onClick={() => onSelectMarker?.(marker.id)}
-          className="absolute flex -translate-x-1/2 -translate-y-full items-center gap-1 rounded-full border border-white/50 bg-white/80 px-2 py-1 text-xs font-medium text-slate-900 shadow dark:border-slate-800 dark:bg-slate-900/90 dark:text-slate-100"
+          className="absolute flex -translate-x-1/2 -translate-y-full items-center gap-1 rounded-full border border-amber-400/50 bg-white/90 px-2 py-1 text-xs font-semibold text-slate-900 shadow shadow-amber-500/20 transition hover:shadow-amber-500/40 dark:border-amber-400/30 dark:bg-slate-950/90 dark:text-amber-100"
           style={{
             left: `${(marker.x ?? 0) * 100}%`,
             top: `${(marker.y ?? 0) * 100}%`,

--- a/apps/pages/src/components/MarkerPanel.tsx
+++ b/apps/pages/src/components/MarkerPanel.tsx
@@ -13,7 +13,7 @@ const MarkerPanel: React.FC<MarkerPanelProps> = ({ markers, onRemove, onUpdate }
       {markers.map((marker) => (
         <div
           key={marker.id}
-          className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm dark:border-slate-700 dark:bg-slate-800"
+          className="rounded-2xl border border-white/60 bg-white/70 px-3 py-2 text-sm shadow-sm shadow-amber-500/10 backdrop-blur-sm dark:border-slate-800/70 dark:bg-slate-950/70"
         >
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
@@ -30,18 +30,18 @@ const MarkerPanel: React.FC<MarkerPanelProps> = ({ markers, onRemove, onUpdate }
             </div>
             <div className="flex items-center gap-2">
               <button
-                className="rounded-full border border-slate-300 px-2 py-1 text-xs text-slate-600 hover:bg-slate-100 dark:border-slate-600 dark:text-slate-300 dark:hover:bg-slate-700"
+                className="rounded-full border border-amber-400/60 px-2 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-amber-700 transition hover:bg-amber-100/80 dark:border-amber-400/40 dark:text-amber-200 dark:hover:bg-amber-400/20"
                 onClick={() => onUpdate?.(marker)}
               >
                 Edit
               </button>
               <button
-                className="rounded-full bg-rose-500 px-2 py-1 text-xs text-white hover:bg-rose-600"
+                className="rounded-full border border-rose-400/60 bg-rose-500/90 px-2 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-white transition hover:bg-rose-500"
                 onClick={() => onRemove?.(marker.id)}
               >
                 Remove
               </button>
-            </div>
+          </div>
           </div>
           {marker.description && <p className="mt-2 text-xs opacity-75">{marker.description}</p>}
         </div>

--- a/apps/pages/src/components/RegionList.tsx
+++ b/apps/pages/src/components/RegionList.tsx
@@ -16,9 +16,9 @@ const RegionList: React.FC<RegionListProps> = ({ regions, revealedRegionIds, onT
         return (
           <div
             key={region.id}
-            className={`flex items-start justify-between rounded-lg border px-3 py-2 text-sm shadow-sm transition hover:border-primary/60 hover:shadow ${
+            className={`flex items-start justify-between rounded-lg border px-3 py-2 text-sm shadow-sm transition hover:border-amber-400/70 hover:shadow ${
               revealed
-                ? 'border-emerald-400/60 bg-emerald-100/20 text-emerald-900 dark:border-emerald-500/40 dark:bg-emerald-500/10 dark:text-emerald-100'
+                ? 'border-amber-400/70 bg-amber-100/40 text-amber-900 dark:border-amber-400/50 dark:bg-amber-400/10 dark:text-amber-100'
                 : 'border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-800'
             }`}
           >
@@ -32,10 +32,10 @@ const RegionList: React.FC<RegionListProps> = ({ regions, revealedRegionIds, onT
               {region.notes && <p className="mt-1 text-xs opacity-75">{region.notes}</p>}
             </div>
             <button
-              className={`rounded-full px-3 py-1 text-xs font-semibold ${
+              className={`rounded-full px-3 py-1 text-xs font-semibold transition ${
                 revealed
-                  ? 'bg-emerald-500 text-white hover:bg-emerald-600'
-                  : 'bg-primary text-white hover:bg-primary-dark'
+                  ? 'bg-amber-500 text-slate-900 hover:bg-amber-400'
+                  : 'bg-gradient-to-r from-amber-500 via-orange-500 to-rose-500 text-white hover:shadow-lg hover:shadow-amber-500/30'
               }`}
               onClick={() => onToggleRegion?.(region, !revealed)}
             >

--- a/apps/pages/src/components/SessionViewer.tsx
+++ b/apps/pages/src/components/SessionViewer.tsx
@@ -169,22 +169,22 @@ const SessionViewer: React.FC<SessionViewerProps> = ({
       <div className="lg:col-span-2 space-y-4">
         <div className="flex items-center justify-between">
           <div>
-            <h2 className="text-lg font-semibold">{session.name}</h2>
+            <h2 className="text-lg font-semibold text-slate-900 dark:text-white">{session.name}</h2>
             <p className="text-sm text-slate-500 dark:text-slate-400">
-              Connection: <span className="font-medium text-primary">{connectionState}</span>
+              Connection: <span className="font-semibold text-amber-500">{connectionState}</span>
             </p>
           </div>
           <div className="flex items-center gap-2">
             {mode === 'dm' && (
               <>
                 <button
-                  className="rounded-full border border-slate-300 px-3 py-1 text-xs font-medium hover:bg-slate-100 dark:border-slate-600 dark:hover:bg-slate-700"
+                  className="rounded-full border border-amber-400/60 px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-amber-700 transition hover:bg-amber-100/80 dark:border-amber-400/40 dark:text-amber-200 dark:hover:bg-amber-400/20"
                   onClick={onSaveSession}
                 >
                   Save Snapshot
                 </button>
                 <button
-                  className="rounded-full border border-rose-500 px-3 py-1 text-xs font-medium text-rose-500 hover:bg-rose-500/10"
+                  className="rounded-full border border-rose-400/70 px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-rose-600 transition hover:bg-rose-200/60 dark:border-rose-400/40 dark:text-rose-200 dark:hover:bg-rose-500/20"
                   onClick={onEndSession}
                 >
                   End Session
@@ -192,7 +192,7 @@ const SessionViewer: React.FC<SessionViewerProps> = ({
               </>
             )}
             <button
-              className="rounded-full border border-slate-300 px-3 py-1 text-xs font-medium hover:bg-slate-100 dark:border-slate-600 dark:hover:bg-slate-700"
+              className="rounded-full border border-slate-300/70 px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-slate-600 transition hover:border-amber-400/60 hover:text-amber-500 dark:border-slate-600 dark:text-slate-300 dark:hover:border-amber-400/50 dark:hover:text-amber-200"
               onClick={onLeave}
             >
               Leave
@@ -213,19 +213,19 @@ const SessionViewer: React.FC<SessionViewerProps> = ({
       </div>
       <div className="space-y-6">
         <section>
-          <h3 className="mb-2 text-sm font-semibold uppercase tracking-wide text-slate-500">Players</h3>
+          <h3 className="mb-2 text-sm font-semibold uppercase tracking-[0.3em] text-amber-600 dark:text-amber-200">Players</h3>
           <ul className="space-y-1 text-sm">
             {state.players.map((player) => (
-              <li key={player.id} className="rounded border border-slate-200 px-3 py-1 dark:border-slate-700">
-                <span className="font-medium">{player.name}</span>
-                <span className="ml-2 text-xs uppercase text-slate-500">{player.role}</span>
+              <li key={player.id} className="rounded-xl border border-white/60 bg-white/70 px-3 py-1 shadow-sm shadow-amber-500/10 dark:border-slate-800/70 dark:bg-slate-950/70">
+                <span className="font-medium text-slate-900 dark:text-white">{player.name}</span>
+                <span className="ml-2 text-xs uppercase tracking-[0.3em] text-slate-500 dark:text-slate-400">{player.role}</span>
               </li>
             ))}
-            {state.players.length === 0 && <li className="text-xs text-slate-500">Waiting for players…</li>}
+            {state.players.length === 0 && <li className="text-xs text-slate-500 dark:text-slate-400">Waiting for players…</li>}
           </ul>
         </section>
         <section>
-          <h3 className="mb-2 text-sm font-semibold uppercase tracking-wide text-slate-500">Regions</h3>
+          <h3 className="mb-2 text-sm font-semibold uppercase tracking-[0.3em] text-amber-600 dark:text-amber-200">Regions</h3>
           <RegionList
             regions={regions}
             revealedRegionIds={state.revealedRegions}
@@ -233,7 +233,7 @@ const SessionViewer: React.FC<SessionViewerProps> = ({
           />
         </section>
         <section>
-          <h3 className="mb-2 text-sm font-semibold uppercase tracking-wide text-slate-500">Markers</h3>
+          <h3 className="mb-2 text-sm font-semibold uppercase tracking-[0.3em] text-amber-600 dark:text-amber-200">Markers</h3>
           <MarkerPanel markers={resolvedMarkers} onRemove={mode === 'dm' ? handleRemoveMarker : undefined} onUpdate={mode === 'dm' ? handleUpdateMarker : undefined} />
         </section>
       </div>

--- a/apps/pages/src/components/Toolbar.tsx
+++ b/apps/pages/src/components/Toolbar.tsx
@@ -44,15 +44,15 @@ const Toolbar: React.FC<ToolbarProps> = ({
   };
 
   return (
-    <div className="flex flex-col gap-4 rounded-lg border border-slate-200 bg-white/80 p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900/70">
+    <div className="flex flex-col gap-4 rounded-2xl border border-white/60 bg-white/70 p-4 shadow-lg shadow-amber-500/10 backdrop-blur-sm dark:border-slate-800/70 dark:bg-slate-950/70 dark:shadow-black/30">
       <div className="flex items-center justify-between" role="group" aria-label="Selection tools">
         <div className="flex gap-2">
           <button
             type="button"
             className={`rounded-md px-3 py-2 text-sm font-medium transition ${
               activeTool === 'magneticLasso'
-                ? 'bg-indigo-600 text-white shadow'
-                : 'bg-slate-100 text-slate-700 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700'
+                ? 'bg-gradient-to-r from-amber-500 via-orange-500 to-rose-500 text-white shadow shadow-orange-500/30'
+                : 'bg-white/80 text-slate-700 hover:bg-amber-100/70 dark:bg-slate-900/70 dark:text-slate-200 dark:hover:bg-slate-800'
             }`}
             aria-pressed={activeTool === 'magneticLasso'}
             onClick={() => onToolChange('magneticLasso')}
@@ -63,8 +63,8 @@ const Toolbar: React.FC<ToolbarProps> = ({
             type="button"
             className={`rounded-md px-3 py-2 text-sm font-medium transition ${
               activeTool === 'smartWand'
-                ? 'bg-indigo-600 text-white shadow'
-                : 'bg-slate-100 text-slate-700 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700'
+                ? 'bg-gradient-to-r from-amber-500 via-orange-500 to-rose-500 text-white shadow shadow-orange-500/30'
+                : 'bg-white/80 text-slate-700 hover:bg-amber-100/70 dark:bg-slate-900/70 dark:text-slate-200 dark:hover:bg-slate-800'
             }`}
             aria-pressed={activeTool === 'smartWand'}
             onClick={() => onToolChange('smartWand')}

--- a/apps/pages/src/define-rooms/DefineRoom.tsx
+++ b/apps/pages/src/define-rooms/DefineRoom.tsx
@@ -1,18 +1,18 @@
 /** @jsxImportSource ./lib */
 
 const ROOM_COLORS = [
-  "#ff6b6b",
-  "#4ecdc4",
-  "#ffd166",
-  "#9b5de5",
-  "#48cae4",
-  "#f72585",
-  "#06d6a0",
-  "#f8961e",
-  "#577590",
-  "#ff7f50",
-  "#2ec4b6",
-  "#c77dff"
+  "#f97316",
+  "#facc15",
+  "#fb7185",
+  "#f59e0b",
+  "#f472b6",
+  "#f43f5e",
+  "#fde68a",
+  "#fbbf24",
+  "#ea580c",
+  "#fda4af",
+  "#fdba74",
+  "#fcd34d"
 ];
 
 type ToolType = "brush" | "eraser" | "lasso" | "magnetic" | "wand" | "magnify" | "move";

--- a/apps/pages/src/define-rooms/styles.css
+++ b/apps/pages/src/define-rooms/styles.css
@@ -46,7 +46,7 @@
 .define-room-window {
   width: min(1200px, 92vw);
   height: min(760px, 88vh);
-  background: #0b1220;
+  background: #101827;
   border-radius: 24px;
   border: 1px solid rgba(148, 163, 184, 0.2);
   display: flex;
@@ -225,8 +225,8 @@
   padding: 6px 12px;
   border-radius: 10px;
   border: none;
-  background: linear-gradient(135deg, #38bdf8, #34d399);
-  color: #0b1220;
+  background: linear-gradient(135deg, #f97316, #facc15);
+  color: #101827;
   font-weight: 600;
   cursor: pointer;
 }
@@ -261,12 +261,12 @@
 }
 
 .room-card:hover {
-  border-color: rgba(56, 189, 248, 0.4);
+  border-color: rgba(249, 115, 22, 0.4);
 }
 
 .room-card.expanded,
 .room-card.editing {
-  border-color: rgba(56, 189, 248, 0.7);
+  border-color: rgba(249, 115, 22, 0.7);
   transform: translateY(-1px);
   box-shadow: 0 10px 30px rgba(15, 23, 42, 0.3);
 }
@@ -341,8 +341,8 @@
 .room-description:focus,
 .room-tags:focus {
   outline: none;
-  border-color: rgba(56, 189, 248, 0.6);
-  box-shadow: 0 0 0 1px rgba(56, 189, 248, 0.3);
+  border-color: rgba(249, 115, 22, 0.6);
+  box-shadow: 0 0 0 1px rgba(249, 115, 22, 0.3);
 }
 
 .room-visible {
@@ -356,7 +356,7 @@
 .room-visible-checkbox {
   width: 16px;
   height: 16px;
-  accent-color: #38bdf8;
+  accent-color: #f97316;
 }
 
 .room-card-footer {
@@ -387,14 +387,14 @@
 }
 
 .room-save-button {
-  background: linear-gradient(135deg, #38bdf8, #34d399);
-  color: #0b1220;
-  box-shadow: 0 6px 18px rgba(56, 189, 248, 0.35);
+  background: linear-gradient(135deg, #f97316, #facc15);
+  color: #101827;
+  box-shadow: 0 6px 18px rgba(249, 115, 22, 0.35);
 }
 
 .room-save-button:hover {
   transform: translateY(-1px);
-  box-shadow: 0 8px 22px rgba(56, 189, 248, 0.45);
+  box-shadow: 0 8px 22px rgba(249, 115, 22, 0.45);
 }
 
 .room-color {
@@ -408,7 +408,7 @@
 
 .room-color:hover {
   transform: scale(1.05);
-  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.25);
+  box-shadow: 0 0 0 3px rgba(249, 115, 22, 0.25);
 }
 
 .room-delete-button {
@@ -482,12 +482,12 @@
 .room-color-option:focus-visible {
   outline: none;
   transform: scale(1.08);
-  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.25);
+  box-shadow: 0 0 0 3px rgba(249, 115, 22, 0.25);
 }
 
 .room-color-option.selected {
-  border-color: rgba(56, 189, 248, 0.9);
-  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.2);
+  border-color: rgba(249, 115, 22, 0.9);
+  box-shadow: 0 0 0 3px rgba(249, 115, 22, 0.2);
 }
 
 .room-name {
@@ -570,7 +570,7 @@
 }
 
 .brush-slider-container.dragging {
-  box-shadow: 0 24px 70px rgba(56, 189, 248, 0.35);
+  box-shadow: 0 24px 70px rgba(249, 115, 22, 0.35);
 }
 
 .brush-slider-track {
@@ -591,7 +591,7 @@
   bottom: 0;
   height: 0;
   border-radius: inherit;
-  background: linear-gradient(180deg, #38bdf8, #818cf8);
+  background: linear-gradient(180deg, #f97316, #fb7185);
 }
 
 .brush-slider-thumb {
@@ -601,9 +601,9 @@
   width: 22px;
   height: 22px;
   border-radius: 999px;
-  background: #38bdf8;
+  background: #f97316;
   border: 2px solid #0f172a;
-  box-shadow: 0 10px 24px rgba(56, 189, 248, 0.35);
+  box-shadow: 0 10px 24px rgba(249, 115, 22, 0.35);
   transform: translate(-50%, -50%);
   touch-action: none;
   cursor: grab;
@@ -611,7 +611,7 @@
 
 .brush-slider-container.dragging .brush-slider-thumb {
   cursor: grabbing;
-  box-shadow: 0 12px 32px rgba(56, 189, 248, 0.45);
+  box-shadow: 0 12px 32px rgba(249, 115, 22, 0.45);
 }
 
 .brush-slider-value {
@@ -654,7 +654,7 @@
   left: 2px;
   width: 3px;
   border-radius: 999px;
-  background: linear-gradient(180deg, #38bdf8, #3b82f6);
+  background: linear-gradient(180deg, #f97316, #f43f5e);
 }
 
 .toolbar-button {
@@ -692,8 +692,8 @@
 }
 
 .toolbar-button:focus-visible:not(:disabled) {
-  box-shadow: 0 14px 36px rgba(56, 189, 248, 0.35);
-  border-color: rgba(56, 189, 248, 0.65);
+  box-shadow: 0 14px 36px rgba(249, 115, 22, 0.35);
+  border-color: rgba(249, 115, 22, 0.65);
 }
 
 .toolbar-button-label {
@@ -748,14 +748,14 @@
 .toolbar-primary {
   border: none;
   background: linear-gradient(135deg, #f97316, #facc15);
-  color: #0b1220;
+  color: #101827;
   box-shadow: 0 14px 32px rgba(249, 115, 22, 0.32);
 }
 
 .toolbar-primary:hover:not(:disabled),
 .toolbar-primary:focus-visible:not(:disabled) {
   background: linear-gradient(135deg, #fb923c, #fde68a);
-  color: #0b1220;
+  color: #101827;
   box-shadow: 0 20px 44px rgba(249, 115, 22, 0.45);
 }
 
@@ -789,14 +789,14 @@
 
 .tool-button:hover:not(:disabled),
 .tool-button:focus-visible:not(:disabled) {
-  background: #1d4ed8;
+  background: #ea580c;
   border-color: rgba(96, 165, 250, 0.75);
   color: #dbeafe;
-  box-shadow: 0 18px 40px rgba(59, 130, 246, 0.28);
+  box-shadow: 0 18px 40px rgba(244, 63, 94, 0.28);
 }
 
 .tool-button.active {
-  background: #2563eb;
+  background: #f97316;
   border-color: rgba(147, 197, 253, 0.85);
   color: #e0f2fe;
   box-shadow: 0 20px 44px rgba(37, 99, 235, 0.35);
@@ -804,7 +804,7 @@
 
 .tool-button.active:hover:not(:disabled),
 .tool-button.active:focus-visible:not(:disabled) {
-  background: #2563eb;
+  background: #f97316;
   border-color: rgba(147, 197, 253, 0.85);
   color: #e0f2fe;
 }
@@ -818,16 +818,16 @@
 
 .toolbar-confirm {
   border: none;
-  background: linear-gradient(135deg, #22c55e, #4ade80);
+  background: linear-gradient(135deg, #facc15, #fb923c);
   color: #052e16;
-  box-shadow: 0 16px 34px rgba(34, 197, 94, 0.32);
+  box-shadow: 0 16px 34px rgba(250, 204, 21, 0.32);
 }
 
 .toolbar-confirm:hover:not(:disabled),
 .toolbar-confirm:focus-visible:not(:disabled) {
-  background: linear-gradient(135deg, #34d399, #86efac);
+  background: linear-gradient(135deg, #facc15, #fde68a);
   color: #052e16;
-  box-shadow: 0 22px 46px rgba(34, 197, 94, 0.4);
+  box-shadow: 0 22px 46px rgba(250, 204, 21, 0.4);
 }
 
 .toolbar-cancel {

--- a/apps/pages/tailwind.config.cjs
+++ b/apps/pages/tailwind.config.cjs
@@ -5,9 +5,18 @@ module.exports = {
     extend: {
       colors: {
         primary: {
-          DEFAULT: '#6366f1',
-          light: '#818cf8',
-          dark: '#4f46e5',
+          DEFAULT: '#f97316',
+          light: '#fb923c',
+          dark: '#ea580c',
+        },
+        accent: {
+          DEFAULT: '#facc15',
+          soft: '#fde68a',
+          deep: '#f59e0b',
+        },
+        danger: {
+          DEFAULT: '#f97373',
+          dark: '#f43f5e',
         },
       },
     },


### PR DESCRIPTION
## Summary
- restyle the map creation wizard with warm amber and orange accents that mirror the landing page visuals
- update map management, session controls, and supporting panels to share the same palette for a cohesive look
- refresh the room editor palette and Tailwind theme colors to reinforce the new warm scheme

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd95e046448323b9288244b0f0c5d7