### PR TITLE
Link map markers to defined rooms

### DIFF
--- a/apps/pages/src/api/client.ts
+++ b/apps/pages/src/api/client.ts
@@ -68,6 +68,7 @@ interface MarkerPayload {
   areaShape?: MarkerAreaShape | null;
   circle?: MarkerCircleGeometry | null;
   polygon?: MarkerPolygonGeometry | null;
+  regionId?: string | null;
 }
 
 interface SessionPayload {
@@ -187,6 +188,9 @@ const serializeMarkerPayload = (payload: Partial<MarkerPayload>) => {
   if (payload.notes !== undefined) {
     body.notes = payload.notes;
   }
+  if (payload.regionId !== undefined) {
+    body.regionId = payload.regionId === null ? null : String(payload.regionId);
+  }
   if (payload.x !== undefined) {
     body.x = clampNormalized(payload.x, 0.5);
   }
@@ -264,6 +268,9 @@ const serializeMarkerPayload = (payload: Partial<MarkerPayload>) => {
 };
 
 const normalizeMarker = (raw: any): Marker => {
+  const rawRegionId = raw?.regionId ?? raw?.data?.regionId;
+  const normalizedRegionId =
+    rawRegionId === undefined || rawRegionId === null ? null : String(rawRegionId);
   const base: Marker = {
     id: String(raw?.id ?? ''),
     mapId: raw?.mapId ? String(raw.mapId) : undefined,
@@ -278,6 +285,7 @@ const normalizeMarker = (raw: any): Marker => {
     areaShape: null,
     circle: null,
     polygon: null,
+    regionId: normalizedRegionId,
   };
 
   const data = raw?.data && typeof raw.data === 'object' ? (raw.data as Record<string, unknown>) : {};

--- a/apps/pages/src/types.ts
+++ b/apps/pages/src/types.ts
@@ -75,6 +75,7 @@ export interface Marker {
   areaShape?: MarkerAreaShape | null;
   circle?: MarkerCircleGeometry | null;
   polygon?: MarkerPolygonGeometry | null;
+  regionId?: string | null;
 }
 
 export interface SessionRecord {


### PR DESCRIPTION
## Summary
- derive polygons for defined rooms and auto-assign draft markers to the containing room while tracking manual overrides
- surface each marker's linked room or hallway in the wizard UI with controls to reassign or reset to auto-detection
- persist region links by including the resolved region id when creating markers and extend marker typing for downstream use

## Testing
- npm run test *(fails: vitest prompts to install jsdom)*

------
https://chatgpt.com/codex/tasks/task_e_68df3820b89083239c114f92e3975803