### PR TITLE
Expose shared tools on temporary markers tab

### DIFF
--- a/apps/pages/src/define-rooms/DefineRoom.tsx
+++ b/apps/pages/src/define-rooms/DefineRoom.tsx
@@ -311,6 +311,68 @@ const CANCEL_ROOM_ICON = `
   </svg>
 `;
 
+const CHARACTER_MARKER_ICON = `
+  <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <circle
+      cx="12"
+      cy="8"
+      r="3.5"
+      stroke="currentColor"
+      stroke-width="1.6"
+    />
+    <path
+      d="M5 19c.7-3.2 3.4-5.5 7-5.5s6.3 2.3 7 5.5"
+      stroke="currentColor"
+      stroke-width="1.6"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+  </svg>
+`;
+
+const OBJECT_MARKER_ICON = `
+  <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path
+      d="M4 8l8-4 8 4v8l-8 4-8-4V8z"
+      stroke="currentColor"
+      stroke-width="1.6"
+      stroke-linejoin="round"
+    />
+    <path
+      d="M12 4v16"
+      stroke="currentColor"
+      stroke-width="1.6"
+      stroke-linecap="round"
+    />
+    <path
+      d="M4 12l8 4 8-4"
+      stroke="currentColor"
+      stroke-width="1.6"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+  </svg>
+`;
+
+const SWITCH_TO_TEMPORARY_MARKERS_ICON = `
+  <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <circle cx="12" cy="12" r="5.5" stroke="currentColor" stroke-width="1.7" />
+    <path d="M12 4v2.2" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" />
+    <path d="M12 17.8V20" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" />
+    <path d="M4 12h2.2" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" />
+    <path d="M17.8 12H20" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" />
+  </svg>
+`;
+
+const SWITCH_TO_ROOMS_ICON = `
+  <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect x="5" y="5" width="6" height="6" rx="1.4" stroke="currentColor" stroke-width="1.6" />
+    <rect x="13" y="5" width="6" height="6" rx="1.4" stroke="currentColor" stroke-width="1.6" />
+    <rect x="5" y="13" width="6" height="6" rx="1.4" stroke="currentColor" stroke-width="1.6" />
+    <rect x="13" y="13" width="6" height="6" rx="1.4" stroke="currentColor" stroke-width="1.6" />
+  </svg>
+`;
+
 const TOOL_ORDER: ToolType[] = ["move", "magnify", "brush", "eraser", "lasso", "magnetic", "wand"];
 
 const UNDO_ICON = `
@@ -481,6 +543,20 @@ export class DefineRoom {
 
   private toolbarContainer!: HTMLElement;
 
+  private markersToolbar!: HTMLElement;
+
+  private tabToggleButton!: HTMLButtonElement;
+
+  private tabToggleButtonIcon: HTMLElement | null = null;
+
+  private characterMarkersButton!: HTMLButtonElement;
+
+  private objectMarkersButton!: HTMLButtonElement;
+
+  private temporaryMarkersPanel!: HTMLElement;
+
+  private activeTab: 'rooms' | 'temporary-markers' = 'rooms';
+
   private handleColorMenuOutsideClick = (event: MouseEvent): void => {
     if (!this.colorMenu || this.colorMenu.classList.contains("hidden")) {
       return;
@@ -510,6 +586,10 @@ export class DefineRoom {
   private undoButton!: HTMLButtonElement;
 
   private redoButton!: HTMLButtonElement;
+
+  private sharedToolGroup!: HTMLElement;
+
+  private roomToolGroup!: HTMLElement;
 
   private toolButtons: Map<ToolType, HTMLButtonElement> = new Map();
 
@@ -689,54 +769,115 @@ export class DefineRoom {
                     ref={(node: HTMLElement | null) => node && (this.brushSliderValueLabel = node)}
                   ></div>
                 </div>
-                <div class="toolbar" ref={(node: HTMLElement | null) => node && (this.toolbarContainer = node)}>
-                  <div class="toolbar-primary-group">
-                    <button class="toolbar-button toolbar-primary" type="button" aria-label="New Room" title="New Room">
-                      <span class="toolbar-button-icon" aria-hidden="true"></span>
-                      <span class="toolbar-button-label" aria-hidden="true">New Room</span>
-                    </button>
-                    <div class="toolbar-confirm-group">
+                <div class="toolbar-stack">
+                  <button
+                    class="toolbar-button toolbar-switch-tab"
+                    type="button"
+                    aria-label="Switch to Temporary Markers tab"
+                    title="Switch to Temporary Markers tab"
+                    data-target-tab="temporary-markers"
+                    ref={(node: HTMLButtonElement | null) => node && (this.tabToggleButton = node)}
+                  >
+                    <span
+                      class="toolbar-button-icon"
+                      aria-hidden="true"
+                      ref={(node: HTMLElement | null) => node && (this.tabToggleButtonIcon = node)}
+                    ></span>
+                  </button>
+                  <div class="toolbar toolbar-shared" role="group" aria-label="Common room tools">
+                    <div class="history-group">
                       <button
-                        class="toolbar-button toolbar-confirm"
+                        class="toolbar-button tool-button history-button toolbar-undo"
                         type="button"
-                        aria-label="Confirm Room"
-                        title="Confirm Room"
+                        aria-label="Undo"
+                        title="Undo"
                       >
                         <span class="toolbar-button-icon" aria-hidden="true"></span>
-                        <span class="toolbar-button-label" aria-hidden="true">Confirm</span>
+                        <span class="toolbar-button-label" aria-hidden="true">Undo</span>
                       </button>
                       <button
-                        class="toolbar-button toolbar-cancel"
+                        class="toolbar-button tool-button history-button toolbar-redo"
                         type="button"
-                        aria-label="Cancel Room"
-                        title="Cancel Room"
+                        aria-label="Redo"
+                        title="Redo"
                       >
                         <span class="toolbar-button-icon" aria-hidden="true"></span>
-                        <span class="toolbar-button-label" aria-hidden="true">Cancel</span>
+                        <span class="toolbar-button-label" aria-hidden="true">Redo</span>
                       </button>
                     </div>
+                    <div
+                      class="tool-group tool-group-shared"
+                      ref={(node: HTMLElement | null) => node && (this.sharedToolGroup = node)}
+                    ></div>
                   </div>
-                  <div class="history-group">
+                  <div
+                    class="toolbar toolbar-rooms"
+                    id="define-room-toolbar"
+                    role="group"
+                    aria-label="Define Rooms toolbar"
+                    ref={(node: HTMLElement | null) => node && (this.toolbarContainer = node)}
+                  >
+                    <div class="toolbar-primary-group">
+                      <button class="toolbar-button toolbar-primary" type="button" aria-label="New Room" title="New Room">
+                        <span class="toolbar-button-icon" aria-hidden="true"></span>
+                        <span class="toolbar-button-label" aria-hidden="true">New Room</span>
+                      </button>
+                      <div class="toolbar-confirm-group">
+                        <button
+                          class="toolbar-button toolbar-confirm"
+                          type="button"
+                          aria-label="Confirm Room"
+                          title="Confirm Room"
+                        >
+                          <span class="toolbar-button-icon" aria-hidden="true"></span>
+                          <span class="toolbar-button-label" aria-hidden="true">Confirm</span>
+                        </button>
+                        <button
+                          class="toolbar-button toolbar-cancel"
+                          type="button"
+                          aria-label="Cancel Room"
+                          title="Cancel Room"
+                        >
+                          <span class="toolbar-button-icon" aria-hidden="true"></span>
+                          <span class="toolbar-button-label" aria-hidden="true">Cancel</span>
+                        </button>
+                      </div>
+                    </div>
+                    <div
+                      class="tool-group tool-group-rooms"
+                      ref={(node: HTMLElement | null) => node && (this.roomToolGroup = node)}
+                    ></div>
+                  </div>
+                  <div
+                    class="toolbar toolbar-temporary-markers"
+                    id="temporary-markers-toolbar"
+                    role="group"
+                    aria-label="Temporary Markers toolbar"
+                    aria-hidden="true"
+                    hidden
+                    ref={(node: HTMLElement | null) => node && (this.markersToolbar = node)}
+                  >
                     <button
-                      class="toolbar-button tool-button history-button toolbar-undo"
+                      class="toolbar-button toolbar-temporary"
                       type="button"
-                      aria-label="Undo"
-                      title="Undo"
+                      aria-label="Character Markers"
+                      title="Character Markers"
+                      ref={(node: HTMLButtonElement | null) => node && (this.characterMarkersButton = node)}
                     >
                       <span class="toolbar-button-icon" aria-hidden="true"></span>
-                      <span class="toolbar-button-label" aria-hidden="true">Undo</span>
+                      <span class="toolbar-button-label" aria-hidden="true">Character Markers</span>
                     </button>
                     <button
-                      class="toolbar-button tool-button history-button toolbar-redo"
+                      class="toolbar-button toolbar-temporary"
                       type="button"
-                      aria-label="Redo"
-                      title="Redo"
+                      aria-label="Object Markers"
+                      title="Object Markers"
+                      ref={(node: HTMLButtonElement | null) => node && (this.objectMarkersButton = node)}
                     >
                       <span class="toolbar-button-icon" aria-hidden="true"></span>
-                      <span class="toolbar-button-label" aria-hidden="true">Redo</span>
+                      <span class="toolbar-button-label" aria-hidden="true">Object Markers</span>
                     </button>
                   </div>
-                  <div class="tool-group"></div>
                 </div>
               </div>
               <div class="canvas-wrapper">
@@ -755,6 +896,22 @@ export class DefineRoom {
               </p>
               <div class="rooms-list"></div>
               <div class="room-color-menu hidden" aria-hidden="true"></div>
+            </aside>
+            <aside
+              class="define-room-sidebar temporary-markers-panel"
+              ref={(node: HTMLElement | null) => node && (this.temporaryMarkersPanel = node)}
+              aria-hidden="true"
+              hidden
+            >
+              <div class="rooms-header">
+                <h2>Temporary Markers</h2>
+              </div>
+              <p class="temporary-markers-description">
+                Add quick callouts while planning without committing them to the final map yet.
+              </p>
+              <div class="temporary-markers-placeholder">
+                <p class="temporary-markers-empty">Temporary markers will appear here once added.</p>
+              </div>
             </aside>
           </div>
         </div>
@@ -856,6 +1013,59 @@ export class DefineRoom {
     this.updateCanvasCursor();
   }
 
+  private setActiveTab(tab: 'rooms' | 'temporary-markers'): void {
+    if (this.activeTab === tab) {
+      return;
+    }
+    this.activeTab = tab;
+    this.applyActiveTabState();
+  }
+
+  private applyActiveTabState(): void {
+    const isRooms = this.activeTab === 'rooms';
+    this.root.classList.toggle('define-room-temporary-markers-active', !isRooms);
+
+    if (this.tabToggleButton) {
+      const nextTab = isRooms ? 'temporary-markers' : 'rooms';
+      const label =
+        nextTab === 'temporary-markers'
+          ? 'Switch to Temporary Markers tab'
+          : 'Switch to Define Rooms tab';
+      this.tabToggleButton.setAttribute('aria-label', label);
+      this.tabToggleButton.setAttribute('title', label);
+      this.tabToggleButton.dataset.targetTab = nextTab;
+    }
+
+    if (this.tabToggleButtonIcon) {
+      const icon =
+        this.activeTab === 'rooms'
+          ? SWITCH_TO_TEMPORARY_MARKERS_ICON
+          : SWITCH_TO_ROOMS_ICON;
+      this.tabToggleButtonIcon.innerHTML = icon;
+    }
+
+    if (this.toolbarContainer) {
+      this.toolbarContainer.hidden = !isRooms;
+      this.toolbarContainer.setAttribute('aria-hidden', isRooms ? 'false' : 'true');
+    }
+
+    if (this.markersToolbar) {
+      this.markersToolbar.hidden = isRooms;
+      this.markersToolbar.setAttribute('aria-hidden', isRooms ? 'true' : 'false');
+    }
+
+    if (this.roomsPanel) {
+      this.roomsPanel.hidden = !isRooms;
+    }
+
+    if (this.temporaryMarkersPanel) {
+      this.temporaryMarkersPanel.hidden = isRooms;
+      this.temporaryMarkersPanel.setAttribute('aria-hidden', isRooms ? 'true' : 'false');
+    }
+
+    this.updateBrushSliderVisibility();
+  }
+
   public capturePolygonForMarker(): Promise<Array<{ x: number; y: number }> | null> {
     if (!this.imageData) {
       return Promise.resolve(null);
@@ -918,13 +1128,32 @@ export class DefineRoom {
     this.toolbarCancelButton = this.root.querySelector(".toolbar-cancel") as HTMLButtonElement;
     this.undoButton = this.root.querySelector(".toolbar-undo") as HTMLButtonElement;
     this.redoButton = this.root.querySelector(".toolbar-redo") as HTMLButtonElement;
+    this.tabToggleButton = this.root.querySelector(
+      ".toolbar-switch-tab",
+    ) as HTMLButtonElement;
+    this.tabToggleButtonIcon = (this.tabToggleButton?.querySelector(
+      ".toolbar-button-icon",
+    ) as HTMLElement | null) ?? null;
+    this.markersToolbar = this.root.querySelector(".toolbar-temporary-markers") as HTMLElement;
+    this.characterMarkersButton = this.root.querySelector(
+      '.toolbar-temporary[aria-label="Character Markers"]',
+    ) as HTMLButtonElement;
+    this.objectMarkersButton = this.root.querySelector(
+      '.toolbar-temporary[aria-label="Object Markers"]',
+    ) as HTMLButtonElement;
+    this.temporaryMarkersPanel = this.root.querySelector(
+      ".temporary-markers-panel",
+    ) as HTMLElement;
+    this.sharedToolGroup =
+      this.sharedToolGroup ?? (this.root.querySelector(".tool-group-shared") as HTMLElement);
+    this.roomToolGroup =
+      this.roomToolGroup ?? (this.root.querySelector(".tool-group-rooms") as HTMLElement);
     this.roomsList = this.roomsPanel.querySelector(".rooms-list") as HTMLElement;
     this.colorMenu = this.roomsPanel.querySelector(".room-color-menu") as HTMLElement;
     this.deleteBackdrop = this.root.querySelector(".room-delete-backdrop") as HTMLElement;
     this.deleteCancelButton = this.root.querySelector(".room-delete-cancel") as HTMLButtonElement;
     this.deleteConfirmButton = this.root.querySelector(".room-delete-confirm") as HTMLButtonElement;
     this.deleteDialogIcon = this.root.querySelector(".room-delete-icon") as HTMLElement;
-    const toolGroup = this.root.querySelector(".tool-group") as HTMLElement;
     this.canvasWrapper = this.root.querySelector(".canvas-wrapper") as HTMLElement;
     this.imageCanvas = this.root.querySelector(".image-layer") as HTMLCanvasElement;
     this.overlayCanvas = this.root.querySelector(".mask-layer") as HTMLCanvasElement;
@@ -937,6 +1166,33 @@ export class DefineRoom {
     this.initializeColorMenu();
 
     this.roomsList.addEventListener("scroll", () => this.closeColorMenu());
+
+    if (this.tabToggleButton) {
+      this.tabToggleButton.addEventListener("click", () => {
+        const nextTab = this.activeTab === "rooms" ? "temporary-markers" : "rooms";
+        this.setActiveTab(nextTab);
+      });
+    }
+
+    if (this.characterMarkersButton) {
+      const characterIcon = this.characterMarkersButton.querySelector(
+        ".toolbar-button-icon",
+      ) as HTMLElement | null;
+      if (characterIcon) {
+        characterIcon.innerHTML = CHARACTER_MARKER_ICON;
+      }
+    }
+
+    if (this.objectMarkersButton) {
+      const objectIcon = this.objectMarkersButton.querySelector(
+        ".toolbar-button-icon",
+      ) as HTMLElement | null;
+      if (objectIcon) {
+        objectIcon.innerHTML = OBJECT_MARKER_ICON;
+      }
+    }
+
+    this.applyActiveTabState();
 
     if (this.deleteBackdrop) {
       this.deleteBackdrop.addEventListener("click", (event) => {
@@ -1026,6 +1282,10 @@ export class DefineRoom {
     this.updateNewRoomControls();
     this.updateHistoryControls();
 
+    if (!this.sharedToolGroup || !this.roomToolGroup) {
+      throw new Error("DefineRoom tool groups failed to initialize");
+    }
+
     TOOL_ORDER.forEach((tool) => {
       const button = document.createElement("button");
       button.type = "button";
@@ -1046,7 +1306,10 @@ export class DefineRoom {
       button.appendChild(label);
 
       button.addEventListener("click", () => this.setTool(tool));
-      toolGroup.appendChild(button);
+
+      const targetGroup =
+        tool === "move" || tool === "magnify" ? this.sharedToolGroup : this.roomToolGroup;
+      targetGroup.appendChild(button);
       this.toolButtons.set(tool, button);
     });
     this.setTool(this.currentTool);
@@ -1411,10 +1674,11 @@ export class DefineRoom {
     }
 
     const isBrushTool = this.currentTool === "brush" || this.currentTool === "eraser";
-    this.brushSliderContainer.classList.toggle("visible", isBrushTool);
-    this.brushSliderContainer.setAttribute("aria-hidden", isBrushTool ? "false" : "true");
+    const shouldShowSlider = this.activeTab === "rooms" && isBrushTool;
+    this.brushSliderContainer.classList.toggle("visible", shouldShowSlider);
+    this.brushSliderContainer.setAttribute("aria-hidden", shouldShowSlider ? "false" : "true");
 
-    if (!isBrushTool && this.isAdjustingBrushSize) {
+    if ((!shouldShowSlider || !isBrushTool) && this.isAdjustingBrushSize) {
       this.stopBrushSliderInteraction();
     }
   }

--- a/apps/pages/src/define-rooms/styles.css
+++ b/apps/pages/src/define-rooms/styles.css
@@ -272,6 +272,35 @@
   color: rgba(226, 232, 240, 0.6);
 }
 
+.temporary-markers-panel {
+  gap: 16px;
+}
+
+.temporary-markers-description {
+  margin: 0;
+  font-size: 0.88rem;
+  color: rgba(226, 232, 240, 0.65);
+  line-height: 1.5;
+}
+
+.temporary-markers-placeholder {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 18px;
+  border-radius: 16px;
+  border: 1px dashed rgba(148, 163, 184, 0.28);
+  background: rgba(15, 23, 42, 0.45);
+  text-align: center;
+}
+
+.temporary-markers-empty {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(148, 163, 184, 0.75);
+}
+
 .rooms-list {
   flex: 1;
   overflow-y: auto;
@@ -550,6 +579,75 @@
   flex-shrink: 0;
 }
 
+.toolbar-stack {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+  flex-shrink: 0;
+}
+
+.toolbar-switch-tab {
+  margin-left: 0;
+  width: 36px;
+  min-width: 36px;
+  justify-content: center;
+  background: rgba(22, 32, 51, 0.95);
+  border-color: rgba(96, 165, 250, 0.45);
+  box-shadow: 0 12px 32px rgba(59, 130, 246, 0.35);
+  transition: transform 0.25s ease, box-shadow 0.25s ease, background 0.25s ease,
+    border-color 0.25s ease;
+}
+
+.toolbar-switch-tab[data-target-tab="temporary-markers"] {
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.92), rgba(129, 140, 248, 0.92));
+  color: #0b1220;
+  border-color: transparent;
+}
+
+.toolbar-switch-tab[data-target-tab="rooms"] {
+  background: linear-gradient(135deg, rgba(244, 114, 182, 0.88), rgba(251, 191, 36, 0.82));
+  color: rgba(15, 23, 42, 0.92);
+  border-color: transparent;
+  box-shadow: 0 12px 32px rgba(244, 114, 182, 0.35);
+}
+
+.toolbar-switch-tab:hover:not(:disabled),
+.toolbar-switch-tab:focus-visible:not(:disabled) {
+  width: 36px;
+  transform: translateY(-1px);
+  box-shadow: 0 16px 38px rgba(56, 189, 248, 0.4);
+}
+
+.toolbar-switch-tab[data-target-tab="rooms"]:hover:not(:disabled),
+.toolbar-switch-tab[data-target-tab="rooms"]:focus-visible:not(:disabled) {
+  box-shadow: 0 16px 38px rgba(244, 114, 182, 0.42);
+}
+
+.toolbar-switch-tab:active:not(:disabled) {
+  transform: translateY(0);
+  box-shadow: 0 10px 24px rgba(56, 189, 248, 0.28);
+}
+
+.toolbar-switch-tab .toolbar-button-icon {
+  opacity: 1;
+  width: 18px;
+  height: 18px;
+  transform: none;
+}
+
+.toolbar-switch-tab .toolbar-button-icon svg {
+  width: 18px;
+  height: 18px;
+}
+
+.toolbar-switch-tab:hover:not(:disabled) .toolbar-button-icon,
+.toolbar-switch-tab:focus-visible:not(:disabled) .toolbar-button-icon {
+  opacity: 1;
+  width: 18px;
+  transform: none;
+}
+
 .toolbar {
   display: flex;
   flex-direction: column;
@@ -773,6 +871,19 @@
   opacity: 0;
   width: 0;
   transform: translateX(-10px);
+}
+
+.toolbar-temporary {
+  border: none;
+  background: linear-gradient(135deg, #38bdf8, #818cf8);
+  color: #0b1220;
+  box-shadow: 0 16px 36px rgba(56, 189, 248, 0.35);
+}
+
+.toolbar-temporary:hover:not(:disabled),
+.toolbar-temporary:focus-visible:not(:disabled) {
+  background: linear-gradient(135deg, #60a5fa, #a855f7);
+  color: #0b1220;
 }
 
 .toolbar-primary {


### PR DESCRIPTION
## Summary
- move the undo/redo controls into a shared toolbar that is visible from both tabs
- surface the move and zoom tools in the shared toolbar while leaving the remaining room tools scoped to the rooms tab
- guard initialization so shared tool containers are resolved before tool buttons are created

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69023b2b0a10832383c6fb04fb59c58a