### PR TITLE
Integrate marker placement UI into Define Rooms step

### DIFF
--- a/apps/pages/src/define-rooms/DefineRoom.tsx
+++ b/apps/pages/src/define-rooms/DefineRoom.tsx
@@ -456,6 +456,9 @@ export class DefineRoom {
   private root: HTMLElement;
 
   private roomsPanel!: HTMLElement;
+  private markerPanel!: HTMLElement;
+  private markerPanelContent!: HTMLElement;
+  private markerToolbarHost!: HTMLElement;
 
   private roomsList!: HTMLElement;
 
@@ -690,6 +693,10 @@ export class DefineRoom {
                   ></div>
                 </div>
                 <div class="toolbar" ref={(node: HTMLElement | null) => node && (this.toolbarContainer = node)}>
+                  <div
+                    class="marker-toolbar"
+                    ref={(node: HTMLElement | null) => node && (this.markerToolbarHost = node)}
+                  ></div>
                   <div class="toolbar-primary-group">
                     <button class="toolbar-button toolbar-primary" type="button" aria-label="New Room" title="New Room">
                       <span class="toolbar-button-icon" aria-hidden="true"></span>
@@ -746,15 +753,26 @@ export class DefineRoom {
                 <div class="room-hover-label" aria-hidden="true"></div>
               </div>
             </section>
-            <aside class="define-room-sidebar" ref={(node: HTMLElement | null) => node && (this.roomsPanel = node)}>
-              <div class="rooms-header">
-                <h2>Rooms</h2>
+            <aside class="define-room-sidebar">
+              <div class="rooms-panel" ref={(node: HTMLElement | null) => node && (this.roomsPanel = node)}>
+                <div class="rooms-header">
+                  <h2>Rooms</h2>
+                </div>
+                <p class="rooms-empty" ref={(node: HTMLElement | null) => node && (this.roomsEmptyState = node)}>
+                  No rooms defined yet.
+                </p>
+                <div class="rooms-list"></div>
+                <div class="room-color-menu hidden" aria-hidden="true"></div>
               </div>
-              <p class="rooms-empty" ref={(node: HTMLElement | null) => node && (this.roomsEmptyState = node)}>
-                No rooms defined yet.
-              </p>
-              <div class="rooms-list"></div>
-              <div class="room-color-menu hidden" aria-hidden="true"></div>
+              <div
+                class="marker-panel"
+                ref={(node: HTMLElement | null) => node && (this.markerPanel = node)}
+              >
+                <div
+                  class="marker-panel-content"
+                  ref={(node: HTMLElement | null) => node && (this.markerPanelContent = node)}
+                ></div>
+              </div>
             </aside>
           </div>
         </div>
@@ -827,6 +845,14 @@ export class DefineRoom {
     }));
   }
 
+  public getMarkerSidebarHost(): HTMLElement | null {
+    return this.markerPanelContent ?? null;
+  }
+
+  public getMarkerToolbarHost(): HTMLElement | null {
+    return this.markerToolbarHost ?? null;
+  }
+
   public getImageDimensions(): { width: number; height: number } {
     return { width: this.width, height: this.height };
   }
@@ -849,6 +875,18 @@ export class DefineRoom {
     }
     this.interactionMode = nextMode;
     this.root.classList.toggle("define-room-marker-placement", enabled);
+    if (this.toolbarContainer) {
+      this.toolbarContainer.classList.toggle("marker-mode", enabled);
+    }
+    if (this.markerToolbarHost) {
+      this.markerToolbarHost.classList.toggle("marker-toolbar--active", enabled);
+    }
+    if (this.roomsPanel) {
+      this.roomsPanel.classList.toggle("rooms-panel--hidden", enabled);
+    }
+    if (this.markerPanel) {
+      this.markerPanel.classList.toggle("marker-panel--active", enabled);
+    }
     if (enabled && this.currentTool !== "move") {
       this.setTool("move");
     }

--- a/apps/pages/src/define-rooms/styles.css
+++ b/apps/pages/src/define-rooms/styles.css
@@ -57,8 +57,7 @@
   padding: 0;
 }
 
-.define-room-marker-placement .toolbar-area,
-.define-room-marker-placement .define-room-sidebar,
+
 .define-room-marker-placement .brush-slider-container {
   display: none !important;
 }
@@ -238,6 +237,26 @@
   flex-direction: column;
   gap: 18px;
   position: relative;
+}
+
+.rooms-panel.rooms-panel--hidden {
+  display: none;
+}
+
+.marker-panel {
+  display: none;
+  flex: 1;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.marker-panel.marker-panel--active {
+  display: flex;
+}
+
+.marker-panel-content {
+  flex: 1;
+  min-height: 0;
 }
 
 .rooms-header {
@@ -685,6 +704,38 @@
   width: 3px;
   border-radius: 999px;
   background: linear-gradient(180deg, #38bdf8, #3b82f6);
+}
+
+.marker-toolbar {
+  display: none;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 14px;
+  width: 100%;
+  min-height: 0;
+}
+
+.marker-toolbar.marker-toolbar--active {
+  display: flex;
+}
+
+.marker-toolbar-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  width: 100%;
+}
+
+.marker-toolbar-custom {
+  margin-top: auto;
+  width: 100%;
+}
+
+.toolbar.marker-mode .toolbar-primary-group,
+.toolbar.marker-mode .toolbar-confirm-group,
+.toolbar.marker-mode .history-group,
+.toolbar.marker-mode .tool-group {
+  display: none !important;
 }
 
 .toolbar-button {


### PR DESCRIPTION
## Summary
- embed the marker toolbar and summary sidebar for step 3 through the DefineRoom portals so the map view stays anchored
- remove the legacy add-marker panel and palette logic now that marker controls live inside the Define Rooms layout
- update the embedded DefineRoom styles to expose marker toolbar/sidebar containers when marker placement mode is active

## Testing
- npm test -- --run *(fails: vitest prompts to install missing jsdom)*

------
https://chatgpt.com/codex/tasks/task_e_690148ede0b88323bf6a2d96e587cb45