### PR TITLE
Align dashboard components with landing page theming

### DIFF
--- a/apps/pages/src/components/MapCreationWizard.tsx
+++ b/apps/pages/src/components/MapCreationWizard.tsx
@@ -690,48 +690,53 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex flex-col bg-slate-950/95 backdrop-blur-sm">
-      <header className="mb-0.5 border-b border-slate-800/70 px-5 py-3">
-        <div className="flex flex-wrap items-center justify-between gap-4">
-          <div>
-            <p className="text-xs uppercase tracking-[0.4em] text-teal-300">New Map Wizard</p>
-            <h2 className="text-2xl font-bold text-white">{steps[step].title}</h2>
-            <p className="text-sm text-slate-400">{steps[step].description}</p>
+    <div className="fixed inset-0 z-50 flex flex-col overflow-hidden bg-slate-950/95 text-slate-100 backdrop-blur-sm">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_20%_20%,rgba(251,191,36,0.18),transparent_45%),radial-gradient(circle_at_80%_0%,rgba(249,115,22,0.16),transparent_40%)] opacity-80"
+      />
+      <div className="relative flex flex-1 flex-col">
+        <header className="mb-0.5 border-b border-slate-800/70 px-5 py-3">
+          <div className="flex flex-wrap items-center justify-between gap-4">
+            <div>
+              <p className="text-xs uppercase tracking-[0.4em] text-amber-200">New Map Wizard</p>
+              <h2 className="text-2xl font-bold text-white">{steps[step].title}</h2>
+              <p className="text-sm text-slate-400">{steps[step].description}</p>
+            </div>
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-full border border-slate-700/70 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-300 transition hover:border-rose-400/60 hover:text-rose-200"
+            >
+              Exit Wizard
+            </button>
           </div>
-          <button
-            type="button"
-            onClick={onClose}
-            className="rounded-full border border-slate-700/70 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-300 transition hover:border-rose-400/60 hover:text-rose-200"
-          >
-            Exit Wizard
-          </button>
-        </div>
-        <div className="mt-4 flex flex-wrap gap-2">
-          {steps.map((item, index) => {
-            const isActive = index === step;
-            const isComplete = index < step;
-            return (
-              <div
-                key={item.title}
-                className={`flex items-center gap-3 rounded-full border px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] transition ${
-                  isActive
-                    ? 'border-teal-400/70 bg-teal-500/20 text-teal-100'
-                    : isComplete
-                    ? 'border-slate-700/70 bg-slate-800/80 text-slate-200'
-                    : 'border-slate-800/70 bg-slate-900/80 text-slate-500'
-                }`}
-              >
-                <span className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-current">
-                  {index + 1}
-                </span>
-                {item.title}
-              </div>
-            );
-          })}
-        </div>
-      </header>
-      <main className="flex-1 overflow-x-visible overflow-y-auto py-4">
-        <div className="flex h-full">
+          <div className="mt-4 flex flex-wrap gap-2">
+            {steps.map((item, index) => {
+              const isActive = index === step;
+              const isComplete = index < step;
+              return (
+                <div
+                  key={item.title}
+                  className={`flex items-center gap-3 rounded-full border px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] transition ${
+                    isActive
+                      ? 'border-amber-400/70 bg-amber-400/20 text-amber-100'
+                      : isComplete
+                      ? 'border-slate-700/70 bg-slate-800/80 text-slate-200'
+                      : 'border-slate-800/70 bg-slate-900/80 text-slate-500'
+                  }`}
+                >
+                  <span className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-current">
+                    {index + 1}
+                  </span>
+                  {item.title}
+                </div>
+              );
+            })}
+          </div>
+        </header>
+        <main className="flex-1 overflow-x-visible overflow-y-auto py-4">
+          <div className="flex h-full">
           <div
             ref={brushSliderHostRef}
             className="relative flex h-full w-0 flex-shrink-0 overflow-visible"
@@ -744,7 +749,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                   onDragEnter={(event) => event.preventDefault()}
                   onDragOver={(event) => event.preventDefault()}
                   onDrop={handleDrop}
-                  className="group relative flex min-h-[200px] flex-col items-center justify-center rounded-2xl border-2 border-dashed border-slate-700/70 bg-slate-950/70 px-6 py-8 transition hover:border-teal-400/60"
+                  className="group relative flex min-h-[200px] flex-col items-center justify-center rounded-2xl border-2 border-dashed border-slate-700/70 bg-slate-950/70 px-6 py-8 transition hover:border-amber-400/60"
                 >
                   <input
                     ref={fileInputRef}
@@ -766,14 +771,14 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                   <button
                     type="button"
                     onClick={handleBrowse}
-                    className="mt-5 rounded-full border border-teal-400/60 bg-teal-500/80 px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-teal-400/90"
+                    className="mt-5 rounded-full border border-amber-400/60 bg-amber-300/80 px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-amber-300/90"
                   >
                     Browse Files
                   </button>
                 </div>
                 {previewUrl && (
                   <div className="mt-6">
-                    <p className="text-xs uppercase tracking-[0.4em] text-teal-300">Preview</p>
+                    <p className="text-xs uppercase tracking-[0.4em] text-amber-200">Preview</p>
                     <div className="mt-3 overflow-hidden rounded-2xl border border-slate-800/70">
                       <img
                         src={previewUrl}
@@ -802,7 +807,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                         type="text"
                         value={name}
                         onChange={(event) => setName(event.target.value)}
-                        className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                        className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/30"
                         placeholder="Ancient Ruins"
                       />
                     </div>
@@ -812,7 +817,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                         value={description}
                         onChange={(event) => setDescription(event.target.value)}
                         rows={3}
-                        className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                        className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/30"
                         placeholder="Give a brief overview of the map."
                       />
                     </div>
@@ -822,7 +827,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                         type="text"
                         value={grouping}
                         onChange={(event) => setGrouping(event.target.value)}
-                        className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                        className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/30"
                         placeholder="Dungeon Delves"
                       />
                     </div>
@@ -832,7 +837,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                         value={notes}
                         onChange={(event) => setNotes(event.target.value)}
                         rows={3}
-                        className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                        className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/30"
                         placeholder="DM-only reminders or encounter tips"
                       />
                     </div>
@@ -842,7 +847,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                         type="text"
                         value={tagsInput}
                         onChange={(event) => setTagsInput(event.target.value)}
-                        className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                        className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-600 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/30"
                         placeholder="forest, ruins, night"
                       />
                       <p className="mt-2 text-xs text-slate-500">Separate tags with commas to help search and filtering.</p>
@@ -918,7 +923,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                             markerDisplayMetrics,
                           ),
                         )}
-                        className="group absolute -translate-x-1/2 -translate-y-1/2 rounded-full border border-white/40 bg-slate-950/80 px-3 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-white shadow-lg transition hover:border-teal-300/80 hover:text-teal-100"
+                        className="group absolute -translate-x-1/2 -translate-y-1/2 rounded-full border border-white/40 bg-slate-950/80 px-3 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-white shadow-lg transition hover:border-amber-300/70 hover:text-amber-100"
                       >
                         {marker.label || 'Marker'}
                       </button>
@@ -945,7 +950,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                     <button
                       type="button"
                       onClick={handleAddMarker}
-                      className="rounded-full border border-teal-400/60 bg-teal-500/80 px-4 py-2 text-[10px] font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-teal-400/90"
+                      className="rounded-full border border-amber-400/60 bg-amber-300/80 px-4 py-2 text-[10px] font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-amber-300/90"
                     >
                       Add Marker
                     </button>
@@ -962,7 +967,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                         key={marker.id}
                         className={`rounded-2xl border px-4 py-3 transition ${
                           isExpanded
-                            ? 'border-teal-400/60 bg-slate-950/80'
+                            ? 'border-amber-400/60 bg-slate-950/80'
                             : 'border-slate-800/70 bg-slate-950/70'
                         }`}
                       >
@@ -991,7 +996,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                           </div>
                           <span
                             className={`text-[10px] uppercase tracking-[0.35em] ${
-                              isExpanded ? 'text-teal-200' : 'text-slate-400'
+                              isExpanded ? 'text-amber-200' : 'text-slate-400'
                             }`}
                           >
                             {isExpanded ? 'Hide' : 'Edit'}
@@ -1007,7 +1012,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                                 onChange={(event) =>
                                   handleMarkerChange(marker.id, 'label', event.target.value)
                                 }
-                                className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-3 py-2 text-xs text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                                className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-3 py-2 text-xs text-slate-100 placeholder:text-slate-600 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/30"
                                 placeholder="Secret Door"
                               />
                             </label>
@@ -1020,7 +1025,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                                     handleMarkerChange(marker.id, 'notes', event.target.value)
                                   }
                                   rows={2}
-                                  className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-3 py-2 text-xs text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                                  className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-3 py-2 text-xs text-slate-100 placeholder:text-slate-600 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/30"
                                   placeholder="Trap trigger, treasure cache, etc."
                                 />
                               </label>
@@ -1032,7 +1037,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                                   onChange={(event) =>
                                     handleMarkerChange(marker.id, 'color', event.target.value)
                                   }
-                                  className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-3 py-2 text-xs text-slate-100 placeholder:text-slate-600 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
+                                  className="mt-2 w-full rounded-xl border border-slate-800/60 bg-slate-950/70 px-3 py-2 text-xs text-slate-100 placeholder:text-slate-600 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/30"
                                   placeholder="#facc15"
                                 />
                               </label>
@@ -1063,12 +1068,12 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
           </div>
         </div>
       </main>
-      <footer className="mt-0.5 border-t border-slate-800/70 px-5 py-1.5">
+        <footer className="mt-0.5 border-t border-slate-800/70 px-5 py-1.5">
         <div className="flex flex-wrap items-center justify-between gap-2">
           <button
             type="button"
             onClick={handleBack}
-            className="rounded-full border border-slate-700/70 px-4 py-1.5 text-[11px] font-semibold uppercase tracking-[0.3em] text-slate-300 transition hover:border-teal-400/60 hover:text-teal-200"
+            className="rounded-full border border-slate-700/70 px-4 py-1.5 text-[11px] font-semibold uppercase tracking-[0.3em] text-slate-300 transition hover:border-amber-400/60 hover:text-amber-200"
           >
             {step === 0 ? 'Cancel' : 'Back'}
           </button>
@@ -1081,7 +1086,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                 onClick={handleContinue}
                 className={`rounded-full border px-5 py-1.5 text-[11px] font-semibold uppercase tracking-[0.3em] transition ${
                   allowNext
-                    ? 'border-teal-400/60 bg-teal-500/80 text-slate-900 hover:bg-teal-400/90'
+                    ? 'border-amber-400/60 bg-amber-300/80 text-slate-900 hover:bg-amber-300/90'
                     : 'cursor-not-allowed border-slate-800/70 bg-slate-900/70 text-slate-500'
                 }`}
               >
@@ -1095,7 +1100,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
                 className={`rounded-full border px-5 py-1.5 text-[11px] font-semibold uppercase tracking-[0.3em] transition ${
                   creating
                     ? 'cursor-wait border-slate-800/70 bg-slate-900/70 text-slate-500'
-                    : 'border-teal-400/60 bg-teal-500/80 text-slate-900 hover:bg-teal-400/90'
+                    : 'border-amber-400/60 bg-amber-300/80 text-slate-900 hover:bg-amber-300/90'
                 }`}
               >
                 {creating ? 'Creating…' : 'Create Map'}
@@ -1103,7 +1108,8 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
             )}
           </div>
         </div>
-      </footer>
+        </footer>
+      </div>
     </div>
   );
 };

--- a/apps/pages/src/components/MapFolderList.tsx
+++ b/apps/pages/src/components/MapFolderList.tsx
@@ -87,7 +87,7 @@ const MapFolderList: React.FC<MapFolderListProps> = ({
         <button
           type="button"
           onClick={onCreateMap}
-          className="rounded-xl border border-teal-400/60 bg-teal-500/80 px-5 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-teal-400/90"
+          className="rounded-xl border border-amber-400/60 bg-amber-300/80 px-5 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-amber-300/90"
         >
           New Map
         </button>
@@ -114,7 +114,7 @@ const MapFolderList: React.FC<MapFolderListProps> = ({
                     </div>
                     <span
                       className={`inline-flex h-8 w-8 items-center justify-center rounded-full border border-slate-700/70 text-xs font-bold text-slate-300 transition ${
-                        expanded ? 'bg-teal-500/10 text-teal-200' : 'bg-slate-900'
+                        expanded ? 'bg-amber-400/10 text-amber-200' : 'bg-slate-900'
                       }`}
                       aria-hidden="true"
                     >
@@ -153,10 +153,10 @@ const MapFolderList: React.FC<MapFolderListProps> = ({
                               onSelect(map);
                             }
                           }}
-                          className={`group relative overflow-hidden rounded-2xl border px-5 py-6 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-teal-400/60 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 ${
+                          className={`group relative overflow-hidden rounded-2xl border px-5 py-6 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400/60 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 ${
                             selectedMapId === map.id
-                              ? 'border-teal-400 bg-teal-500/10 shadow-[0_0_0_1px_rgba(45,212,191,0.4)]'
-                              : 'border-slate-800/60 bg-slate-950/60 hover:border-teal-400/60 hover:shadow-[0_0_0_1px_rgba(45,212,191,0.3)]'
+                              ? 'border-amber-400 bg-amber-400/10 shadow-[0_0_0_1px_rgba(251,191,36,0.4)]'
+                              : 'border-slate-800/60 bg-slate-950/60 hover:border-amber-400/60 hover:shadow-[0_0_0_1px_rgba(251,191,36,0.3)]'
                           }`}
                         >
                           <div className="absolute right-4 top-4 flex items-center gap-2">

--- a/apps/pages/src/components/MapMaskCanvas.tsx
+++ b/apps/pages/src/components/MapMaskCanvas.tsx
@@ -112,7 +112,7 @@ const MapMaskCanvas: React.FC<MapMaskCanvasProps> = ({
       const polygon = polygonById.get(hoverRegion);
       if (polygon && polygon.length) {
         context.beginPath();
-        context.fillStyle = 'rgba(99, 102, 241, 0.25)';
+        context.fillStyle = 'rgba(251, 191, 36, 0.2)';
         polygon.forEach((point, index) => {
           const x = point.x * maskWidth;
           const y = point.y * maskHeight;
@@ -155,7 +155,7 @@ const MapMaskCanvas: React.FC<MapMaskCanvasProps> = ({
   const displayHeight = imageSize?.height || height || 768;
 
   return (
-    <div className="relative w-full overflow-hidden rounded-lg border border-slate-200 bg-slate-900/60 shadow-inner dark:border-slate-700">
+    <div className="relative w-full overflow-hidden rounded-2xl border border-white/70 bg-white/60 shadow-inner dark:border-slate-800/70 dark:bg-slate-950/60">
       {imageUrl ? (
         <img
           src={imageUrl}
@@ -164,7 +164,7 @@ const MapMaskCanvas: React.FC<MapMaskCanvasProps> = ({
           style={{ maxHeight: '70vh', objectFit: 'contain' }}
         />
       ) : (
-        <div className="flex h-64 items-center justify-center text-sm text-slate-400">
+        <div className="flex h-64 items-center justify-center text-sm text-slate-500 dark:text-slate-400">
           Upload a map to begin
         </div>
       )}
@@ -182,7 +182,7 @@ const MapMaskCanvas: React.FC<MapMaskCanvasProps> = ({
         <button
           key={marker.id}
           onClick={() => onSelectMarker?.(marker.id)}
-          className="absolute flex -translate-x-1/2 -translate-y-full items-center gap-1 rounded-full border border-white/50 bg-white/80 px-2 py-1 text-xs font-medium text-slate-900 shadow dark:border-slate-800 dark:bg-slate-900/90 dark:text-slate-100"
+          className="absolute flex -translate-x-1/2 -translate-y-full items-center gap-1 rounded-full border border-amber-400/60 bg-amber-100/90 px-2 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-amber-800 shadow dark:border-amber-400/40 dark:bg-amber-400/20 dark:text-amber-100"
           style={{
             left: `${(marker.x ?? 0) * 100}%`,
             top: `${(marker.y ?? 0) * 100}%`,

--- a/apps/pages/src/components/MarkerPanel.tsx
+++ b/apps/pages/src/components/MarkerPanel.tsx
@@ -13,7 +13,7 @@ const MarkerPanel: React.FC<MarkerPanelProps> = ({ markers, onRemove, onUpdate }
       {markers.map((marker) => (
         <div
           key={marker.id}
-          className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm dark:border-slate-700 dark:bg-slate-800"
+          className="rounded-xl border border-white/70 bg-white/60 px-3 py-2 text-sm shadow-sm dark:border-slate-800 dark:bg-slate-950/70"
         >
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
@@ -22,15 +22,15 @@ const MarkerPanel: React.FC<MarkerPanelProps> = ({ markers, onRemove, onUpdate }
                 style={{ backgroundColor: marker.color || '#facc15' }}
               />
               <div>
-                <p className="font-medium">{marker.label}</p>
-                <p className="text-xs text-slate-500 dark:text-slate-400">
+                <p className="font-semibold text-slate-900 dark:text-white">{marker.label}</p>
+                <p className="text-xs text-slate-600 dark:text-slate-400">
                   ({Math.round((marker.x ?? 0) * 100)}%, {Math.round((marker.y ?? 0) * 100)}%)
                 </p>
               </div>
             </div>
             <div className="flex items-center gap-2">
               <button
-                className="rounded-full border border-slate-300 px-2 py-1 text-xs text-slate-600 hover:bg-slate-100 dark:border-slate-600 dark:text-slate-300 dark:hover:bg-slate-700"
+                className="rounded-full border border-amber-400/70 bg-amber-200/60 px-2 py-1 text-[11px] font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-amber-200/80 dark:border-amber-400/50 dark:bg-amber-400/20 dark:text-amber-100 dark:hover:bg-amber-400/30"
                 onClick={() => onUpdate?.(marker)}
               >
                 Edit
@@ -43,10 +43,10 @@ const MarkerPanel: React.FC<MarkerPanelProps> = ({ markers, onRemove, onUpdate }
               </button>
             </div>
           </div>
-          {marker.description && <p className="mt-2 text-xs opacity-75">{marker.description}</p>}
+          {marker.description && <p className="mt-2 text-xs text-slate-600 dark:text-slate-400">{marker.description}</p>}
         </div>
       ))}
-      {markers.length === 0 && <p className="text-sm text-slate-500">No markers placed.</p>}
+      {markers.length === 0 && <p className="text-sm text-slate-500 dark:text-slate-400">No markers placed.</p>}
     </div>
   );
 };

--- a/apps/pages/src/components/RegionList.tsx
+++ b/apps/pages/src/components/RegionList.tsx
@@ -16,26 +16,26 @@ const RegionList: React.FC<RegionListProps> = ({ regions, revealedRegionIds, onT
         return (
           <div
             key={region.id}
-            className={`flex items-start justify-between rounded-lg border px-3 py-2 text-sm shadow-sm transition hover:border-primary/60 hover:shadow ${
+            className={`flex items-start justify-between rounded-xl border px-3 py-2 text-sm shadow-sm transition ${
               revealed
-                ? 'border-emerald-400/60 bg-emerald-100/20 text-emerald-900 dark:border-emerald-500/40 dark:bg-emerald-500/10 dark:text-emerald-100'
-                : 'border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-800'
+                ? 'border-amber-400/70 bg-amber-200/20 text-amber-900 dark:border-amber-400/40 dark:bg-amber-400/15 dark:text-amber-100'
+                : 'border-white/70 bg-white/60 dark:border-slate-800 dark:bg-slate-950/70'
             }`}
           >
             <div>
               <button
-                className="font-medium hover:underline"
+                className="font-semibold text-slate-900 underline-offset-4 transition hover:text-amber-600 hover:underline dark:text-white dark:hover:text-amber-200"
                 onClick={() => onSelectRegion?.(region)}
               >
                 {region.name}
               </button>
-              {region.notes && <p className="mt-1 text-xs opacity-75">{region.notes}</p>}
+              {region.notes && <p className="mt-1 text-xs text-slate-600 dark:text-slate-400">{region.notes}</p>}
             </div>
             <button
-              className={`rounded-full px-3 py-1 text-xs font-semibold ${
+              className={`rounded-full px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.3em] transition ${
                 revealed
-                  ? 'bg-emerald-500 text-white hover:bg-emerald-600'
-                  : 'bg-primary text-white hover:bg-primary-dark'
+                  ? 'border border-amber-500/70 bg-amber-500/20 text-amber-900 hover:bg-amber-500/30 dark:border-amber-400/40 dark:bg-amber-400/20 dark:text-amber-100'
+                  : 'border border-amber-400/70 bg-amber-300/80 text-slate-900 hover:bg-amber-300/90 dark:border-amber-400/50 dark:bg-amber-400/20 dark:text-amber-100'
               }`}
               onClick={() => onToggleRegion?.(region, !revealed)}
             >

--- a/apps/pages/src/components/SessionViewer.tsx
+++ b/apps/pages/src/components/SessionViewer.tsx
@@ -166,19 +166,20 @@ const SessionViewer: React.FC<SessionViewerProps> = ({
 
   return (
     <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
-      <div className="lg:col-span-2 space-y-4">
+      <div className="space-y-4 lg:col-span-2">
         <div className="flex items-center justify-between">
           <div>
-            <h2 className="text-lg font-semibold">{session.name}</h2>
-            <p className="text-sm text-slate-500 dark:text-slate-400">
-              Connection: <span className="font-medium text-primary">{connectionState}</span>
+            <h2 className="text-lg font-semibold text-slate-900 dark:text-white">{session.name}</h2>
+            <p className="text-sm text-slate-600 dark:text-slate-300">
+              Connection:{' '}
+              <span className="font-semibold text-amber-600 dark:text-amber-200">{connectionState}</span>
             </p>
           </div>
           <div className="flex items-center gap-2">
             {mode === 'dm' && (
               <>
                 <button
-                  className="rounded-full border border-slate-300 px-3 py-1 text-xs font-medium hover:bg-slate-100 dark:border-slate-600 dark:hover:bg-slate-700"
+                  className="rounded-full border border-amber-400/70 bg-amber-200/60 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-amber-200/80 dark:border-amber-400/50 dark:bg-amber-400/20 dark:text-amber-100 dark:hover:bg-amber-400/30"
                   onClick={onSaveSession}
                 >
                   Save Snapshot
@@ -192,7 +193,7 @@ const SessionViewer: React.FC<SessionViewerProps> = ({
               </>
             )}
             <button
-              className="rounded-full border border-slate-300 px-3 py-1 text-xs font-medium hover:bg-slate-100 dark:border-slate-600 dark:hover:bg-slate-700"
+              className="rounded-full border border-white/70 bg-white/60 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.3em] text-slate-700 transition hover:border-amber-400/70 hover:text-amber-600 dark:border-slate-700 dark:bg-slate-900/70 dark:text-slate-200 dark:hover:border-amber-400/60 dark:hover:text-amber-200"
               onClick={onLeave}
             >
               Leave
@@ -213,19 +214,26 @@ const SessionViewer: React.FC<SessionViewerProps> = ({
       </div>
       <div className="space-y-6">
         <section>
-          <h3 className="mb-2 text-sm font-semibold uppercase tracking-wide text-slate-500">Players</h3>
+          <h3 className="mb-2 text-xs font-semibold uppercase tracking-[0.35em] text-amber-600 dark:text-amber-200">Players</h3>
           <ul className="space-y-1 text-sm">
             {state.players.map((player) => (
-              <li key={player.id} className="rounded border border-slate-200 px-3 py-1 dark:border-slate-700">
-                <span className="font-medium">{player.name}</span>
-                <span className="ml-2 text-xs uppercase text-slate-500">{player.role}</span>
+              <li
+                key={player.id}
+                className="rounded-xl border border-white/70 bg-white/60 px-3 py-1 shadow-sm dark:border-slate-800 dark:bg-slate-950/70"
+              >
+                <span className="font-semibold text-slate-900 dark:text-white">{player.name}</span>
+                <span className="ml-2 text-[10px] uppercase tracking-[0.35em] text-slate-500 dark:text-slate-400">
+                  {player.role}
+                </span>
               </li>
             ))}
-            {state.players.length === 0 && <li className="text-xs text-slate-500">Waiting for players…</li>}
+            {state.players.length === 0 && (
+              <li className="text-xs text-slate-500 dark:text-slate-400">Waiting for players…</li>
+            )}
           </ul>
         </section>
         <section>
-          <h3 className="mb-2 text-sm font-semibold uppercase tracking-wide text-slate-500">Regions</h3>
+          <h3 className="mb-2 text-xs font-semibold uppercase tracking-[0.35em] text-amber-600 dark:text-amber-200">Regions</h3>
           <RegionList
             regions={regions}
             revealedRegionIds={state.revealedRegions}
@@ -233,7 +241,7 @@ const SessionViewer: React.FC<SessionViewerProps> = ({
           />
         </section>
         <section>
-          <h3 className="mb-2 text-sm font-semibold uppercase tracking-wide text-slate-500">Markers</h3>
+          <h3 className="mb-2 text-xs font-semibold uppercase tracking-[0.35em] text-amber-600 dark:text-amber-200">Markers</h3>
           <MarkerPanel markers={resolvedMarkers} onRemove={mode === 'dm' ? handleRemoveMarker : undefined} onUpdate={mode === 'dm' ? handleUpdateMarker : undefined} />
         </section>
       </div>

--- a/apps/pages/src/components/Toolbar.tsx
+++ b/apps/pages/src/components/Toolbar.tsx
@@ -44,15 +44,15 @@ const Toolbar: React.FC<ToolbarProps> = ({
   };
 
   return (
-    <div className="flex flex-col gap-4 rounded-lg border border-slate-200 bg-white/80 p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900/70">
+    <div className="flex flex-col gap-4 rounded-2xl border border-white/70 bg-white/60 p-4 shadow-sm dark:border-slate-800 dark:bg-slate-950/70">
       <div className="flex items-center justify-between" role="group" aria-label="Selection tools">
         <div className="flex gap-2">
           <button
             type="button"
             className={`rounded-md px-3 py-2 text-sm font-medium transition ${
               activeTool === 'magneticLasso'
-                ? 'bg-indigo-600 text-white shadow'
-                : 'bg-slate-100 text-slate-700 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700'
+                ? 'bg-gradient-to-r from-amber-400 via-orange-400 to-rose-400 text-slate-900 shadow-lg shadow-orange-500/30'
+                : 'border border-white/60 bg-white/40 text-slate-700 hover:border-amber-400/60 hover:text-amber-600 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-200 dark:hover:border-amber-400/50 dark:hover:text-amber-200'
             }`}
             aria-pressed={activeTool === 'magneticLasso'}
             onClick={() => onToolChange('magneticLasso')}
@@ -63,8 +63,8 @@ const Toolbar: React.FC<ToolbarProps> = ({
             type="button"
             className={`rounded-md px-3 py-2 text-sm font-medium transition ${
               activeTool === 'smartWand'
-                ? 'bg-indigo-600 text-white shadow'
-                : 'bg-slate-100 text-slate-700 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700'
+                ? 'bg-gradient-to-r from-amber-400 via-orange-400 to-rose-400 text-slate-900 shadow-lg shadow-orange-500/30'
+                : 'border border-white/60 bg-white/40 text-slate-700 hover:border-amber-400/60 hover:text-amber-600 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-200 dark:hover:border-amber-400/50 dark:hover:text-amber-200'
             }`}
             aria-pressed={activeTool === 'smartWand'}
             onClick={() => onToolChange('smartWand')}
@@ -74,7 +74,7 @@ const Toolbar: React.FC<ToolbarProps> = ({
         </div>
       </div>
       <div className="grid grid-cols-1 gap-3" aria-label="Advanced selection settings">
-        <label className="flex flex-col gap-1 text-sm font-medium text-slate-700 dark:text-slate-200">
+        <label className="flex flex-col gap-1 text-sm font-semibold text-slate-800 dark:text-slate-200">
           Edge contrast emphasis
           <input
             type="range"
@@ -85,11 +85,11 @@ const Toolbar: React.FC<ToolbarProps> = ({
             onChange={(event) => updateSetting('edgeContrast', parseFloat(event.currentTarget.value))}
             aria-label="Edge contrast emphasis"
           />
-          <span className="text-xs font-normal text-slate-500 dark:text-slate-400">
+          <span className="text-xs font-normal text-slate-600 dark:text-slate-400">
             Higher values increase the CLAHE contrast boost for the worker pipeline.
           </span>
         </label>
-        <label className="flex flex-col gap-1 text-sm font-medium text-slate-700 dark:text-slate-200">
+        <label className="flex flex-col gap-1 text-sm font-semibold text-slate-800 dark:text-slate-200">
           Snap strength
           <input
             type="range"
@@ -100,11 +100,11 @@ const Toolbar: React.FC<ToolbarProps> = ({
             onChange={(event) => updateSetting('snapStrength', parseFloat(event.currentTarget.value))}
             aria-label="Snap strength"
           />
-          <span className="text-xs font-normal text-slate-500 dark:text-slate-400">
+          <span className="text-xs font-normal text-slate-600 dark:text-slate-400">
             Controls how aggressively polygons snap to the cost pyramid edges.
           </span>
         </label>
-        <label className="flex items-center gap-2 text-sm font-medium text-slate-700 dark:text-slate-200">
+        <label className="flex items-center gap-2 text-sm font-semibold text-slate-800 dark:text-slate-200">
           <input
             type="checkbox"
             checked={settings.autoEntranceLock}
@@ -112,7 +112,7 @@ const Toolbar: React.FC<ToolbarProps> = ({
           />
           Auto-lock detected entrances
         </label>
-        <label className="flex items-center gap-2 text-sm font-medium text-slate-700 dark:text-slate-200">
+        <label className="flex items-center gap-2 text-sm font-semibold text-slate-800 dark:text-slate-200">
           <input
             type="checkbox"
             checked={settings.livePreview}
@@ -120,7 +120,7 @@ const Toolbar: React.FC<ToolbarProps> = ({
           />
           Live preview updates
         </label>
-        <label className="flex items-center gap-2 text-sm font-medium text-slate-700 dark:text-slate-200">
+        <label className="flex items-center gap-2 text-sm font-semibold text-slate-800 dark:text-slate-200">
           <input
             type="checkbox"
             checked={settings.showDebugOverlay}


### PR DESCRIPTION
## Summary
- retheme the map creation wizard with warm amber accents and parchment-inspired overlays that match the landing page palette
- refresh dashboard list, toolbar, and session controls to share the same amber-focused styling and typography
- update map canvas, region, and marker surfaces so supporting panels inherit the new color system

## Testing
- npm run test -- --run *(fails: prompts for missing jsdom dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68dd95e046448323b9288244b0f0c5d7