### PR TITLE
Add marker type palette to map wizard

### DIFF
--- a/apps/pages/src/components/MapMaskCanvas.tsx
+++ b/apps/pages/src/components/MapMaskCanvas.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import type { Marker, Region } from '../types';
 import { roomMaskToPolygon } from '../utils/roomMask';
+import { getMapMarkerIconDefinition } from './mapMarkerIcons';
 
 interface MapMaskCanvasProps {
   imageUrl?: string | null;
@@ -178,20 +179,31 @@ const MapMaskCanvas: React.FC<MapMaskCanvasProps> = ({
         onMouseLeave={() => setHoverRegion(null)}
         onClick={handleClick}
       />
-      {resolvedMarkers.map((marker) => (
-        <button
-          key={marker.id}
-          onClick={() => onSelectMarker?.(marker.id)}
-          className="absolute flex -translate-x-1/2 -translate-y-full items-center gap-1 rounded-full border border-amber-400/60 bg-amber-100/90 px-2 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-amber-800 shadow dark:border-amber-400/40 dark:bg-amber-400/20 dark:text-amber-100"
-          style={{
-            left: `${(marker.x ?? 0) * 100}%`,
-            top: `${(marker.y ?? 0) * 100}%`,
-          }}
-        >
-          <span className="inline-block h-2 w-2 rounded-full" style={{ backgroundColor: marker.color || '#facc15' }} />
-          {marker.label}
-        </button>
-      ))}
+      {resolvedMarkers.map((marker) => {
+        const iconDefinition = getMapMarkerIconDefinition(marker.iconKey);
+        return (
+          <button
+            key={marker.id}
+            onClick={() => onSelectMarker?.(marker.id)}
+            className="absolute flex -translate-x-1/2 -translate-y-full items-center gap-1 rounded-full border border-amber-400/60 bg-amber-100/90 px-2 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-amber-800 shadow transition hover:border-amber-400/80 dark:border-amber-400/40 dark:bg-amber-400/20 dark:text-amber-100"
+            style={{
+              left: `${(marker.x ?? 0) * 100}%`,
+              top: `${(marker.y ?? 0) * 100}%`,
+            }}
+          >
+            <span
+              className="inline-block h-2 w-2 rounded-full"
+              style={{ backgroundColor: marker.color || iconDefinition?.defaultColor || '#facc15' }}
+            />
+            {iconDefinition && (
+              <span className="flex h-4 w-4 items-center justify-center text-amber-800 dark:text-amber-100">
+                {iconDefinition.icon}
+              </span>
+            )}
+            {marker.label}
+          </button>
+        );
+      })}
     </div>
   );
 };

--- a/apps/pages/src/components/mapMarkerIcons.tsx
+++ b/apps/pages/src/components/mapMarkerIcons.tsx
@@ -1,0 +1,130 @@
+import React from 'react';
+
+export type MapMarkerIconKey =
+  | 'character'
+  | 'monster'
+  | 'trap'
+  | 'object'
+  | 'investigation'
+  | 'area';
+
+export type MapMarkerKind = 'point' | 'area';
+
+export interface MapMarkerIconDefinition {
+  key: MapMarkerIconKey;
+  label: string;
+  kind: MapMarkerKind;
+  defaultColor: string;
+  icon: React.ReactElement;
+}
+
+const iconBaseClassName = 'h-5 w-5';
+
+const createIcon = (paths: React.ReactNode) => (
+  <svg
+    viewBox="0 0 24 24"
+    role="img"
+    aria-hidden="true"
+    className={iconBaseClassName}
+    focusable="false"
+  >
+    <g fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8}>
+      {paths}
+    </g>
+  </svg>
+);
+
+export const mapMarkerIconDefinitions: MapMarkerIconDefinition[] = [
+  {
+    key: 'character',
+    label: 'Character Marker',
+    kind: 'point',
+    defaultColor: '#facc15',
+    icon: createIcon(
+      <>
+        <circle cx={12} cy={7.5} r={3.5} />
+        <path d="M6.5 19c1.2-3.2 4-5 5.5-5s4.3 1.8 5.5 5" />
+      </>,
+    ),
+  },
+  {
+    key: 'monster',
+    label: 'Monster Marker',
+    kind: 'point',
+    defaultColor: '#f97316',
+    icon: createIcon(
+      <>
+        <path d="M6 8c0-2.8 2.7-5 6-5s6 2.2 6 5v4.5c0 2-1.8 3.5-4 3.5h-4c-2.2 0-4-1.5-4-3.5Z" />
+        <path d="M9.5 12.5c.5.5 1.2.8 2 .8s1.5-.3 2-.8" />
+        <path d="M8 4.5 9.5 7 11 4.5" />
+        <path d="M13 4.5 14.5 7 16 4.5" />
+      </>,
+    ),
+  },
+  {
+    key: 'trap',
+    label: 'Trap Marker',
+    kind: 'point',
+    defaultColor: '#f87171',
+    icon: createIcon(
+      <>
+        <path d="m5 16 7-10 7 10" />
+        <path d="M5 16h14" />
+        <path d="m9 16 3 4 3-4" />
+      </>,
+    ),
+  },
+  {
+    key: 'object',
+    label: 'Object Marker',
+    kind: 'point',
+    defaultColor: '#38bdf8',
+    icon: createIcon(
+      <>
+        <path d="M6.5 10 12 6l5.5 4" />
+        <path d="M6 10v6l6 4 6-4v-6" />
+        <path d="M6 16.5 12 20l6-3.5" />
+      </>,
+    ),
+  },
+  {
+    key: 'investigation',
+    label: 'Investigation Marker',
+    kind: 'point',
+    defaultColor: '#a855f7',
+    icon: createIcon(
+      <>
+        <circle cx={10.5} cy={10.5} r={4} />
+        <path d="m13.5 13.5 4 4" />
+      </>,
+    ),
+  },
+  {
+    key: 'area',
+    label: 'Area Marker',
+    kind: 'area',
+    defaultColor: '#22c55e',
+    icon: createIcon(
+      <>
+        <circle cx={12} cy={12} r={7} />
+        <circle cx={12} cy={12} r={3.5} />
+      </>,
+    ),
+  },
+];
+
+export const mapMarkerIconsByKey: Record<MapMarkerIconKey, MapMarkerIconDefinition> = mapMarkerIconDefinitions.reduce(
+  (acc, definition) => {
+    acc[definition.key] = definition;
+    return acc;
+  },
+  {} as Record<MapMarkerIconKey, MapMarkerIconDefinition>,
+);
+
+export const getMapMarkerIconDefinition = (key: string | null | undefined) => {
+  if (!key) {
+    return undefined;
+  }
+  return mapMarkerIconsByKey[key as MapMarkerIconKey];
+};
+


### PR DESCRIPTION
## Summary
- create shared marker icon metadata for marker palette and map rendering
- replace the step-three "Add Marker" button with an icon palette that presets marker defaults and prompts for area geometry
- propagate selected marker icons when saving markers and render icons on the map canvas

## Testing
- npm run test -- --run *(fails: missing jsdom dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68df1db056c88323a2afd1a8c47d1ca6