### PR TITLE
Integrate Add Markers step with Define Rooms layout

### DIFF
--- a/apps/pages/src/define-rooms/styles.css
+++ b/apps/pages/src/define-rooms/styles.css
@@ -889,6 +889,317 @@
   opacity: 1;
 }
 
+.marker-step {
+  background: rgba(15, 23, 42, 0.45);
+  border-radius: 16px;
+}
+
+.marker-step .define-room-editor {
+  padding: 18px 18px 18px 24px;
+  gap: 24px;
+}
+
+.marker-step .toolbar-area {
+  width: 100%;
+  justify-content: space-between;
+  align-items: stretch;
+}
+
+.marker-toolbar-wrapper {
+  display: flex;
+  gap: 18px;
+  width: 100%;
+  align-items: flex-start;
+}
+
+.marker-room-legend {
+  flex: 1;
+  background: rgba(15, 23, 42, 0.62);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 18px;
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  color: rgba(226, 232, 240, 0.86);
+  min-height: 140px;
+}
+
+.marker-legend-title {
+  margin: 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.35em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.78);
+}
+
+.marker-room-legend-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.marker-room-legend-item {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.marker-room-legend-swatch {
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  border: 2px solid rgba(15, 23, 42, 0.8);
+  flex-shrink: 0;
+  box-shadow: 0 8px 16px rgba(15, 23, 42, 0.45);
+}
+
+.marker-room-legend-details {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.marker-room-legend-name {
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: rgba(226, 232, 240, 0.95);
+}
+
+.marker-room-legend-meta {
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.marker-legend-empty {
+  margin: 0;
+  font-size: 0.8rem;
+  line-height: 1.5;
+  color: rgba(148, 163, 184, 0.78);
+}
+
+.marker-toolbar .toolbar-button {
+  box-shadow: 0 14px 32px rgba(250, 204, 21, 0.3);
+}
+
+.marker-canvas-wrapper {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(15, 23, 42, 0.45);
+}
+
+.marker-stage {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.marker-stage-image {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  pointer-events: none;
+}
+
+.marker-stage-placeholder {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 24px;
+  font-size: 0.85rem;
+  color: rgba(148, 163, 184, 0.8);
+}
+
+.marker-mask-overlay {
+  position: absolute;
+  pointer-events: none;
+  border-radius: 14px;
+  mix-blend-mode: lighten;
+}
+
+.marker-mask-room path {
+  fill-opacity: 0.18;
+  stroke-width: 2;
+  stroke-opacity: 0.7;
+}
+
+.marker-mask-label {
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  fill: rgba(15, 23, 42, 0.86);
+  stroke: rgba(255, 255, 255, 0.85);
+  stroke-width: 0.6px;
+  paint-order: stroke fill;
+  text-transform: uppercase;
+}
+
+.marker-pin {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.45);
+  background: rgba(15, 23, 42, 0.9);
+  color: rgba(248, 250, 252, 0.95);
+  font-size: 0.7rem;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  box-shadow: 0 14px 32px rgba(15, 23, 42, 0.55);
+  cursor: grab;
+  z-index: 3;
+  transition: border-color 0.2s ease, background 0.2s ease, transform 0.2s ease;
+}
+
+.marker-pin:active {
+  cursor: grabbing;
+}
+
+.marker-pin:hover {
+  border-color: rgba(250, 204, 21, 0.7);
+  background: rgba(15, 23, 42, 0.96);
+  transform: translate(-50%, -52%);
+}
+
+.marker-pin-color {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.6);
+  box-shadow: 0 0 0 2px rgba(15, 23, 42, 0.7);
+}
+
+.marker-pin-label {
+  pointer-events: none;
+}
+
+.marker-sidebar {
+  width: 28%;
+  min-width: 260px;
+  background: rgba(15, 23, 42, 0.62);
+}
+
+.marker-empty {
+  font-size: 0.78rem;
+  color: rgba(148, 163, 184, 0.78);
+  margin-top: 0;
+}
+
+.marker-list {
+  gap: 14px;
+}
+
+.marker-card {
+  transition: border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.marker-row {
+  grid-template-columns: 18px 1fr auto;
+  align-items: center;
+  gap: 12px;
+}
+
+.marker-row-details {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.marker-row-name {
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.marker-row-meta {
+  font-size: 0.7rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.marker-row-toggle {
+  font-size: 0.7rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.marker-card-body {
+  gap: 16px;
+}
+
+.marker-field-input,
+.marker-field-textarea {
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.32);
+  border-radius: 12px;
+  padding: 10px 12px;
+  color: rgba(226, 232, 240, 0.95);
+  font-size: 0.9rem;
+}
+
+.marker-field-input:focus,
+.marker-field-textarea:focus {
+  outline: none;
+  border-color: rgba(56, 189, 248, 0.6);
+  box-shadow: 0 0 0 1px rgba(56, 189, 248, 0.35);
+}
+
+.marker-field-textarea {
+  resize: vertical;
+  min-height: 72px;
+}
+
+.marker-card-footer {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.marker-remove-button {
+  border-radius: 999px;
+  padding: 6px 16px;
+  border: 1px solid rgba(248, 113, 113, 0.6);
+  background: rgba(248, 113, 113, 0.12);
+  color: rgba(252, 165, 165, 0.92);
+  font-weight: 600;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.marker-remove-button:hover,
+.marker-remove-button:focus-visible {
+  outline: none;
+  transform: translateY(-1px);
+  background: rgba(248, 113, 113, 0.2);
+  box-shadow: 0 12px 24px rgba(248, 113, 113, 0.28);
+}
+
+.marker-list-empty {
+  border: 1px dashed rgba(148, 163, 184, 0.32);
+  border-radius: 14px;
+  padding: 28px 16px;
+  text-align: center;
+  font-size: 0.8rem;
+  color: rgba(148, 163, 184, 0.75);
+  background: rgba(15, 23, 42, 0.5);
+}
+
 @media (max-width: 960px) {
   .define-room-window {
     height: 90vh;


### PR DESCRIPTION
## Summary
- refactor the Add Markers wizard step to share the Define Rooms editor layout
- surface room masks from the Define Rooms step on the marker canvas with an accompanying legend
- update marker controls and styling to match the Define Rooms interface components

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dee31dfcdc832383296eab71a1cf98