### PR TITLE
Integrate marker placement mode into map wizard

### DIFF
--- a/apps/pages/src/define-rooms/styles.css
+++ b/apps/pages/src/define-rooms/styles.css
@@ -43,6 +43,36 @@
   display: none;
 }
 
+.define-room-marker-placement .define-room-window {
+  background: transparent;
+  border: none;
+  box-shadow: none;
+}
+
+.define-room-marker-placement .define-room-body {
+  padding: 0;
+}
+
+.define-room-marker-placement .define-room-editor {
+  padding: 0;
+}
+
+.define-room-marker-placement .toolbar-area,
+.define-room-marker-placement .define-room-sidebar,
+.define-room-marker-placement .brush-slider-container {
+  display: none !important;
+}
+
+.define-room-marker-placement .canvas-wrapper {
+  background: transparent;
+  border: none;
+  border-radius: inherit;
+}
+
+.define-room-marker-placement .room-hover-label {
+  display: none;
+}
+
 .define-room-window {
   width: min(1200px, 92vw);
   height: min(760px, 88vh);


### PR DESCRIPTION
## Summary
- reuse the DefineRoom instance during the marker placement step and keep existing room masks visible under markers
- add a marker placement interaction mode to DefineRoom that disables editing tools and hides room controls while still rendering confirmed masks
- render markers in an overlay above the DefineRoom canvas during step 3 so they can be dragged without obscuring the masks

## Testing
- pnpm --filter pages lint *(fails: No projects matched the filters)*

------
https://chatgpt.com/codex/tasks/task_e_68def1f021408323b36cd7367746deb9