### PR TITLE
Add marker geometry payload support

### DIFF
--- a/apps/pages/src/types.ts
+++ b/apps/pages/src/types.ts
@@ -48,6 +48,19 @@ export interface Region {
   revealOrder?: number | null;
 }
 
+export type MarkerPoint = { x: number; y: number };
+
+export type MarkerKind = 'point' | 'area';
+
+export type MarkerAreaShape = 'circle' | 'polygon';
+
+export interface MarkerCircleGeometry {
+  center: MarkerPoint;
+  radius: number;
+}
+
+export type MarkerPolygonGeometry = MarkerPoint[];
+
 export interface Marker {
   id: string;
   mapId?: string;
@@ -58,6 +71,10 @@ export interface Marker {
   y: number;
   color?: string | null;
   notes?: string | null;
+  kind?: MarkerKind | null;
+  areaShape?: MarkerAreaShape | null;
+  circle?: MarkerCircleGeometry | null;
+  polygon?: MarkerPolygonGeometry | null;
 }
 
 export interface SessionRecord {


### PR DESCRIPTION
## Summary
- extend marker types to include kind and area geometry definitions
- normalize marker data in the API client and serialize geometry into request payloads
- send icon and geometry information from the map creation wizard when creating markers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df33a4b14083239c9c137a74d3b382