### PR TITLE
Enable interactive placement for temporary markers

### DIFF
--- a/apps/pages/src/define-rooms/styles.css
+++ b/apps/pages/src/define-rooms/styles.css
@@ -43,30 +43,9 @@
   display: none;
 }
 
-.define-room-marker-placement .define-room-window {
-  background: transparent;
-  border: none;
-  box-shadow: none;
-}
-
-.define-room-marker-placement .define-room-body {
-  padding: 0;
-}
-
-.define-room-marker-placement .define-room-editor {
-  padding: 0;
-}
-
-.define-room-marker-placement .toolbar-area,
-.define-room-marker-placement .define-room-sidebar,
-.define-room-marker-placement .brush-slider-container {
-  display: none !important;
-}
-
 .define-room-marker-placement .canvas-wrapper {
-  background: transparent;
-  border: none;
-  border-radius: inherit;
+  border-color: rgba(96, 165, 250, 0.45);
+  box-shadow: 0 0 0 1px rgba(56, 189, 248, 0.35);
 }
 
 .define-room-marker-placement .room-hover-label {
@@ -270,6 +249,106 @@
   margin: 0;
   font-size: 0.9rem;
   color: rgba(226, 232, 240, 0.6);
+}
+
+.temporary-markers-panel {
+  gap: 16px;
+}
+
+.temporary-markers-description {
+  margin: 0;
+  font-size: 0.88rem;
+  color: rgba(226, 232, 240, 0.65);
+  line-height: 1.5;
+}
+
+.temporary-markers-placeholder {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  justify-content: flex-start;
+  gap: 16px;
+  padding: 18px 20px;
+  border-radius: 16px;
+  border: 1px dashed rgba(148, 163, 184, 0.28);
+  background: rgba(15, 23, 42, 0.45);
+  text-align: left;
+  overflow: hidden;
+}
+
+.temporary-markers-empty {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(148, 163, 184, 0.75);
+  text-align: center;
+}
+
+.temporary-markers-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  overflow-y: auto;
+  max-height: 100%;
+}
+
+.temporary-markers-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(30, 41, 59, 0.55);
+  color: rgba(226, 232, 240, 0.92);
+  font-size: 0.85rem;
+  box-shadow: 0 12px 24px rgba(2, 6, 23, 0.25);
+}
+
+.temporary-marker-summary {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.temporary-marker-summary-icon {
+  width: 20px;
+  height: 20px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: rgba(148, 163, 184, 0.9);
+}
+
+.temporary-marker-summary-icon svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+  stroke: currentColor;
+  fill: none;
+}
+
+.temporary-markers-item[data-marker-kind="character"] .temporary-marker-summary-icon {
+  color: #fbbf24;
+}
+
+.temporary-markers-item[data-marker-kind="object"] .temporary-marker-summary-icon {
+  color: #38bdf8;
+}
+
+.temporary-marker-kind-label {
+  font-weight: 600;
+  color: rgba(226, 232, 240, 0.95);
+}
+
+.temporary-marker-coordinates {
+  font-family: "JetBrains Mono", "Fira Mono", monospace;
+  font-size: 0.78rem;
+  color: rgba(148, 163, 184, 0.82);
 }
 
 .rooms-list {
@@ -550,6 +629,75 @@
   flex-shrink: 0;
 }
 
+.toolbar-stack {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+  flex-shrink: 0;
+}
+
+.toolbar-switch-tab {
+  margin-left: 0;
+  width: 36px;
+  min-width: 36px;
+  justify-content: center;
+  background: rgba(22, 32, 51, 0.95);
+  border-color: rgba(96, 165, 250, 0.45);
+  box-shadow: 0 12px 32px rgba(59, 130, 246, 0.35);
+  transition: transform 0.25s ease, box-shadow 0.25s ease, background 0.25s ease,
+    border-color 0.25s ease;
+}
+
+.toolbar-switch-tab[data-target-tab="temporary-markers"] {
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.92), rgba(129, 140, 248, 0.92));
+  color: #0b1220;
+  border-color: transparent;
+}
+
+.toolbar-switch-tab[data-target-tab="rooms"] {
+  background: linear-gradient(135deg, rgba(244, 114, 182, 0.88), rgba(251, 191, 36, 0.82));
+  color: rgba(15, 23, 42, 0.92);
+  border-color: transparent;
+  box-shadow: 0 12px 32px rgba(244, 114, 182, 0.35);
+}
+
+.toolbar-switch-tab:hover:not(:disabled),
+.toolbar-switch-tab:focus-visible:not(:disabled) {
+  width: 36px;
+  transform: translateY(-1px);
+  box-shadow: 0 16px 38px rgba(56, 189, 248, 0.4);
+}
+
+.toolbar-switch-tab[data-target-tab="rooms"]:hover:not(:disabled),
+.toolbar-switch-tab[data-target-tab="rooms"]:focus-visible:not(:disabled) {
+  box-shadow: 0 16px 38px rgba(244, 114, 182, 0.42);
+}
+
+.toolbar-switch-tab:active:not(:disabled) {
+  transform: translateY(0);
+  box-shadow: 0 10px 24px rgba(56, 189, 248, 0.28);
+}
+
+.toolbar-switch-tab .toolbar-button-icon {
+  opacity: 1;
+  width: 18px;
+  height: 18px;
+  transform: none;
+}
+
+.toolbar-switch-tab .toolbar-button-icon svg {
+  width: 18px;
+  height: 18px;
+}
+
+.toolbar-switch-tab:hover:not(:disabled) .toolbar-button-icon,
+.toolbar-switch-tab:focus-visible:not(:disabled) .toolbar-button-icon {
+  opacity: 1;
+  width: 18px;
+  transform: none;
+}
+
 .toolbar {
   display: flex;
   flex-direction: column;
@@ -775,6 +923,24 @@
   transform: translateX(-10px);
 }
 
+.toolbar-temporary {
+  border: none;
+  background: linear-gradient(135deg, #38bdf8, #818cf8);
+  color: #0b1220;
+  box-shadow: 0 16px 36px rgba(56, 189, 248, 0.35);
+}
+
+.toolbar-temporary.active {
+  background: linear-gradient(135deg, #38bdf8, #60a5fa);
+  box-shadow: 0 18px 40px rgba(59, 130, 246, 0.4);
+}
+
+.toolbar-temporary:hover:not(:disabled),
+.toolbar-temporary:focus-visible:not(:disabled) {
+  background: linear-gradient(135deg, #60a5fa, #a855f7);
+  color: #0b1220;
+}
+
 .toolbar-primary {
   border: none;
   background: linear-gradient(135deg, #f97316, #facc15);
@@ -803,12 +969,29 @@
   align-items: flex-start;
 }
 
+.toolbar-shared-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  width: 100%;
+  align-items: flex-start;
+  margin-top: auto;
+}
+
 .tool-group {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
   gap: 16px;
   width: 100%;
+}
+
+.toolbar-temporary-markers {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  width: 100%;
+  align-items: flex-start;
 }
 
 .tool-button {
@@ -894,6 +1077,68 @@
 
 .canvas-wrapper .image-layer {
   position: relative;
+}
+
+.canvas-wrapper.placing-marker {
+  border-color: rgba(96, 165, 250, 0.55);
+  box-shadow: 0 0 0 1px rgba(56, 189, 248, 0.4);
+}
+
+.temporary-marker-layer {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 3;
+}
+
+.temporary-marker {
+  position: absolute;
+  transform: translate(-50%, -100%);
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: rgba(248, 250, 252, 0.92);
+  filter: drop-shadow(0 8px 16px rgba(2, 6, 23, 0.45));
+}
+
+.temporary-marker svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+  stroke: currentColor;
+  fill: none;
+}
+
+.temporary-marker-character {
+  color: #fbbf24;
+}
+
+.temporary-marker-object {
+  color: #38bdf8;
+}
+
+.temporary-marker-guidance {
+  position: absolute;
+  top: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 10px 18px;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.7);
+  color: rgba(248, 250, 252, 0.95);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: none;
+  pointer-events: none;
+  z-index: 4;
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.35);
+  backdrop-filter: blur(4px);
+}
+
+.temporary-marker-guidance[hidden] {
+  display: none;
 }
 
 .selection-layer {


### PR DESCRIPTION
## Summary
- add marker placement handling that toggles a crosshair cursor and top-of-map guidance text when temporary marker tools are active
- drop character or object markers on click with saved pixel coordinates and list them in the temporary markers panel while clearing them on new images
- style the marker guidance overlay, toolbar active state, and sidebar list entries for the new marker workflow

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69023b2b0a10832383c6fb04fb59c58a