### PR TITLE
Add temporary markers tab to room editor

### DIFF
--- a/defineRooms/dist/components/DefineRoom.js
+++ b/defineRooms/dist/components/DefineRoom.js
@@ -394,6 +394,7 @@ export class DefineRoom {
         this.colorMenuOptions = [];
         this.colorMenuTrigger = null;
         this.activeColorRoomId = null;
+        this.activeTab = "rooms";
         this.handleColorMenuOutsideClick = (event) => {
             if (!this.colorMenu || this.colorMenu.classList.contains("hidden")) {
                 return;
@@ -468,7 +469,7 @@ export class DefineRoom {
             this.updateBrushRadiusFromPointer(event);
             this.stopBrushSliderInteraction();
         };
-        this.root = (_jsxs("div", { class: "define-room-overlay hidden", children: [_jsxs("div", { class: "define-room-window", children: [_jsxs("div", { class: "define-room-header", children: [_jsx("h1", { children: "Define Rooms" }), _jsx("button", { class: "define-room-close", type: "button", children: "Close" })] }), _jsxs("div", { class: "define-room-body", children: [_jsxs("section", { class: "define-room-editor", children: [_jsxs("div", { class: "toolbar-area", children: [_jsxs("div", { class: "brush-slider-container", ref: (node) => node && (this.brushSliderContainer = node), "aria-hidden": "true", "aria-label": "Brush size", children: [_jsxs("div", { class: "brush-slider-track", ref: (node) => node && (this.brushSliderTrack = node), children: [_jsx("div", { class: "brush-slider-fill", ref: (node) => node && (this.brushSliderFill = node) }), _jsx("div", { class: "brush-slider-thumb", ref: (node) => node && (this.brushSliderThumb = node) })] }), _jsx("div", { class: "brush-slider-value", "aria-hidden": "true", ref: (node) => node && (this.brushSliderValueLabel = node) })] }), _jsxs("div", { class: "toolbar", ref: (node) => node && (this.toolbarContainer = node), children: [_jsxs("div", { class: "toolbar-primary-group", children: [_jsxs("button", { class: "toolbar-button toolbar-primary", type: "button", "aria-label": "New Room", title: "New Room", children: [_jsx("span", { class: "toolbar-button-icon", "aria-hidden": "true" }), _jsx("span", { class: "toolbar-button-label", "aria-hidden": "true", children: "New Room" })] }), _jsxs("div", { class: "toolbar-confirm-group", children: [_jsxs("button", { class: "toolbar-button toolbar-confirm", type: "button", "aria-label": "Confirm Room", title: "Confirm Room", children: [_jsx("span", { class: "toolbar-button-icon", "aria-hidden": "true" }), _jsx("span", { class: "toolbar-button-label", "aria-hidden": "true", children: "Confirm" })] }), _jsxs("button", { class: "toolbar-button toolbar-cancel", type: "button", "aria-label": "Cancel Room", title: "Cancel Room", children: [_jsx("span", { class: "toolbar-button-icon", "aria-hidden": "true" }), _jsx("span", { class: "toolbar-button-label", "aria-hidden": "true", children: "Cancel" })] })] })] }), _jsxs("div", { class: "history-group", children: [_jsxs("button", { class: "toolbar-button tool-button history-button toolbar-undo", type: "button", "aria-label": "Undo", title: "Undo", children: [_jsx("span", { class: "toolbar-button-icon", "aria-hidden": "true" }), _jsx("span", { class: "toolbar-button-label", "aria-hidden": "true", children: "Undo" })] }), _jsxs("button", { class: "toolbar-button tool-button history-button toolbar-redo", type: "button", "aria-label": "Redo", title: "Redo", children: [_jsx("span", { class: "toolbar-button-icon", "aria-hidden": "true" }), _jsx("span", { class: "toolbar-button-label", "aria-hidden": "true", children: "Redo" })] })] }), _jsx("div", { class: "tool-group" })] })] }), _jsxs("div", { class: "canvas-wrapper", children: [_jsx("canvas", { class: "image-layer" }), _jsx("canvas", { class: "mask-layer" }), _jsx("canvas", { class: "selection-layer" }), _jsx("div", { class: "room-hover-label", "aria-hidden": "true" })] })] }), _jsxs("aside", { class: "define-room-sidebar", ref: (node) => node && (this.roomsPanel = node), children: [_jsx("div", { class: "rooms-header", children: _jsx("h2", { children: "Rooms" }) }), _jsx("p", { class: "rooms-empty", ref: (node) => node && (this.roomsEmptyState = node), children: "No rooms defined yet." }), _jsx("div", { class: "rooms-list" }), _jsx("div", { class: "room-color-menu hidden", "aria-hidden": "true" })] })] })] }), _jsx("div", { class: "room-delete-backdrop hidden", "aria-hidden": "true", children: _jsxs("div", { class: "room-delete-card", role: "dialog", "aria-modal": "true", "aria-labelledby": "room-delete-title", tabindex: "-1", children: [_jsx("div", { class: "room-delete-icon-wrapper", children: _jsx("div", { class: "room-delete-icon", "aria-hidden": "true" }) }), _jsx("h2", { id: "room-delete-title", class: "room-delete-title", children: "Are you sure?" }), _jsx("p", { class: "room-delete-message", children: "Do you really want to continue ? This process cannot be undone" }), _jsxs("div", { class: "room-delete-actions", children: [_jsx("button", { class: "room-delete-cancel", type: "button", children: "Cancel" }), _jsx("button", { class: "room-delete-confirm", type: "button", children: "Confirm" })] })] }) })] }));
+        this.root = (_jsxs("div", { class: "define-room-overlay hidden", children: [_jsxs("div", { class: "define-room-window", children: [_jsxs("div", { class: "define-room-header", children: [_jsx("h1", { children: "Define Rooms" }), _jsx("button", { class: "define-room-close", type: "button", children: "Close" })] }), _jsxs("div", { class: "define-room-body", children: [_jsxs("section", { class: "define-room-editor", children: [_jsxs("div", { class: "toolbar-area", children: [_jsxs("div", { class: "define-room-tabs", children: [_jsx("button", { class: "define-room-tab active", type: "button", "data-tab": "rooms", ref: (node) => node && (this.defineTabButton = node), children: "Define Rooms" }), _jsx("button", { class: "define-room-tab", type: "button", "data-tab": "markers", ref: (node) => node && (this.markersTabButton = node), children: "Temporary Markers" })] }), _jsxs("div", { class: "brush-slider-container", ref: (node) => node && (this.brushSliderContainer = node), "aria-hidden": "true", "aria-label": "Brush size", children: [_jsxs("div", { class: "brush-slider-track", ref: (node) => node && (this.brushSliderTrack = node), children: [_jsx("div", { class: "brush-slider-fill", ref: (node) => node && (this.brushSliderFill = node) }), _jsx("div", { class: "brush-slider-thumb", ref: (node) => node && (this.brushSliderThumb = node) })] }), _jsx("div", { class: "brush-slider-value", "aria-hidden": "true", ref: (node) => node && (this.brushSliderValueLabel = node) })] }), _jsxs("div", { class: "toolbar", ref: (node) => node && (this.toolbarContainer = node), "aria-hidden": "false", children: [_jsxs("div", { class: "toolbar-primary-group", children: [_jsxs("button", { class: "toolbar-button toolbar-primary", type: "button", "aria-label": "New Room", title: "New Room", children: [_jsx("span", { class: "toolbar-button-icon", "aria-hidden": "true" }), _jsx("span", { class: "toolbar-button-label", "aria-hidden": "true", children: "New Room" })] }), _jsxs("div", { class: "toolbar-confirm-group", children: [_jsxs("button", { class: "toolbar-button toolbar-confirm", type: "button", "aria-label": "Confirm Room", title: "Confirm Room", children: [_jsx("span", { class: "toolbar-button-icon", "aria-hidden": "true" }), _jsx("span", { class: "toolbar-button-label", "aria-hidden": "true", children: "Confirm" })] }), _jsxs("button", { class: "toolbar-button toolbar-cancel", type: "button", "aria-label": "Cancel Room", title: "Cancel Room", children: [_jsx("span", { class: "toolbar-button-icon", "aria-hidden": "true" }), _jsx("span", { class: "toolbar-button-label", "aria-hidden": "true", children: "Cancel" })] })] })] }), _jsxs("div", { class: "history-group", children: [_jsxs("button", { class: "toolbar-button tool-button history-button toolbar-undo", type: "button", "aria-label": "Undo", title: "Undo", children: [_jsx("span", { class: "toolbar-button-icon", "aria-hidden": "true" }), _jsx("span", { class: "toolbar-button-label", "aria-hidden": "true", children: "Undo" })] }), _jsxs("button", { class: "toolbar-button tool-button history-button toolbar-redo", type: "button", "aria-label": "Redo", title: "Redo", children: [_jsx("span", { class: "toolbar-button-icon", "aria-hidden": "true" }), _jsx("span", { class: "toolbar-button-label", "aria-hidden": "true", children: "Redo" })] })] }), _jsx("div", { class: "tool-group" })] }), _jsxs("div", { class: "toolbar markers-toolbar is-hidden", "aria-hidden": "true", ref: (node) => node && (this.markersToolbar = node), children: [_jsx("button", { class: "markers-toolbar-button", type: "button", children: "Character Markers" }), _jsx("button", { class: "markers-toolbar-button", type: "button", children: "Object Markers" })] })] }), _jsxs("div", { class: "canvas-wrapper", children: [_jsx("canvas", { class: "image-layer" }), _jsx("canvas", { class: "mask-layer" }), _jsx("canvas", { class: "selection-layer" }), _jsx("div", { class: "room-hover-label", "aria-hidden": "true" })] })] }), _jsxs("aside", { class: "define-room-sidebar", "aria-hidden": "false", ref: (node) => node && (this.roomsPanel = node), children: [_jsx("div", { class: "rooms-header", children: _jsx("h2", { children: "Rooms" }) }), _jsx("p", { class: "rooms-empty", ref: (node) => node && (this.roomsEmptyState = node), children: "No rooms defined yet." }), _jsx("div", { class: "rooms-list" }), _jsx("div", { class: "room-color-menu hidden", "aria-hidden": "true" })] }), _jsxs("aside", { class: "define-room-sidebar markers-sidebar is-hidden", "aria-hidden": "true", children: [_jsx("div", { class: "rooms-header", children: _jsx("h2", { children: "Temporary Markers" }) }), _jsx("p", { class: "markers-empty", children: "No temporary markers created yet." }), _jsx("div", { class: "markers-list" })] })] })] }), _jsx("div", { class: "room-delete-backdrop hidden", "aria-hidden": "true", children: _jsxs("div", { class: "room-delete-card", role: "dialog", "aria-modal": "true", "aria-labelledby": "room-delete-title", tabindex: "-1", children: [_jsx("div", { class: "room-delete-icon-wrapper", children: _jsx("div", { class: "room-delete-icon", "aria-hidden": "true" }) }), _jsx("h2", { id: "room-delete-title", class: "room-delete-title", children: "Are you sure?" }), _jsx("p", { class: "room-delete-message", children: "Do you really want to continue ? This process cannot be undone" }), _jsxs("div", { class: "room-delete-actions", children: [_jsx("button", { class: "room-delete-cancel", type: "button", children: "Cancel" }), _jsx("button", { class: "room-delete-confirm", type: "button", children: "Confirm" })] })] }) })] }));
         this.initializeDomReferences();
         this.attachEventListeners();
     }
@@ -477,6 +478,7 @@ export class DefineRoom {
     }
     open(image) {
         this.root.classList.remove("hidden");
+        this.setActiveTab("rooms");
         this.prepareImage(image);
     }
     close() {
@@ -489,6 +491,10 @@ export class DefineRoom {
         return this.root;
     }
     initializeDomReferences() {
+        this.markersPanel = this.root.querySelector(".markers-sidebar");
+        this.markersToolbar = this.root.querySelector(".markers-toolbar");
+        this.defineTabButton = this.root.querySelector('[data-tab="rooms"]');
+        this.markersTabButton = this.root.querySelector('[data-tab="markers"]');
         this.toolbarPrimaryButton = this.root.querySelector(".toolbar-primary");
         this.toolbarConfirmGroup = this.root.querySelector(".toolbar-confirm-group");
         this.toolbarConfirmButton = this.root.querySelector(".toolbar-confirm");
@@ -599,11 +605,14 @@ export class DefineRoom {
         });
         this.setTool(this.currentTool);
         this.updateToolAvailability();
+        this.setActiveTab("rooms");
         if (this.hoverLabel) {
             this.hoverLabel.setAttribute("aria-hidden", "true");
         }
     }
     attachEventListeners() {
+        this.defineTabButton.addEventListener("click", () => this.setActiveTab("rooms"));
+        this.markersTabButton.addEventListener("click", () => this.setActiveTab("markers"));
         this.closeButton.addEventListener("click", () => this.close());
         this.root.addEventListener("click", (event) => {
             if (event.target === this.root) {
@@ -617,6 +626,27 @@ export class DefineRoom {
         this.overlayCanvas.addEventListener("contextmenu", (event) => event.preventDefault());
         this.overlayCanvas.style.touchAction = "none";
         this.attachBrushSliderEvents();
+    }
+    setActiveTab(tab) {
+        this.activeTab = tab;
+        const isRooms = tab === "rooms";
+        if (!isRooms) {
+            this.stopBrushSliderInteraction();
+        }
+        this.defineTabButton.classList.toggle("active", isRooms);
+        this.defineTabButton.setAttribute("aria-pressed", isRooms ? "true" : "false");
+        this.markersTabButton.classList.toggle("active", !isRooms);
+        this.markersTabButton.setAttribute("aria-pressed", !isRooms ? "true" : "false");
+        this.toolbarContainer.classList.toggle("is-hidden", !isRooms);
+        this.toolbarContainer.setAttribute("aria-hidden", isRooms ? "false" : "true");
+        this.markersToolbar.classList.toggle("is-hidden", isRooms);
+        this.markersToolbar.setAttribute("aria-hidden", isRooms ? "true" : "false");
+        this.brushSliderContainer.classList.toggle("is-hidden", !isRooms);
+        this.brushSliderContainer.setAttribute("aria-hidden", isRooms ? "false" : "true");
+        this.roomsPanel.classList.toggle("is-hidden", !isRooms);
+        this.roomsPanel.setAttribute("aria-hidden", isRooms ? "false" : "true");
+        this.markersPanel.classList.toggle("is-hidden", isRooms);
+        this.markersPanel.setAttribute("aria-hidden", isRooms ? "true" : "false");
     }
     initializeColorMenu() {
         if (!this.colorMenu) {

--- a/defineRooms/styles.css
+++ b/defineRooms/styles.css
@@ -359,6 +359,12 @@ body {
   color: rgba(226, 232, 240, 0.6);
 }
 
+.markers-empty {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(226, 232, 240, 0.6);
+}
+
 .rooms-list {
   flex: 1;
   overflow-y: auto;
@@ -366,6 +372,16 @@ body {
   flex-direction: column;
   gap: 10px;
   padding-top: 4px;
+}
+
+.markers-list {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  gap: 10px;
+  padding-top: 4px;
+  color: rgba(226, 232, 240, 0.7);
 }
 
 .room-card {
@@ -631,9 +647,49 @@ body {
 .toolbar-area {
   position: relative;
   display: flex;
-  justify-content: flex-end;
-  align-items: center;
+  flex-direction: column;
+  align-items: flex-end;
+  justify-content: flex-start;
+  gap: 12px;
   flex-shrink: 0;
+}
+
+.define-room-tabs {
+  display: inline-flex;
+  padding: 4px;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.92);
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.45);
+  gap: 4px;
+}
+
+.define-room-tab {
+  border: none;
+  border-radius: 999px;
+  padding: 6px 16px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: rgba(226, 232, 240, 0.75);
+  background: transparent;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.define-room-tab:hover,
+.define-room-tab:focus-visible {
+  color: rgba(226, 232, 240, 0.92);
+  outline: none;
+}
+
+.define-room-tab.active {
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.85), rgba(129, 140, 248, 0.85));
+  color: #0f172a;
+  box-shadow: 0 10px 22px rgba(56, 189, 248, 0.35);
+}
+
+.is-hidden {
+  display: none !important;
 }
 
 .toolbar {
@@ -652,6 +708,40 @@ body {
   overflow: visible;
   flex-shrink: 0;
   z-index: 3;
+}
+
+.markers-toolbar {
+  width: auto;
+  min-width: 0;
+  padding: 16px;
+  align-items: stretch;
+  gap: 12px;
+}
+
+.markers-toolbar::before {
+  display: none;
+}
+
+.markers-toolbar-button {
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: 14px;
+  padding: 10px 18px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  background: rgba(15, 23, 42, 0.96);
+  color: rgba(226, 232, 240, 0.92);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease,
+    border-color 0.2s ease;
+}
+
+.markers-toolbar-button:hover,
+.markers-toolbar-button:focus-visible {
+  outline: none;
+  transform: translateY(-1px);
+  background: rgba(30, 41, 59, 0.96);
+  border-color: rgba(56, 189, 248, 0.55);
+  box-shadow: 0 14px 28px rgba(56, 189, 248, 0.25);
 }
 
 .brush-slider-container {


### PR DESCRIPTION
## Summary
- add a tab switcher above the Define Rooms toolbar so the editor can toggle between rooms and temporary markers
- swap the toolbar contents for Character/Object marker shortcuts and expose a temporary markers sidebar when that tab is active
- style the new tabs, marker toolbar, and sidebar elements to match the existing UI

## Testing
- npm run build *(fails: Cannot find module './App.js')*

------
https://chatgpt.com/codex/tasks/task_e_69023b2b0a10832383c6fb04fb59c58a