### PR TITLE
Add temporary markers tab to define rooms UI

### DIFF
--- a/defineRooms/dist/components/DefineRoom.js
+++ b/defineRooms/dist/components/DefineRoom.js
@@ -307,6 +307,56 @@ const REDO_ICON = `
     />
   </svg>
 `;
+const CHARACTER_MARKER_ICON = `
+  <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path
+      d="M12 21c3.3-3.1 5-5.9 5-8.5a5 5 0 10-10 0c0 2.6 1.7 5.4 5 8.5z"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+    <path
+      d="M12 11a3 3 0 100-6 3 3 0 000 6z"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+  </svg>
+`;
+const OBJECT_MARKER_ICON = `
+  <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path
+      d="M12 3l8 4.5v9L12 21l-8-4.5v-9L12 3z"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+    <path
+      d="M12 12l8-4.5"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+    <path
+      d="M12 12v9"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+    <path
+      d="M12 12L4 7.5"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+  </svg>
+`;
 const HISTORY_LIMIT = 30;
 function colorToVector(color) {
     const hex = color.replace("#", "");
@@ -410,6 +460,7 @@ export class DefineRoom {
         this.toolButtons = new Map();
         this.brushSliderPointerId = null;
         this.brushSliderCaptureElement = null;
+        this.activeEditorMode = "rooms";
         this.rooms = [];
         this.expandedRoomId = null;
         this.activeRoomId = null;
@@ -468,15 +519,17 @@ export class DefineRoom {
             this.updateBrushRadiusFromPointer(event);
             this.stopBrushSliderInteraction();
         };
-        this.root = (_jsxs("div", { class: "define-room-overlay hidden", children: [_jsxs("div", { class: "define-room-window", children: [_jsxs("div", { class: "define-room-header", children: [_jsx("h1", { children: "Define Rooms" }), _jsx("button", { class: "define-room-close", type: "button", children: "Close" })] }), _jsxs("div", { class: "define-room-body", children: [_jsxs("section", { class: "define-room-editor", children: [_jsxs("div", { class: "toolbar-area", children: [_jsxs("div", { class: "brush-slider-container", ref: (node) => node && (this.brushSliderContainer = node), "aria-hidden": "true", "aria-label": "Brush size", children: [_jsxs("div", { class: "brush-slider-track", ref: (node) => node && (this.brushSliderTrack = node), children: [_jsx("div", { class: "brush-slider-fill", ref: (node) => node && (this.brushSliderFill = node) }), _jsx("div", { class: "brush-slider-thumb", ref: (node) => node && (this.brushSliderThumb = node) })] }), _jsx("div", { class: "brush-slider-value", "aria-hidden": "true", ref: (node) => node && (this.brushSliderValueLabel = node) })] }), _jsxs("div", { class: "toolbar", ref: (node) => node && (this.toolbarContainer = node), children: [_jsxs("div", { class: "toolbar-primary-group", children: [_jsxs("button", { class: "toolbar-button toolbar-primary", type: "button", "aria-label": "New Room", title: "New Room", children: [_jsx("span", { class: "toolbar-button-icon", "aria-hidden": "true" }), _jsx("span", { class: "toolbar-button-label", "aria-hidden": "true", children: "New Room" })] }), _jsxs("div", { class: "toolbar-confirm-group", children: [_jsxs("button", { class: "toolbar-button toolbar-confirm", type: "button", "aria-label": "Confirm Room", title: "Confirm Room", children: [_jsx("span", { class: "toolbar-button-icon", "aria-hidden": "true" }), _jsx("span", { class: "toolbar-button-label", "aria-hidden": "true", children: "Confirm" })] }), _jsxs("button", { class: "toolbar-button toolbar-cancel", type: "button", "aria-label": "Cancel Room", title: "Cancel Room", children: [_jsx("span", { class: "toolbar-button-icon", "aria-hidden": "true" }), _jsx("span", { class: "toolbar-button-label", "aria-hidden": "true", children: "Cancel" })] })] })] }), _jsxs("div", { class: "history-group", children: [_jsxs("button", { class: "toolbar-button tool-button history-button toolbar-undo", type: "button", "aria-label": "Undo", title: "Undo", children: [_jsx("span", { class: "toolbar-button-icon", "aria-hidden": "true" }), _jsx("span", { class: "toolbar-button-label", "aria-hidden": "true", children: "Undo" })] }), _jsxs("button", { class: "toolbar-button tool-button history-button toolbar-redo", type: "button", "aria-label": "Redo", title: "Redo", children: [_jsx("span", { class: "toolbar-button-icon", "aria-hidden": "true" }), _jsx("span", { class: "toolbar-button-label", "aria-hidden": "true", children: "Redo" })] })] }), _jsx("div", { class: "tool-group" })] })] }), _jsxs("div", { class: "canvas-wrapper", children: [_jsx("canvas", { class: "image-layer" }), _jsx("canvas", { class: "mask-layer" }), _jsx("canvas", { class: "selection-layer" }), _jsx("div", { class: "room-hover-label", "aria-hidden": "true" })] })] }), _jsxs("aside", { class: "define-room-sidebar", ref: (node) => node && (this.roomsPanel = node), children: [_jsx("div", { class: "rooms-header", children: _jsx("h2", { children: "Rooms" }) }), _jsx("p", { class: "rooms-empty", ref: (node) => node && (this.roomsEmptyState = node), children: "No rooms defined yet." }), _jsx("div", { class: "rooms-list" }), _jsx("div", { class: "room-color-menu hidden", "aria-hidden": "true" })] })] })] }), _jsx("div", { class: "room-delete-backdrop hidden", "aria-hidden": "true", children: _jsxs("div", { class: "room-delete-card", role: "dialog", "aria-modal": "true", "aria-labelledby": "room-delete-title", tabindex: "-1", children: [_jsx("div", { class: "room-delete-icon-wrapper", children: _jsx("div", { class: "room-delete-icon", "aria-hidden": "true" }) }), _jsx("h2", { id: "room-delete-title", class: "room-delete-title", children: "Are you sure?" }), _jsx("p", { class: "room-delete-message", children: "Do you really want to continue ? This process cannot be undone" }), _jsxs("div", { class: "room-delete-actions", children: [_jsx("button", { class: "room-delete-cancel", type: "button", children: "Cancel" }), _jsx("button", { class: "room-delete-confirm", type: "button", children: "Confirm" })] })] }) })] }));
+        this.root = (_jsxs("div", { class: "define-room-overlay hidden", children: [_jsxs("div", { class: "define-room-window", children: [_jsxs("div", { class: "define-room-header", children: [_jsx("h1", { children: "Define Rooms" }), _jsx("button", { class: "define-room-close", type: "button", children: "Close" })] }), _jsxs("div", { class: "define-room-body", children: [_jsxs("section", { class: "define-room-editor", children: [_jsxs("div", { class: "toolbar-area", children: [_jsxs("div", { class: "editor-tabs", role: "tablist", children: [_jsx("button", { class: "editor-tab active", type: "button", role: "tab", "aria-selected": "true", "data-mode": "rooms", ref: (node) => node && (this.editorTabsDefineRoomsButton = node), children: "Define Rooms" }), _jsx("button", { class: "editor-tab", type: "button", role: "tab", "aria-selected": "false", "data-mode": "markers", ref: (node) => node && (this.editorTabsMarkersButton = node), children: "Temporary Markers" })] }), _jsxs("div", { class: "toolbar-wrapper", ref: (node) => node && (this.defineRoomsToolbarWrapper = node), "aria-hidden": "false", children: [_jsxs("div", { class: "brush-slider-container", ref: (node) => node && (this.brushSliderContainer = node), "aria-hidden": "true", "aria-label": "Brush size", children: [_jsxs("div", { class: "brush-slider-track", ref: (node) => node && (this.brushSliderTrack = node), children: [_jsx("div", { class: "brush-slider-fill", ref: (node) => node && (this.brushSliderFill = node) }), _jsx("div", { class: "brush-slider-thumb", ref: (node) => node && (this.brushSliderThumb = node) })] }), _jsx("div", { class: "brush-slider-value", "aria-hidden": "true", ref: (node) => node && (this.brushSliderValueLabel = node) })] }), _jsxs("div", { class: "toolbar", ref: (node) => node && (this.toolbarContainer = node), children: [_jsxs("div", { class: "toolbar-primary-group", children: [_jsxs("button", { class: "toolbar-button toolbar-primary", type: "button", "aria-label": "New Room", title: "New Room", children: [_jsx("span", { class: "toolbar-button-icon", "aria-hidden": "true" }), _jsx("span", { class: "toolbar-button-label", "aria-hidden": "true", children: "New Room" })] }), _jsxs("div", { class: "toolbar-confirm-group", children: [_jsxs("button", { class: "toolbar-button toolbar-confirm", type: "button", "aria-label": "Confirm Room", title: "Confirm Room", children: [_jsx("span", { class: "toolbar-button-icon", "aria-hidden": "true" }), _jsx("span", { class: "toolbar-button-label", "aria-hidden": "true", children: "Confirm" })] }), _jsxs("button", { class: "toolbar-button toolbar-cancel", type: "button", "aria-label": "Cancel Room", title: "Cancel Room", children: [_jsx("span", { class: "toolbar-button-icon", "aria-hidden": "true" }), _jsx("span", { class: "toolbar-button-label", "aria-hidden": "true", children: "Cancel" })] })] })] }), _jsxs("div", { class: "history-group", children: [_jsxs("button", { class: "toolbar-button tool-button history-button toolbar-undo", type: "button", "aria-label": "Undo", title: "Undo", children: [_jsx("span", { class: "toolbar-button-icon", "aria-hidden": "true" }), _jsx("span", { class: "toolbar-button-label", "aria-hidden": "true", children: "Undo" })] }), _jsxs("button", { class: "toolbar-button tool-button history-button toolbar-redo", type: "button", "aria-label": "Redo", title: "Redo", children: [_jsx("span", { class: "toolbar-button-icon", "aria-hidden": "true" }), _jsx("span", { class: "toolbar-button-label", "aria-hidden": "true", children: "Redo" })] })] }), _jsx("div", { class: "tool-group" })] })] }), _jsx("div", { class: "toolbar-wrapper markers-toolbar-wrapper is-hidden", ref: (node) => node && (this.temporaryMarkersToolbarWrapper = node), "aria-hidden": "true", children: _jsxs("div", { class: "toolbar markers-toolbar", children: [_jsxs("button", { class: "toolbar-button markers-toolbar-button", type: "button", "aria-label": "Character Markers", title: "Character Markers", ref: (node) => node && (this.characterMarkerButton = node), children: [_jsx("span", { class: "toolbar-button-icon", "aria-hidden": "true" }), _jsx("span", { class: "toolbar-button-label", "aria-hidden": "true", children: "Character Markers" })] }), _jsxs("button", { class: "toolbar-button markers-toolbar-button", type: "button", "aria-label": "Object Markers", title: "Object Markers", ref: (node) => node && (this.objectMarkerButton = node), children: [_jsx("span", { class: "toolbar-button-icon", "aria-hidden": "true" }), _jsx("span", { class: "toolbar-button-label", "aria-hidden": "true", children: "Object Markers" })] })] }) })] }), _jsxs("div", { class: "canvas-wrapper", children: [_jsx("canvas", { class: "image-layer" }), _jsx("canvas", { class: "mask-layer" }), _jsx("canvas", { class: "selection-layer" }), _jsx("div", { class: "room-hover-label", "aria-hidden": "true" })] })] }), _jsxs("aside", { class: "define-room-sidebar", ref: (node) => node && (this.roomsPanel = node), children: [_jsxs("div", { class: "sidebar-panel rooms-sidebar", ref: (node) => node && (this.defineRoomsSidebarSection = node), "aria-hidden": "false", children: [_jsx("div", { class: "rooms-header", children: _jsx("h2", { children: "Rooms" }) }), _jsx("p", { class: "rooms-empty", ref: (node) => node && (this.roomsEmptyState = node), children: "No rooms defined yet." }), _jsx("div", { class: "rooms-list" }), _jsx("div", { class: "room-color-menu hidden", "aria-hidden": "true" })] }), _jsxs("div", { class: "sidebar-panel temporary-markers-sidebar is-hidden", ref: (node) => node && (this.temporaryMarkersSidebar = node), "aria-hidden": "true", children: [_jsx("div", { class: "rooms-header temporary-markers-header", children: _jsx("h2", { children: "Temporary Markers" }) }), _jsx("p", { class: "temporary-markers-empty", children: "No temporary markers yet." }), _jsx("div", { class: "temporary-markers-list" })] })] })] })] }), _jsx("div", { class: "room-delete-backdrop hidden", "aria-hidden": "true", children: _jsxs("div", { class: "room-delete-card", role: "dialog", "aria-modal": "true", "aria-labelledby": "room-delete-title", tabindex: "-1", children: [_jsx("div", { class: "room-delete-icon-wrapper", children: _jsx("div", { class: "room-delete-icon", "aria-hidden": "true" }) }), _jsx("h2", { id: "room-delete-title", class: "room-delete-title", children: "Are you sure?" }), _jsx("p", { class: "room-delete-message", children: "Do you really want to continue ? This process cannot be undone" }), _jsxs("div", { class: "room-delete-actions", children: [_jsx("button", { class: "room-delete-cancel", type: "button", children: "Cancel" }), _jsx("button", { class: "room-delete-confirm", type: "button", children: "Confirm" })] })] }) })] }));
         this.initializeDomReferences();
         this.attachEventListeners();
+        this.switchEditorMode("rooms", true);
     }
     mount(container) {
         container.appendChild(this.root);
     }
     open(image) {
         this.root.classList.remove("hidden");
+        this.switchEditorMode("rooms");
         this.prepareImage(image);
     }
     close() {
@@ -484,6 +537,7 @@ export class DefineRoom {
         this.stopBrushSliderInteraction();
         this.closeColorMenu();
         this.hideDeleteDialog();
+        this.switchEditorMode("rooms");
     }
     get element() {
         return this.root;
@@ -495,8 +549,8 @@ export class DefineRoom {
         this.toolbarCancelButton = this.root.querySelector(".toolbar-cancel");
         this.undoButton = this.root.querySelector(".toolbar-undo");
         this.redoButton = this.root.querySelector(".toolbar-redo");
-        this.roomsList = this.roomsPanel.querySelector(".rooms-list");
-        this.colorMenu = this.roomsPanel.querySelector(".room-color-menu");
+        this.roomsList = this.defineRoomsSidebarSection.querySelector(".rooms-list");
+        this.colorMenu = this.defineRoomsSidebarSection.querySelector(".room-color-menu");
         this.deleteBackdrop = this.root.querySelector(".room-delete-backdrop");
         this.deleteCancelButton = this.root.querySelector(".room-delete-cancel");
         this.deleteConfirmButton = this.root.querySelector(".room-delete-confirm");
@@ -540,7 +594,7 @@ export class DefineRoom {
         document.addEventListener("click", this.handleColorMenuOutsideClick);
         this.updateBrushSliderUi();
         this.roomsPanel.addEventListener("click", (event) => {
-            if (this.isConfirmingRoom) {
+            if (this.activeEditorMode !== "rooms" || this.isConfirmingRoom) {
                 return;
             }
             if (event.target === this.roomsPanel || event.target === this.roomsList) {
@@ -566,6 +620,14 @@ export class DefineRoom {
         const redoIcon = this.redoButton.querySelector(".toolbar-button-icon");
         if (redoIcon) {
             redoIcon.innerHTML = REDO_ICON;
+        }
+        const characterMarkerIcon = this.characterMarkerButton.querySelector(".toolbar-button-icon");
+        if (characterMarkerIcon) {
+            characterMarkerIcon.innerHTML = CHARACTER_MARKER_ICON;
+        }
+        const objectMarkerIcon = this.objectMarkerButton.querySelector(".toolbar-button-icon");
+        if (objectMarkerIcon) {
+            objectMarkerIcon.innerHTML = OBJECT_MARKER_ICON;
         }
         this.imageContext = this.imageCanvas.getContext("2d", { willReadFrequently: true });
         this.overlayContext = this.overlayCanvas.getContext("2d");
@@ -610,6 +672,8 @@ export class DefineRoom {
                 this.close();
             }
         });
+        this.editorTabsDefineRoomsButton.addEventListener("click", () => this.switchEditorMode("rooms"));
+        this.editorTabsMarkersButton.addEventListener("click", () => this.switchEditorMode("markers"));
         this.overlayCanvas.addEventListener("pointerdown", (event) => this.handlePointerDown(event));
         this.overlayCanvas.addEventListener("pointermove", (event) => this.handlePointerMove(event));
         this.overlayCanvas.addEventListener("pointerup", (event) => this.handlePointerUp(event));
@@ -617,6 +681,28 @@ export class DefineRoom {
         this.overlayCanvas.addEventListener("contextmenu", (event) => event.preventDefault());
         this.overlayCanvas.style.touchAction = "none";
         this.attachBrushSliderEvents();
+    }
+    switchEditorMode(mode, force = false) {
+        if (!force && this.activeEditorMode === mode) {
+            return;
+        }
+        this.activeEditorMode = mode;
+        const isMarkers = mode === "markers";
+        this.editorTabsDefineRoomsButton.classList.toggle("active", !isMarkers);
+        this.editorTabsDefineRoomsButton.setAttribute("aria-selected", (!isMarkers).toString());
+        this.editorTabsMarkersButton.classList.toggle("active", isMarkers);
+        this.editorTabsMarkersButton.setAttribute("aria-selected", isMarkers.toString());
+        this.defineRoomsToolbarWrapper.classList.toggle("is-hidden", isMarkers);
+        this.defineRoomsToolbarWrapper.setAttribute("aria-hidden", isMarkers ? "true" : "false");
+        this.temporaryMarkersToolbarWrapper.classList.toggle("is-hidden", !isMarkers);
+        this.temporaryMarkersToolbarWrapper.setAttribute("aria-hidden", !isMarkers ? "true" : "false");
+        this.defineRoomsSidebarSection.classList.toggle("is-hidden", isMarkers);
+        this.defineRoomsSidebarSection.setAttribute("aria-hidden", isMarkers ? "true" : "false");
+        this.temporaryMarkersSidebar.classList.toggle("is-hidden", !isMarkers);
+        this.temporaryMarkersSidebar.setAttribute("aria-hidden", !isMarkers ? "true" : "false");
+        if (isMarkers) {
+            this.closeColorMenu();
+        }
     }
     initializeColorMenu() {
         if (!this.colorMenu) {

--- a/defineRooms/src/components/DefineRoom.tsx
+++ b/defineRooms/src/components/DefineRoom.tsx
@@ -332,6 +332,58 @@ const REDO_ICON = `
   </svg>
 `;
 
+const CHARACTER_MARKER_ICON = `
+  <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path
+      d="M12 21c3.3-3.1 5-5.9 5-8.5a5 5 0 10-10 0c0 2.6 1.7 5.4 5 8.5z"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+    <path
+      d="M12 11a3 3 0 100-6 3 3 0 000 6z"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+  </svg>
+`;
+
+const OBJECT_MARKER_ICON = `
+  <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path
+      d="M12 3l8 4.5v9L12 21l-8-4.5v-9L12 3z"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+    <path
+      d="M12 12l8-4.5"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+    <path
+      d="M12 12v9"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+    <path
+      d="M12 12L4 7.5"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+  </svg>
+`;
+
 const HISTORY_LIMIT = 30;
 
 function colorToVector(color: string): [number, number, number] {
@@ -462,6 +514,18 @@ export class DefineRoom {
 
   private toolbarContainer!: HTMLElement;
 
+  private editorTabsDefineRoomsButton!: HTMLButtonElement;
+
+  private editorTabsMarkersButton!: HTMLButtonElement;
+
+  private defineRoomsToolbarWrapper!: HTMLElement;
+
+  private temporaryMarkersToolbarWrapper!: HTMLElement;
+
+  private characterMarkerButton!: HTMLButtonElement;
+
+  private objectMarkerButton!: HTMLButtonElement;
+
   private handleColorMenuOutsideClick = (event: MouseEvent): void => {
     if (!this.colorMenu || this.colorMenu.classList.contains("hidden")) {
       return;
@@ -517,6 +581,12 @@ export class DefineRoom {
   private canvasWrapper!: HTMLElement;
 
   private hoverLabel!: HTMLElement;
+
+  private defineRoomsSidebarSection!: HTMLElement;
+
+  private temporaryMarkersSidebar!: HTMLElement;
+
+  private activeEditorMode: "rooms" | "markers" = "rooms";
 
   private closeButton!: HTMLButtonElement;
 
@@ -623,70 +693,126 @@ export class DefineRoom {
           <div class="define-room-body">
             <section class="define-room-editor">
               <div class="toolbar-area">
-                <div
-                  class="brush-slider-container"
-                  ref={(node: HTMLElement | null) => node && (this.brushSliderContainer = node)}
-                  aria-hidden="true"
-                  aria-label="Brush size"
-                >
-                  <div class="brush-slider-track" ref={(node: HTMLElement | null) => node && (this.brushSliderTrack = node)}>
-                    <div class="brush-slider-fill" ref={(node: HTMLElement | null) => node && (this.brushSliderFill = node)}></div>
-                    <div class="brush-slider-thumb" ref={(node: HTMLElement | null) => node && (this.brushSliderThumb = node)}></div>
-                  </div>
-                  <div
-                    class="brush-slider-value"
-                    aria-hidden="true"
-                    ref={(node: HTMLElement | null) => node && (this.brushSliderValueLabel = node)}
-                  ></div>
+                <div class="editor-tabs" role="tablist">
+                  <button
+                    class="editor-tab active"
+                    type="button"
+                    role="tab"
+                    aria-selected="true"
+                    data-mode="rooms"
+                    ref={(node: HTMLButtonElement | null) => node && (this.editorTabsDefineRoomsButton = node)}
+                  >
+                    Define Rooms
+                  </button>
+                  <button
+                    class="editor-tab"
+                    type="button"
+                    role="tab"
+                    aria-selected="false"
+                    data-mode="markers"
+                    ref={(node: HTMLButtonElement | null) => node && (this.editorTabsMarkersButton = node)}
+                  >
+                    Temporary Markers
+                  </button>
                 </div>
-                <div class="toolbar" ref={(node: HTMLElement | null) => node && (this.toolbarContainer = node)}>
-                  <div class="toolbar-primary-group">
-                    <button class="toolbar-button toolbar-primary" type="button" aria-label="New Room" title="New Room">
-                      <span class="toolbar-button-icon" aria-hidden="true"></span>
-                      <span class="toolbar-button-label" aria-hidden="true">New Room</span>
-                    </button>
-                    <div class="toolbar-confirm-group">
+                <div
+                  class="toolbar-wrapper"
+                  ref={(node: HTMLElement | null) => node && (this.defineRoomsToolbarWrapper = node)}
+                  aria-hidden="false"
+                >
+                  <div
+                    class="brush-slider-container"
+                    ref={(node: HTMLElement | null) => node && (this.brushSliderContainer = node)}
+                    aria-hidden="true"
+                    aria-label="Brush size"
+                  >
+                    <div class="brush-slider-track" ref={(node: HTMLElement | null) => node && (this.brushSliderTrack = node)}>
+                      <div class="brush-slider-fill" ref={(node: HTMLElement | null) => node && (this.brushSliderFill = node)}></div>
+                      <div class="brush-slider-thumb" ref={(node: HTMLElement | null) => node && (this.brushSliderThumb = node)}></div>
+                    </div>
+                    <div
+                      class="brush-slider-value"
+                      aria-hidden="true"
+                      ref={(node: HTMLElement | null) => node && (this.brushSliderValueLabel = node)}
+                    ></div>
+                  </div>
+                  <div class="toolbar" ref={(node: HTMLElement | null) => node && (this.toolbarContainer = node)}>
+                    <div class="toolbar-primary-group">
+                      <button class="toolbar-button toolbar-primary" type="button" aria-label="New Room" title="New Room">
+                        <span class="toolbar-button-icon" aria-hidden="true"></span>
+                        <span class="toolbar-button-label" aria-hidden="true">New Room</span>
+                      </button>
+                      <div class="toolbar-confirm-group">
+                        <button
+                          class="toolbar-button toolbar-confirm"
+                          type="button"
+                          aria-label="Confirm Room"
+                          title="Confirm Room"
+                        >
+                          <span class="toolbar-button-icon" aria-hidden="true"></span>
+                          <span class="toolbar-button-label" aria-hidden="true">Confirm</span>
+                        </button>
+                        <button
+                          class="toolbar-button toolbar-cancel"
+                          type="button"
+                          aria-label="Cancel Room"
+                          title="Cancel Room"
+                        >
+                          <span class="toolbar-button-icon" aria-hidden="true"></span>
+                          <span class="toolbar-button-label" aria-hidden="true">Cancel</span>
+                        </button>
+                      </div>
+                    </div>
+                    <div class="history-group">
                       <button
-                        class="toolbar-button toolbar-confirm"
+                        class="toolbar-button tool-button history-button toolbar-undo"
                         type="button"
-                        aria-label="Confirm Room"
-                        title="Confirm Room"
+                        aria-label="Undo"
+                        title="Undo"
                       >
                         <span class="toolbar-button-icon" aria-hidden="true"></span>
-                        <span class="toolbar-button-label" aria-hidden="true">Confirm</span>
+                        <span class="toolbar-button-label" aria-hidden="true">Undo</span>
                       </button>
                       <button
-                        class="toolbar-button toolbar-cancel"
+                        class="toolbar-button tool-button history-button toolbar-redo"
                         type="button"
-                        aria-label="Cancel Room"
-                        title="Cancel Room"
+                        aria-label="Redo"
+                        title="Redo"
                       >
                         <span class="toolbar-button-icon" aria-hidden="true"></span>
-                        <span class="toolbar-button-label" aria-hidden="true">Cancel</span>
+                        <span class="toolbar-button-label" aria-hidden="true">Redo</span>
                       </button>
                     </div>
+                    <div class="tool-group"></div>
                   </div>
-                  <div class="history-group">
+                </div>
+                <div
+                  class="toolbar-wrapper markers-toolbar-wrapper is-hidden"
+                  ref={(node: HTMLElement | null) => node && (this.temporaryMarkersToolbarWrapper = node)}
+                  aria-hidden="true"
+                >
+                  <div class="toolbar markers-toolbar">
                     <button
-                      class="toolbar-button tool-button history-button toolbar-undo"
+                      class="toolbar-button markers-toolbar-button"
                       type="button"
-                      aria-label="Undo"
-                      title="Undo"
+                      aria-label="Character Markers"
+                      title="Character Markers"
+                      ref={(node: HTMLButtonElement | null) => node && (this.characterMarkerButton = node)}
                     >
                       <span class="toolbar-button-icon" aria-hidden="true"></span>
-                      <span class="toolbar-button-label" aria-hidden="true">Undo</span>
+                      <span class="toolbar-button-label" aria-hidden="true">Character Markers</span>
                     </button>
                     <button
-                      class="toolbar-button tool-button history-button toolbar-redo"
+                      class="toolbar-button markers-toolbar-button"
                       type="button"
-                      aria-label="Redo"
-                      title="Redo"
+                      aria-label="Object Markers"
+                      title="Object Markers"
+                      ref={(node: HTMLButtonElement | null) => node && (this.objectMarkerButton = node)}
                     >
                       <span class="toolbar-button-icon" aria-hidden="true"></span>
-                      <span class="toolbar-button-label" aria-hidden="true">Redo</span>
+                      <span class="toolbar-button-label" aria-hidden="true">Object Markers</span>
                     </button>
                   </div>
-                  <div class="tool-group"></div>
                 </div>
               </div>
               <div class="canvas-wrapper">
@@ -697,14 +823,31 @@ export class DefineRoom {
               </div>
             </section>
             <aside class="define-room-sidebar" ref={(node: HTMLElement | null) => node && (this.roomsPanel = node)}>
-              <div class="rooms-header">
-                <h2>Rooms</h2>
+              <div
+                class="sidebar-panel rooms-sidebar"
+                ref={(node: HTMLElement | null) => node && (this.defineRoomsSidebarSection = node)}
+                aria-hidden="false"
+              >
+                <div class="rooms-header">
+                  <h2>Rooms</h2>
+                </div>
+                <p class="rooms-empty" ref={(node: HTMLElement | null) => node && (this.roomsEmptyState = node)}>
+                  No rooms defined yet.
+                </p>
+                <div class="rooms-list"></div>
+                <div class="room-color-menu hidden" aria-hidden="true"></div>
               </div>
-              <p class="rooms-empty" ref={(node: HTMLElement | null) => node && (this.roomsEmptyState = node)}>
-                No rooms defined yet.
-              </p>
-              <div class="rooms-list"></div>
-              <div class="room-color-menu hidden" aria-hidden="true"></div>
+              <div
+                class="sidebar-panel temporary-markers-sidebar is-hidden"
+                ref={(node: HTMLElement | null) => node && (this.temporaryMarkersSidebar = node)}
+                aria-hidden="true"
+              >
+                <div class="rooms-header temporary-markers-header">
+                  <h2>Temporary Markers</h2>
+                </div>
+                <p class="temporary-markers-empty">No temporary markers yet.</p>
+                <div class="temporary-markers-list"></div>
+              </div>
             </aside>
           </div>
         </div>
@@ -734,6 +877,7 @@ export class DefineRoom {
 
     this.initializeDomReferences();
     this.attachEventListeners();
+    this.switchEditorMode("rooms", true);
   }
 
   public mount(container: HTMLElement): void {
@@ -742,6 +886,7 @@ export class DefineRoom {
 
   public open(image: HTMLImageElement): void {
     this.root.classList.remove("hidden");
+    this.switchEditorMode("rooms");
     this.prepareImage(image);
   }
 
@@ -750,6 +895,7 @@ export class DefineRoom {
     this.stopBrushSliderInteraction();
     this.closeColorMenu();
     this.hideDeleteDialog();
+    this.switchEditorMode("rooms");
   }
 
   public get element(): HTMLElement {
@@ -763,8 +909,8 @@ export class DefineRoom {
     this.toolbarCancelButton = this.root.querySelector(".toolbar-cancel") as HTMLButtonElement;
     this.undoButton = this.root.querySelector(".toolbar-undo") as HTMLButtonElement;
     this.redoButton = this.root.querySelector(".toolbar-redo") as HTMLButtonElement;
-    this.roomsList = this.roomsPanel.querySelector(".rooms-list") as HTMLElement;
-    this.colorMenu = this.roomsPanel.querySelector(".room-color-menu") as HTMLElement;
+    this.roomsList = this.defineRoomsSidebarSection.querySelector(".rooms-list") as HTMLElement;
+    this.colorMenu = this.defineRoomsSidebarSection.querySelector(".room-color-menu") as HTMLElement;
     this.deleteBackdrop = this.root.querySelector(".room-delete-backdrop") as HTMLElement;
     this.deleteCancelButton = this.root.querySelector(".room-delete-cancel") as HTMLButtonElement;
     this.deleteConfirmButton = this.root.querySelector(".room-delete-confirm") as HTMLButtonElement;
@@ -817,7 +963,7 @@ export class DefineRoom {
     this.updateBrushSliderUi();
 
     this.roomsPanel.addEventListener("click", (event) => {
-      if (this.isConfirmingRoom) {
+      if (this.activeEditorMode !== "rooms" || this.isConfirmingRoom) {
         return;
       }
       if (event.target === this.roomsPanel || event.target === this.roomsList) {
@@ -854,6 +1000,20 @@ export class DefineRoom {
     const redoIcon = this.redoButton.querySelector(".toolbar-button-icon") as HTMLElement | null;
     if (redoIcon) {
       redoIcon.innerHTML = REDO_ICON;
+    }
+
+    const characterMarkerIcon = this.characterMarkerButton.querySelector(
+      ".toolbar-button-icon"
+    ) as HTMLElement | null;
+    if (characterMarkerIcon) {
+      characterMarkerIcon.innerHTML = CHARACTER_MARKER_ICON;
+    }
+
+    const objectMarkerIcon = this.objectMarkerButton.querySelector(
+      ".toolbar-button-icon"
+    ) as HTMLElement | null;
+    if (objectMarkerIcon) {
+      objectMarkerIcon.innerHTML = OBJECT_MARKER_ICON;
     }
 
     this.imageContext = this.imageCanvas.getContext("2d", { willReadFrequently: true }) as CanvasRenderingContext2D;
@@ -908,6 +1068,9 @@ export class DefineRoom {
       }
     });
 
+    this.editorTabsDefineRoomsButton.addEventListener("click", () => this.switchEditorMode("rooms"));
+    this.editorTabsMarkersButton.addEventListener("click", () => this.switchEditorMode("markers"));
+
     this.overlayCanvas.addEventListener("pointerdown", (event) => this.handlePointerDown(event));
     this.overlayCanvas.addEventListener("pointermove", (event) => this.handlePointerMove(event));
     this.overlayCanvas.addEventListener("pointerup", (event) => this.handlePointerUp(event));
@@ -916,6 +1079,35 @@ export class DefineRoom {
     this.overlayCanvas.style.touchAction = "none";
 
     this.attachBrushSliderEvents();
+  }
+
+  private switchEditorMode(mode: "rooms" | "markers", force = false): void {
+    if (!force && this.activeEditorMode === mode) {
+      return;
+    }
+
+    this.activeEditorMode = mode;
+
+    const isMarkers = mode === "markers";
+
+    this.editorTabsDefineRoomsButton.classList.toggle("active", !isMarkers);
+    this.editorTabsDefineRoomsButton.setAttribute("aria-selected", (!isMarkers).toString());
+    this.editorTabsMarkersButton.classList.toggle("active", isMarkers);
+    this.editorTabsMarkersButton.setAttribute("aria-selected", isMarkers.toString());
+
+    this.defineRoomsToolbarWrapper.classList.toggle("is-hidden", isMarkers);
+    this.defineRoomsToolbarWrapper.setAttribute("aria-hidden", isMarkers ? "true" : "false");
+    this.temporaryMarkersToolbarWrapper.classList.toggle("is-hidden", !isMarkers);
+    this.temporaryMarkersToolbarWrapper.setAttribute("aria-hidden", !isMarkers ? "true" : "false");
+
+    this.defineRoomsSidebarSection.classList.toggle("is-hidden", isMarkers);
+    this.defineRoomsSidebarSection.setAttribute("aria-hidden", isMarkers ? "true" : "false");
+    this.temporaryMarkersSidebar.classList.toggle("is-hidden", !isMarkers);
+    this.temporaryMarkersSidebar.setAttribute("aria-hidden", !isMarkers ? "true" : "false");
+
+    if (isMarkers) {
+      this.closeColorMenu();
+    }
   }
 
   private initializeColorMenu(): void {

--- a/defineRooms/styles.css
+++ b/defineRooms/styles.css
@@ -15,6 +15,10 @@ body {
     #0f172a;
 }
 
+.is-hidden {
+  display: none !important;
+}
+
 #root {
   width: min(960px, 92vw);
   padding: 48px 0 64px;
@@ -327,6 +331,31 @@ body {
   position: relative;
 }
 
+.sidebar-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  flex: 1;
+}
+
+.temporary-markers-empty {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(226, 232, 240, 0.6);
+}
+
+.temporary-markers-list {
+  flex: 1;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.45);
+  border: 1px dashed rgba(148, 163, 184, 0.24);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px;
+  overflow-y: auto;
+}
+
 .rooms-header {
   display: flex;
   align-items: center;
@@ -631,9 +660,63 @@ body {
 .toolbar-area {
   position: relative;
   display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 12px;
+  flex-shrink: 0;
+}
+
+.editor-tabs {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px;
+  border-radius: 999px;
+  background: rgba(30, 41, 59, 0.72);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  box-shadow: 0 14px 30px rgba(15, 23, 42, 0.45);
+  backdrop-filter: blur(12px);
+}
+
+.editor-tab {
+  border: none;
+  background: transparent;
+  color: rgba(226, 232, 240, 0.75);
+  font-weight: 600;
+  font-size: 0.85rem;
+  letter-spacing: 0.01em;
+  padding: 6px 16px;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 0.3s ease, color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.editor-tab:hover:not(.active),
+.editor-tab:focus-visible:not(.active) {
+  color: rgba(226, 232, 240, 0.95);
+}
+
+.editor-tab:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.35);
+}
+
+.editor-tab.active {
+  background: linear-gradient(135deg, #38bdf8, #818cf8);
+  color: #0b1220;
+  box-shadow: 0 12px 24px rgba(56, 189, 248, 0.35);
+}
+
+.toolbar-wrapper {
+  position: relative;
+  display: flex;
   justify-content: flex-end;
   align-items: center;
   flex-shrink: 0;
+}
+
+.toolbar-wrapper.is-hidden {
+  display: none;
 }
 
 .toolbar {


### PR DESCRIPTION
## Summary
- add an editor tab switcher to toggle between Define Rooms and Temporary Markers views
- show a dedicated temporary markers toolbar with character and object marker controls
- style the new tabs and sidebar panels to match the existing overlay aesthetic

## Testing
- npm run build *(fails: Cannot find module './App.js')*

------
https://chatgpt.com/codex/tasks/task_e_69023b2b0a10832383c6fb04fb59c58a