### PR TITLE
Align marker editing and deletion flows

### DIFF
--- a/apps/pages/src/components/MapCreationWizard.tsx
+++ b/apps/pages/src/components/MapCreationWizard.tsx
@@ -20,7 +20,7 @@ import {
   type MapMarkerIconDefinition,
 } from './mapMarkerIcons';
 
-type WizardStep = 0 | 1 | 2;
+type WizardStep = 0 | 1 | 2 | 3;
 
 interface MapCreationWizardProps {
   campaign: Campaign;
@@ -90,6 +90,10 @@ const steps: Array<{ title: string; description: string }> = [
   {
     title: 'Define Rooms',
     description: 'Use the room editor to outline areas before placing your markers.',
+  },
+  {
+    title: 'Add Markers',
+    description: 'Place markers to highlight important characters, objects, or areas.',
   },
 ];
 
@@ -708,7 +712,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
       defineRoomRef.current?.loadImage(image);
       setDefinedRooms([]);
       const currentStep = stepRef.current;
-      if (currentStep === 2) {
+      if (currentStep === 2 || currentStep === 3) {
         defineRoomRef.current?.setMarkerPlacementMode(false);
         defineRoomRef.current?.open(image, { resetExisting: true });
       } else {
@@ -730,12 +734,28 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
     if (!editor) {
       return;
     }
-    if (step === 2 && defineRoomImageRef.current) {
+    if ((step === 2 || step === 3) && defineRoomImageRef.current) {
       editor.setMarkerPlacementMode(false);
       editor.open(defineRoomImageRef.current, { resetExisting: false });
     } else {
       editor.setMarkerPlacementMode(false);
       editor.close();
+    }
+  }, [defineRoomReady, step]);
+
+  useEffect(() => {
+    if (!defineRoomReady) {
+      return;
+    }
+    const editor = defineRoomRef.current;
+    if (!editor) {
+      return;
+    }
+    if (step === 2) {
+      editor.setActiveTab('rooms');
+    }
+    if (step === 3) {
+      editor.setActiveTab('markers');
     }
   }, [defineRoomReady, step]);
 
@@ -1856,7 +1876,7 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
               </div>
             </div>
           )}
-          {step === 2 && (
+          {(step === 2 || step === 3) && (
             <div className="flex h-full min-h-0 flex-1 justify-center">
               <div className="flex h-full min-h-0 w-full rounded-3xl border border-slate-800/70 bg-slate-900/70 p-4">
                 <div

--- a/apps/pages/src/define-rooms/DefineRoom.tsx
+++ b/apps/pages/src/define-rooms/DefineRoom.tsx
@@ -42,6 +42,10 @@ type TemporaryMarkerType = "character" | "object";
 type TemporaryMarker = {
   id: string;
   type: TemporaryMarkerType;
+  name: string;
+  description: string;
+  tags: string;
+  visibleAtStart: boolean;
   x: number;
   y: number;
 };
@@ -363,25 +367,6 @@ const OBJECT_MARKER_ICON = `
   </svg>
 `;
 
-const SWITCH_TO_TEMPORARY_MARKERS_ICON = `
-  <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <circle cx="12" cy="12" r="5.5" stroke="currentColor" stroke-width="1.7" />
-    <path d="M12 4v2.2" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" />
-    <path d="M12 17.8V20" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" />
-    <path d="M4 12h2.2" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" />
-    <path d="M17.8 12H20" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" />
-  </svg>
-`;
-
-const SWITCH_TO_ROOMS_ICON = `
-  <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <rect x="5" y="5" width="6" height="6" rx="1.4" stroke="currentColor" stroke-width="1.6" />
-    <rect x="13" y="5" width="6" height="6" rx="1.4" stroke="currentColor" stroke-width="1.6" />
-    <rect x="5" y="13" width="6" height="6" rx="1.4" stroke="currentColor" stroke-width="1.6" />
-    <rect x="13" y="13" width="6" height="6" rx="1.4" stroke="currentColor" stroke-width="1.6" />
-  </svg>
-`;
-
 const TOOL_ORDER: ToolType[] = ["move", "magnify", "brush", "eraser", "lasso", "magnetic", "wand"];
 
 const UNDO_ICON = `
@@ -540,7 +525,15 @@ export class DefineRoom {
 
   private deleteDialogIcon!: HTMLElement;
 
+  private deleteTitle!: HTMLElement;
+
+  private deleteMessage!: HTMLElement;
+
+  private pendingDeleteType: 'room' | 'marker' | null = null;
+
   private pendingDeleteRoomId: string | null = null;
+
+  private pendingDeleteMarkerId: string | null = null;
 
   private colorMenu!: HTMLElement;
 
@@ -562,10 +555,6 @@ export class DefineRoom {
 
   private markerInstructionLabel!: HTMLElement;
 
-  private tabToggleButton!: HTMLButtonElement;
-
-  private tabToggleButtonIcon: HTMLElement | null = null;
-
   private characterMarkersButton!: HTMLButtonElement;
 
   private objectMarkersButton!: HTMLButtonElement;
@@ -576,18 +565,48 @@ export class DefineRoom {
 
   private temporaryMarkersList!: HTMLElement;
 
-  private activeTab: 'rooms' | 'temporary-markers' = 'rooms';
+  private activeTab: 'rooms' | 'markers' = 'rooms';
 
   private activeMarkerType: TemporaryMarkerType | null = null;
 
   private temporaryMarkers: TemporaryMarker[] = [];
 
+  private expandedMarkerId: string | null = null;
+
+  private markerIconMenu!: HTMLElement;
+
+  private markerIconMenuOptions: HTMLButtonElement[] = [];
+
+  private markerIconMenuTrigger: HTMLElement | null = null;
+
+  private activeIconMarkerId: string | null = null;
+
+  private repositioningMarkerId: string | null = null;
+
+  private markerDragPointerId: number | null = null;
+
+  private markerDragElement: HTMLElement | null = null;
+
   private handleColorMenuOutsideClick = (event: MouseEvent): void => {
+    const target = event.target as Node;
+
+    if (
+      this.markerIconMenu &&
+      !this.markerIconMenu.classList.contains("hidden")
+    ) {
+      if (
+        this.markerIconMenu.contains(target) ||
+        (this.markerIconMenuTrigger && this.markerIconMenuTrigger.contains(target))
+      ) {
+        return;
+      }
+      this.closeMarkerIconMenu();
+    }
+
     if (!this.colorMenu || this.colorMenu.classList.contains("hidden")) {
       return;
     }
 
-    const target = event.target as Node;
     if (this.colorMenu.contains(target)) {
       return;
     }
@@ -793,20 +812,6 @@ export class DefineRoom {
                   ></div>
                 </div>
                 <div class="toolbar-stack">
-                  <button
-                    class="toolbar-button toolbar-switch-tab"
-                    type="button"
-                    aria-label="Switch to Temporary Markers tab"
-                    title="Switch to Temporary Markers tab"
-                    data-target-tab="temporary-markers"
-                    ref={(node: HTMLButtonElement | null) => node && (this.tabToggleButton = node)}
-                  >
-                    <span
-                      class="toolbar-button-icon"
-                      aria-hidden="true"
-                      ref={(node: HTMLElement | null) => node && (this.tabToggleButtonIcon = node)}
-                    ></span>
-                  </button>
                   <div
                     class="toolbar"
                     id="define-room-toolbar"
@@ -845,7 +850,7 @@ export class DefineRoom {
                       class="toolbar-temporary-markers"
                       id="temporary-markers-toolbar"
                       role="group"
-                      aria-label="Temporary Markers toolbar"
+                      aria-label="Markers toolbar"
                       aria-hidden="true"
                       hidden
                       ref={(node: HTMLElement | null) => node && (this.markersToolbar = node)}
@@ -923,20 +928,16 @@ export class DefineRoom {
               hidden
             >
               <div class="rooms-header">
-                <h2>Temporary Markers</h2>
+                <h2>Markers</h2>
               </div>
-              <p class="temporary-markers-description">
-                Add quick callouts while planning without committing them to the final map yet.
-              </p>
-              <div class="temporary-markers-content">
-                <p class="temporary-markers-empty">Temporary markers will appear here once added.</p>
-                <ul
-                  class="temporary-markers-list"
-                  aria-live="polite"
-                  aria-label="Temporary markers"
-                  hidden
-                ></ul>
-              </div>
+              <p class="rooms-empty temporary-markers-empty">Markers will appear here once added.</p>
+              <ul
+                class="rooms-list temporary-markers-list"
+                aria-live="polite"
+                aria-label="Markers"
+                hidden
+              ></ul>
+              <div class="marker-icon-menu hidden" aria-hidden="true"></div>
             </aside>
           </div>
         </div>
@@ -998,6 +999,16 @@ export class DefineRoom {
     this.root.classList.add("hidden");
     this.stopBrushSliderInteraction();
     this.closeColorMenu();
+    this.closeMarkerIconMenu();
+    if (this.repositioningMarkerId) {
+      this.completeMarkerReposition();
+    } else {
+      if (this.markersLayer) {
+        this.markersLayer.classList.remove("is-repositioning");
+      }
+      this.updateMarkerElementsRepositionState();
+      this.updateMarkerInstructions();
+    }
     this.hideDeleteDialog();
     this.endMarkerPlacement();
   }
@@ -1043,7 +1054,7 @@ export class DefineRoom {
     this.updateMarkerButtonsState();
   }
 
-  private setActiveTab(tab: 'rooms' | 'temporary-markers'): void {
+  public setActiveTab(tab: 'rooms' | 'markers'): void {
     if (this.activeTab === tab) {
       return;
     }
@@ -1053,29 +1064,17 @@ export class DefineRoom {
 
   private applyActiveTabState(): void {
     const isRooms = this.activeTab === 'rooms';
-    this.root.classList.toggle('define-room-temporary-markers-active', !isRooms);
+    this.root.classList.toggle('define-room-markers-active', !isRooms);
+
+    if (isRooms) {
+      if (this.repositioningMarkerId) {
+        this.completeMarkerReposition();
+      }
+      this.closeMarkerIconMenu();
+    }
 
     if (isRooms && this.interactionMode === "marker-placement") {
       this.endMarkerPlacement();
-    }
-
-    if (this.tabToggleButton) {
-      const nextTab = isRooms ? 'temporary-markers' : 'rooms';
-      const label =
-        nextTab === 'temporary-markers'
-          ? 'Switch to Temporary Markers tab'
-          : 'Switch to Define Rooms tab';
-      this.tabToggleButton.setAttribute('aria-label', label);
-      this.tabToggleButton.setAttribute('title', label);
-      this.tabToggleButton.dataset.targetTab = nextTab;
-    }
-
-    if (this.tabToggleButtonIcon) {
-      const icon =
-        this.activeTab === 'rooms'
-          ? SWITCH_TO_TEMPORARY_MARKERS_ICON
-          : SWITCH_TO_ROOMS_ICON;
-      this.tabToggleButtonIcon.innerHTML = icon;
     }
 
     if (this.toolbarContainer) {
@@ -1225,16 +1224,27 @@ export class DefineRoom {
       return;
     }
 
+    const index = this.temporaryMarkers.filter((entry) => entry.type === type).length + 1;
+    const defaultName =
+      type === "character" ? `Character Marker ${index}` : `Object Marker ${index}`;
+
     const marker: TemporaryMarker = {
       id: `marker-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
       type,
+      name: defaultName,
+      description: "",
+      tags: "",
+      visibleAtStart: true,
       x: clamp(point.x, 0, this.width - 1),
       y: clamp(point.y, 0, this.height - 1),
     };
 
     this.temporaryMarkers.push(marker);
+    this.repositioningMarkerId = null;
+    this.markerDragPointerId = null;
+    this.markerDragElement = null;
     this.renderTemporaryMarkers();
-    this.updateTemporaryMarkersPanel();
+    this.selectMarker(marker.id, { focusName: true });
   }
 
   private renderTemporaryMarkers(): void {
@@ -1252,6 +1262,13 @@ export class DefineRoom {
       const markerElement = document.createElement("div");
       markerElement.className = `temporary-marker temporary-marker-${marker.type}`;
       markerElement.dataset.markerId = marker.id;
+      markerElement.title = marker.name;
+      markerElement.setAttribute("aria-label", marker.name);
+
+      if (this.repositioningMarkerId === marker.id) {
+        markerElement.classList.add("is-reposition-target");
+      }
+
       const icon = document.createElement("span");
       icon.className = "temporary-marker-icon";
       icon.innerHTML = marker.type === "character" ? CHARACTER_MARKER_ICON : OBJECT_MARKER_ICON;
@@ -1263,8 +1280,37 @@ export class DefineRoom {
       markerElement.style.left = `${percentX}%`;
       markerElement.style.top = `${percentY}%`;
 
+      markerElement.addEventListener("pointerdown", (event) => {
+        this.handleMarkerPointerDown(event, marker.id);
+      });
+
       this.markersLayer.appendChild(markerElement);
     });
+
+    this.updateMarkerElementsRepositionState();
+  }
+
+  private selectMarker(
+    markerId: string | null,
+    options: { focusName?: boolean; forceUpdate?: boolean } = {},
+  ): void {
+    const { focusName = false, forceUpdate = false } = options;
+    const isSameMarker = this.expandedMarkerId === markerId;
+
+    this.expandedMarkerId = markerId;
+
+    if (forceUpdate || !isSameMarker) {
+      this.updateTemporaryMarkersPanel();
+    }
+
+    if (focusName && markerId) {
+      queueMicrotask(() => {
+        const input = this.temporaryMarkersList?.querySelector(
+          `[data-marker-id="${markerId}"] .marker-name`,
+        ) as HTMLInputElement | null;
+        input?.focus();
+      });
+    }
   }
 
   private updateTemporaryMarkersPanel(): void {
@@ -1281,42 +1327,327 @@ export class DefineRoom {
     this.temporaryMarkersList.innerHTML = "";
 
     if (!hasMarkers) {
+      this.expandedMarkerId = null;
+      this.repositioningMarkerId = null;
+      this.updateMarkerElementsRepositionState();
       return;
     }
 
-    this.temporaryMarkers.forEach((marker, index) => {
-      const item = document.createElement("li");
-      item.className = `temporary-marker-item temporary-marker-item-${marker.type}`;
-      item.dataset.markerId = marker.id;
+    if (this.expandedMarkerId && !this.temporaryMarkers.some((marker) => marker.id === this.expandedMarkerId)) {
+      this.expandedMarkerId = null;
+    }
 
-      const indexBadge = document.createElement("span");
-      indexBadge.className = "temporary-marker-item-index";
-      indexBadge.textContent = `#${index + 1}`;
+    if (this.repositioningMarkerId && !this.temporaryMarkers.some((marker) => marker.id === this.repositioningMarkerId)) {
+      this.repositioningMarkerId = null;
+    }
 
-      const icon = document.createElement("span");
-      icon.className = "temporary-marker-item-icon";
-      icon.innerHTML = marker.type === "character" ? CHARACTER_MARKER_ICON : OBJECT_MARKER_ICON;
+    this.closeMarkerIconMenu();
 
-      const content = document.createElement("div");
-      content.className = "temporary-marker-item-content";
+    this.temporaryMarkers.forEach((marker) => {
+      const isExpanded = this.expandedMarkerId === marker.id;
+      const isRepositioning = this.repositioningMarkerId === marker.id;
 
-      const label = document.createElement("span");
-      label.className = "temporary-marker-item-label";
-      label.textContent = marker.type === "character" ? "Character marker" : "Object marker";
+      const card = (
+        <li
+          class={`room-card marker-card ${isExpanded ? "expanded" : ""} ${isRepositioning ? "repositioning" : ""}`}
+          data-marker-id={marker.id}
+        >
+          <div class={`room-row marker-row ${isExpanded ? "active" : ""}`} data-marker-id={marker.id}>
+            <button class="marker-icon-button" type="button" aria-label="Change marker icon"></button>
+            <input class="room-name marker-name" type="text" value={marker.name} />
+            <button class="room-delete-button marker-delete-button" type="button" aria-label="Delete marker"></button>
+          </div>
+          <div class="room-card-body marker-card-body">
+            <label class="room-field marker-field">
+              <span class="room-field-label">Description</span>
+              <textarea class="room-description marker-description" rows={3}>{marker.description}</textarea>
+            </label>
+            <label class="room-field marker-field">
+              <span class="room-field-label">Tags</span>
+              <input class="room-tags marker-tags" type="text" value={marker.tags} />
+            </label>
+            <label class="room-visible marker-visible">
+              <input class="marker-visible-checkbox" type="checkbox" checked={marker.visibleAtStart} />
+              <span>Visible upon room entry</span>
+            </label>
+            <div class="room-card-footer marker-card-footer">
+              <button class="room-edit-button marker-reposition-button" type="button">
+                {isRepositioning ? "Finish Moving" : "Change Location"}
+              </button>
+              <button class="room-save-button marker-save-button" type="button">Save Details</button>
+            </div>
+          </div>
+        </li>
+      ) as HTMLLIElement;
 
-      const coordinates = document.createElement("span");
-      coordinates.className = "temporary-marker-item-coordinates";
-      coordinates.textContent = `(${Math.round(marker.x)}, ${Math.round(marker.y)})`;
+      const header = card.querySelector(".marker-row") as HTMLElement;
+      header.addEventListener("click", () => this.selectMarker(marker.id));
 
-      content.appendChild(label);
-      content.appendChild(coordinates);
+      const nameInput = card.querySelector(".marker-name") as HTMLInputElement;
+      nameInput.addEventListener("input", (event) => {
+        marker.name = (event.target as HTMLInputElement).value;
+        this.updateOverlayMarkerLabel(marker.id, marker.name);
+      });
+      nameInput.addEventListener("focus", () => {
+        this.selectMarker(marker.id, { focusName: true });
+      });
 
-      item.appendChild(indexBadge);
-      item.appendChild(icon);
-      item.appendChild(content);
+      const iconButton = card.querySelector(".marker-icon-button") as HTMLButtonElement;
+      iconButton.innerHTML = marker.type === "character" ? CHARACTER_MARKER_ICON : OBJECT_MARKER_ICON;
+      iconButton.addEventListener("click", (event) => {
+        event.stopPropagation();
+        this.openMarkerIconMenu(marker.id, iconButton);
+      });
 
-      this.temporaryMarkersList.appendChild(item);
+      const deleteButton = card.querySelector(".marker-delete-button") as HTMLButtonElement | null;
+      if (deleteButton) {
+        deleteButton.innerHTML = DELETE_ROOM_ICON;
+        deleteButton.addEventListener("click", (event) => {
+          event.stopPropagation();
+          this.requestMarkerDeletion(marker.id);
+        });
+      }
+
+      const descriptionField = card.querySelector(".marker-description") as HTMLTextAreaElement;
+      descriptionField.addEventListener("input", (event) => {
+        marker.description = (event.target as HTMLTextAreaElement).value;
+      });
+
+      const tagsField = card.querySelector(".marker-tags") as HTMLInputElement;
+      tagsField.addEventListener("input", (event) => {
+        marker.tags = (event.target as HTMLInputElement).value;
+      });
+
+      const visibleCheckbox = card.querySelector(".marker-visible-checkbox") as HTMLInputElement;
+      visibleCheckbox.addEventListener("change", (event) => {
+        marker.visibleAtStart = (event.target as HTMLInputElement).checked;
+      });
+
+      const repositionButton = card.querySelector(".marker-reposition-button") as HTMLButtonElement;
+      repositionButton.addEventListener("click", (event) => {
+        event.stopPropagation();
+        if (this.repositioningMarkerId === marker.id) {
+          this.completeMarkerReposition();
+        } else {
+          this.beginMarkerReposition(marker);
+        }
+      });
+
+      const saveButton = card.querySelector(".marker-save-button") as HTMLButtonElement | null;
+      if (saveButton) {
+        saveButton.addEventListener("click", (event) => {
+          event.stopPropagation();
+          this.selectMarker(null);
+        });
+      }
+
+      this.temporaryMarkersList.appendChild(card);
     });
+
+    this.updateMarkerElementsRepositionState();
+  }
+
+  private deleteTemporaryMarker(markerId: string): void {
+    const index = this.temporaryMarkers.findIndex((entry) => entry.id === markerId);
+    if (index === -1) {
+      return;
+    }
+
+    if (this.activeIconMarkerId === markerId) {
+      this.activeIconMarkerId = null;
+      this.closeMarkerIconMenu();
+    }
+
+    if (this.repositioningMarkerId === markerId) {
+      this.completeMarkerReposition();
+    }
+
+    this.temporaryMarkers.splice(index, 1);
+
+    if (this.expandedMarkerId === markerId) {
+      this.expandedMarkerId = null;
+    }
+
+    this.renderTemporaryMarkers();
+    this.updateTemporaryMarkersPanel();
+    this.updateMarkerInstructions();
+  }
+
+  private updateOverlayMarkerLabel(markerId: string, label: string): void {
+    if (!this.markersLayer) {
+      return;
+    }
+    const markerElement = this.markersLayer.querySelector(
+      `[data-marker-id="${markerId}"]`,
+    ) as HTMLElement | null;
+    if (markerElement) {
+      markerElement.title = label;
+      markerElement.setAttribute("aria-label", label);
+    }
+  }
+
+  private updateOverlayMarkerIcon(markerId: string, type: TemporaryMarkerType): void {
+    if (!this.markersLayer) {
+      return;
+    }
+
+    const markerElement = this.markersLayer.querySelector(
+      `[data-marker-id="${markerId}"]`,
+    ) as HTMLElement | null;
+    if (!markerElement) {
+      return;
+    }
+
+    markerElement.classList.remove("temporary-marker-character", "temporary-marker-object");
+    markerElement.classList.add(`temporary-marker-${type}`);
+
+    const icon = markerElement.querySelector(".temporary-marker-icon") as HTMLElement | null;
+    if (icon) {
+      icon.innerHTML = type === "character" ? CHARACTER_MARKER_ICON : OBJECT_MARKER_ICON;
+    }
+  }
+
+  private beginMarkerReposition(marker: TemporaryMarker): void {
+    this.repositioningMarkerId = marker.id;
+    this.markerDragPointerId = null;
+    this.markerDragElement = null;
+    this.selectMarker(marker.id, { forceUpdate: true });
+
+    if (this.markerInstructionLabel) {
+      this.markerInstructionLabel.textContent = "Drag the marker to set its new location";
+      this.markerInstructionLabel.classList.add("visible");
+      this.markerInstructionLabel.setAttribute("aria-hidden", "false");
+    }
+
+    if (this.markersLayer) {
+      this.markersLayer.classList.add("is-repositioning");
+    }
+
+    this.updateMarkerElementsRepositionState();
+  }
+
+  private completeMarkerReposition(): void {
+    if (!this.repositioningMarkerId) {
+      return;
+    }
+
+    this.repositioningMarkerId = null;
+    this.markerDragPointerId = null;
+    this.markerDragElement = null;
+
+    if (this.markersLayer) {
+      this.markersLayer.classList.remove("is-repositioning");
+    }
+
+    this.updateMarkerInstructions();
+    this.updateMarkerElementsRepositionState();
+    this.updateTemporaryMarkersPanel();
+  }
+
+  private updateMarkerElementsRepositionState(): void {
+    if (!this.markersLayer) {
+      return;
+    }
+
+    this.markersLayer.classList.toggle(
+      "is-repositioning",
+      Boolean(this.repositioningMarkerId),
+    );
+
+    const elements = this.markersLayer.querySelectorAll<HTMLElement>(".temporary-marker");
+    elements.forEach((element) => {
+      const isTarget = element.dataset.markerId === this.repositioningMarkerId;
+      element.classList.toggle("is-reposition-target", isTarget);
+      if (!isTarget) {
+        element.classList.remove("is-dragging");
+      }
+    });
+  }
+
+  private handleMarkerPointerDown(event: PointerEvent, markerId: string): void {
+    if (event.button !== 0) {
+      return;
+    }
+
+    if (this.repositioningMarkerId !== markerId) {
+      return;
+    }
+
+    const markerElement = event.currentTarget as HTMLElement | null;
+    if (!markerElement) {
+      return;
+    }
+
+    event.preventDefault();
+    markerElement.setPointerCapture(event.pointerId);
+    markerElement.classList.add("is-dragging");
+    markerElement.addEventListener("pointermove", this.handleMarkerDragPointerMove);
+    markerElement.addEventListener("pointerup", this.handleMarkerDragPointerUp);
+    markerElement.addEventListener("pointercancel", this.handleMarkerDragPointerUp);
+
+    this.markerDragPointerId = event.pointerId;
+    this.markerDragElement = markerElement;
+  }
+
+  private handleMarkerDragPointerMove = (event: PointerEvent): void => {
+    if (this.markerDragPointerId !== event.pointerId) {
+      return;
+    }
+
+    event.preventDefault();
+    this.updateMarkerPositionFromPointer(event);
+  };
+
+  private handleMarkerDragPointerUp = (event: PointerEvent): void => {
+    if (this.markerDragPointerId !== event.pointerId) {
+      return;
+    }
+
+    event.preventDefault();
+    this.updateMarkerPositionFromPointer(event);
+
+    if (this.markerDragElement) {
+      this.markerDragElement.classList.remove("is-dragging");
+      this.markerDragElement.releasePointerCapture(event.pointerId);
+      this.markerDragElement.removeEventListener("pointermove", this.handleMarkerDragPointerMove);
+      this.markerDragElement.removeEventListener("pointerup", this.handleMarkerDragPointerUp);
+      this.markerDragElement.removeEventListener("pointercancel", this.handleMarkerDragPointerUp);
+    }
+
+    this.markerDragPointerId = null;
+    this.markerDragElement = null;
+    this.completeMarkerReposition();
+  };
+
+  private updateMarkerPositionFromPointer(event: PointerEvent): void {
+    const markerId = this.repositioningMarkerId;
+    if (!markerId) {
+      return;
+    }
+
+    const point = this.clientToCanvasPoint(event.clientX, event.clientY);
+    if (!point) {
+      return;
+    }
+
+    const marker = this.temporaryMarkers.find((entry) => entry.id === markerId);
+    if (!marker) {
+      return;
+    }
+
+    marker.x = clamp(point.x, 0, this.width - 1);
+    marker.y = clamp(point.y, 0, this.height - 1);
+
+    const percentX = clamp((marker.x / this.width) * 100, 0, 100);
+    const percentY = clamp((marker.y / this.height) * 100, 0, 100);
+
+    const markerElement = this.markersLayer?.querySelector(
+      `[data-marker-id="${marker.id}"]`,
+    ) as HTMLElement | null;
+    if (markerElement) {
+      markerElement.style.left = `${percentX}%`;
+      markerElement.style.top = `${percentY}%`;
+    }
   }
 
   private initializeDomReferences(): void {
@@ -1327,12 +1658,6 @@ export class DefineRoom {
     this.toolbarCancelButton = this.root.querySelector(".toolbar-cancel") as HTMLButtonElement;
     this.undoButton = this.root.querySelector(".toolbar-undo") as HTMLButtonElement;
     this.redoButton = this.root.querySelector(".toolbar-redo") as HTMLButtonElement;
-    this.tabToggleButton = this.root.querySelector(
-      ".toolbar-switch-tab",
-    ) as HTMLButtonElement;
-    this.tabToggleButtonIcon = (this.tabToggleButton?.querySelector(
-      ".toolbar-button-icon",
-    ) as HTMLElement | null) ?? null;
     this.markersToolbar = this.root.querySelector(".toolbar-temporary-markers") as HTMLElement;
     this.markersLayer = this.root.querySelector(".temporary-markers-layer") as HTMLElement;
     this.markerInstructionLabel = this.root.querySelector(
@@ -1354,7 +1679,7 @@ export class DefineRoom {
       throw new Error("DefineRoom: missing marker instruction label");
     }
     if (!this.temporaryMarkersPanel) {
-      throw new Error("DefineRoom: missing temporary markers panel");
+      throw new Error("DefineRoom: missing markers panel");
     }
     this.temporaryMarkersEmptyState = this.temporaryMarkersPanel.querySelector(
       ".temporary-markers-empty",
@@ -1363,7 +1688,13 @@ export class DefineRoom {
       ".temporary-markers-list",
     ) as HTMLElement;
     if (!this.temporaryMarkersEmptyState || !this.temporaryMarkersList) {
-      throw new Error("DefineRoom: missing temporary markers list");
+      throw new Error("DefineRoom: missing markers list");
+    }
+    this.markerIconMenu = this.temporaryMarkersPanel.querySelector(
+      ".marker-icon-menu",
+    ) as HTMLElement;
+    if (!this.markerIconMenu) {
+      throw new Error("DefineRoom: missing marker icon menu");
     }
     const sharedToolGroup = this.root.querySelector(
       ".shared-tool-group",
@@ -1385,6 +1716,11 @@ export class DefineRoom {
     this.deleteCancelButton = this.root.querySelector(".room-delete-cancel") as HTMLButtonElement;
     this.deleteConfirmButton = this.root.querySelector(".room-delete-confirm") as HTMLButtonElement;
     this.deleteDialogIcon = this.root.querySelector(".room-delete-icon") as HTMLElement;
+    this.deleteTitle = this.root.querySelector(".room-delete-title") as HTMLElement;
+    this.deleteMessage = this.root.querySelector(".room-delete-message") as HTMLElement;
+    if (!this.deleteTitle || !this.deleteMessage) {
+      throw new Error("DefineRoom: missing delete dialog content");
+    }
     this.canvasWrapper = this.root.querySelector(".canvas-wrapper") as HTMLElement;
     this.imageCanvas = this.root.querySelector(".image-layer") as HTMLCanvasElement;
     this.overlayCanvas = this.root.querySelector(".mask-layer") as HTMLCanvasElement;
@@ -1395,15 +1731,10 @@ export class DefineRoom {
     ) as HTMLButtonElement | null;
 
     this.initializeColorMenu();
+    this.initializeMarkerIconMenu();
 
     this.roomsList.addEventListener("scroll", () => this.closeColorMenu());
-
-    if (this.tabToggleButton) {
-      this.tabToggleButton.addEventListener("click", () => {
-        const nextTab = this.activeTab === "rooms" ? "temporary-markers" : "rooms";
-        this.setActiveTab(nextTab);
-      });
-    }
+    this.temporaryMarkersList.addEventListener("scroll", () => this.closeMarkerIconMenu());
 
     if (this.characterMarkersButton) {
       const characterIcon = this.characterMarkersButton.querySelector(
@@ -1456,7 +1787,7 @@ export class DefineRoom {
     }
 
     if (this.deleteConfirmButton) {
-      this.deleteConfirmButton.addEventListener("click", () => this.confirmRoomDeletion());
+      this.deleteConfirmButton.addEventListener("click", () => this.handleDeleteConfirm());
     }
 
     if (this.deleteDialogIcon) {
@@ -1603,6 +1934,31 @@ export class DefineRoom {
     this.colorMenu.appendChild(grid);
   }
 
+  private initializeMarkerIconMenu(): void {
+    if (!this.markerIconMenu) {
+      return;
+    }
+
+    this.markerIconMenu.innerHTML = "";
+    this.markerIconMenuOptions = [];
+
+    const grid = document.createElement("div");
+    grid.className = "marker-icon-grid";
+
+    (["character", "object"] as TemporaryMarkerType[]).forEach((type) => {
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = "marker-icon-option";
+      button.dataset.type = type;
+      button.innerHTML = type === "character" ? CHARACTER_MARKER_ICON : OBJECT_MARKER_ICON;
+      button.addEventListener("click", () => this.handleMarkerIconSelection(type));
+      grid.appendChild(button);
+      this.markerIconMenuOptions.push(button);
+    });
+
+    this.markerIconMenu.appendChild(grid);
+  }
+
   private openColorMenu(roomId: string, trigger: HTMLElement): void {
     if (!this.colorMenu) {
       return;
@@ -1647,6 +2003,50 @@ export class DefineRoom {
     this.colorMenu.style.left = `${left}px`;
   }
 
+  private openMarkerIconMenu(markerId: string, trigger: HTMLElement): void {
+    if (!this.markerIconMenu) {
+      return;
+    }
+
+    const marker = this.temporaryMarkers.find((entry) => entry.id === markerId);
+    if (!marker) {
+      return;
+    }
+
+    this.activeIconMarkerId = markerId;
+    this.markerIconMenuTrigger = trigger;
+    this.markerIconMenu.classList.remove("hidden");
+    this.markerIconMenu.setAttribute("aria-hidden", "false");
+
+    this.markerIconMenuOptions.forEach((button) => {
+      button.classList.toggle("selected", button.dataset.type === marker.type);
+    });
+
+    requestAnimationFrame(() => this.positionMarkerIconMenu(trigger));
+  }
+
+  private positionMarkerIconMenu(trigger: HTMLElement): void {
+    if (!this.markerIconMenu || !this.temporaryMarkersPanel) {
+      return;
+    }
+
+    const sidebarRect = this.temporaryMarkersPanel.getBoundingClientRect();
+    const triggerRect = trigger.getBoundingClientRect();
+    const menuRect = this.markerIconMenu.getBoundingClientRect();
+
+    let top = triggerRect.top - sidebarRect.top + triggerRect.height / 2 - menuRect.height / 2;
+    const maxTop = this.temporaryMarkersPanel.clientHeight - menuRect.height - 16;
+    top = Math.max(16, Math.min(top, maxTop));
+
+    let left = triggerRect.left - sidebarRect.left - menuRect.width - 12;
+    if (left < 12) {
+      left = 12;
+    }
+
+    this.markerIconMenu.style.top = `${top}px`;
+    this.markerIconMenu.style.left = `${left}px`;
+  }
+
   private closeColorMenu(): void {
     if (!this.colorMenu || this.colorMenu.classList.contains("hidden")) {
       return;
@@ -1655,6 +2055,49 @@ export class DefineRoom {
     this.colorMenu.setAttribute("aria-hidden", "true");
     this.colorMenuTrigger = null;
     this.activeColorRoomId = null;
+  }
+
+  private closeMarkerIconMenu(): void {
+    if (!this.markerIconMenu) {
+      this.markerIconMenuTrigger = null;
+      this.activeIconMarkerId = null;
+      return;
+    }
+
+    if (!this.markerIconMenu.classList.contains("hidden")) {
+      this.markerIconMenu.classList.add("hidden");
+      this.markerIconMenu.setAttribute("aria-hidden", "true");
+    }
+
+    this.markerIconMenuTrigger = null;
+    this.activeIconMarkerId = null;
+  }
+
+  private handleMarkerIconSelection(type: TemporaryMarkerType): void {
+    const markerId = this.activeIconMarkerId;
+    if (!markerId) {
+      this.closeMarkerIconMenu();
+      return;
+    }
+
+    const marker = this.temporaryMarkers.find((entry) => entry.id === markerId);
+    if (!marker) {
+      this.closeMarkerIconMenu();
+      return;
+    }
+
+    if (marker.type !== type) {
+      marker.type = type;
+      const iconButton = this.temporaryMarkersList?.querySelector(
+        `[data-marker-id="${marker.id}"] .marker-icon-button`,
+      ) as HTMLElement | null;
+      if (iconButton) {
+        iconButton.innerHTML = type === "character" ? CHARACTER_MARKER_ICON : OBJECT_MARKER_ICON;
+      }
+      this.updateOverlayMarkerIcon(marker.id, type);
+    }
+
+    this.closeMarkerIconMenu();
   }
 
   private handleColorSelection(color: string): void {
@@ -1691,9 +2134,47 @@ export class DefineRoom {
     }
 
     this.closeColorMenu();
+    this.pendingDeleteType = 'room';
     this.pendingDeleteRoomId = roomId;
+    this.pendingDeleteMarkerId = null;
+    if (this.deleteTitle) {
+      this.deleteTitle.textContent = 'Delete room?';
+    }
+    if (this.deleteMessage) {
+      const roomLabel = room.name.trim() || 'this room';
+      this.deleteMessage.textContent = `Do you really want to delete "${roomLabel}"? This process cannot be undone.`;
+    }
     this.deleteBackdrop.classList.remove("hidden");
     this.deleteBackdrop.setAttribute("aria-hidden", "false");
+
+    queueMicrotask(() => {
+      this.deleteConfirmButton?.focus?.();
+    });
+  }
+
+  private requestMarkerDeletion(markerId: string): void {
+    if (!this.deleteBackdrop) {
+      return;
+    }
+
+    const marker = this.temporaryMarkers.find((entry) => entry.id === markerId);
+    if (!marker) {
+      return;
+    }
+
+    this.closeMarkerIconMenu();
+    this.pendingDeleteType = 'marker';
+    this.pendingDeleteMarkerId = markerId;
+    this.pendingDeleteRoomId = null;
+    if (this.deleteTitle) {
+      this.deleteTitle.textContent = 'Delete marker?';
+    }
+    if (this.deleteMessage) {
+      const markerLabel = marker.name.trim() || 'this marker';
+      this.deleteMessage.textContent = `Do you really want to delete "${markerLabel}"? This process cannot be undone.`;
+    }
+    this.deleteBackdrop.classList.remove('hidden');
+    this.deleteBackdrop.setAttribute('aria-hidden', 'false');
 
     queueMicrotask(() => {
       this.deleteConfirmButton?.focus?.();
@@ -1708,6 +2189,8 @@ export class DefineRoom {
     this.deleteBackdrop.classList.add("hidden");
     this.deleteBackdrop.setAttribute("aria-hidden", "true");
     this.pendingDeleteRoomId = null;
+    this.pendingDeleteMarkerId = null;
+    this.pendingDeleteType = null;
   }
 
   private confirmRoomDeletion(): void {
@@ -1762,6 +2245,32 @@ export class DefineRoom {
     this.updateNewRoomControls();
     this.updateToolAvailability();
     this.updateHistoryControls();
+  }
+
+  private handleDeleteConfirm(): void {
+    if (this.pendingDeleteType === 'room') {
+      this.confirmRoomDeletion();
+      return;
+    }
+
+    if (this.pendingDeleteType === 'marker') {
+      this.confirmMarkerDeletion();
+      return;
+    }
+
+    this.hideDeleteDialog();
+  }
+
+  private confirmMarkerDeletion(): void {
+    if (!this.pendingDeleteMarkerId) {
+      this.hideDeleteDialog();
+      return;
+    }
+
+    const markerId = this.pendingDeleteMarkerId;
+    this.pendingDeleteMarkerId = null;
+    this.hideDeleteDialog();
+    this.deleteTemporaryMarker(markerId);
   }
 
   private attachBrushSliderEvents(): void {
@@ -1967,7 +2476,13 @@ export class DefineRoom {
     this.renderOverlay();
 
     this.temporaryMarkers = [];
+    this.expandedMarkerId = null;
+    this.repositioningMarkerId = null;
+    this.markerDragPointerId = null;
+    this.markerDragElement = null;
+    this.closeMarkerIconMenu();
     this.renderTemporaryMarkers();
+    this.updateMarkerInstructions();
     this.updateTemporaryMarkersPanel();
     this.activeMarkerType = null;
     this.setMarkerPlacementMode(false);

--- a/apps/pages/src/define-rooms/styles.css
+++ b/apps/pages/src/define-rooms/styles.css
@@ -246,116 +246,119 @@
   color: rgba(226, 232, 240, 0.6);
 }
 
-.temporary-markers-panel {
-  gap: 16px;
-}
-
-.temporary-markers-description {
-  margin: 0;
-  font-size: 0.88rem;
-  color: rgba(226, 232, 240, 0.65);
-  line-height: 1.5;
-}
-
-.temporary-markers-content {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-}
-
-.temporary-markers-empty {
-  margin: 0;
-  font-size: 0.85rem;
-  color: rgba(148, 163, 184, 0.75);
-  padding: 18px;
-  border-radius: 16px;
-  border: 1px dashed rgba(148, 163, 184, 0.28);
-  background: rgba(15, 23, 42, 0.45);
-  text-align: center;
-}
-
 .temporary-markers-list {
   list-style: none;
   margin: 0;
   padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
 }
 
-.temporary-marker-item {
-  display: grid;
-  grid-template-columns: auto auto 1fr;
-  align-items: center;
-  gap: 12px;
-  padding: 12px 14px;
-  border-radius: 14px;
-  border: 1px solid rgba(148, 163, 184, 0.28);
-  background: rgba(30, 41, 59, 0.5);
-  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.25);
+.marker-card {
+  position: relative;
 }
 
-.temporary-marker-item-character {
-  border-color: rgba(129, 140, 248, 0.45);
+.marker-card.repositioning {
+  border-color: rgba(56, 189, 248, 0.6);
+  box-shadow: 0 12px 32px rgba(56, 189, 248, 0.25);
 }
 
-.temporary-marker-item-object {
-  border-color: rgba(34, 211, 238, 0.45);
-}
-
-.temporary-marker-item-index {
-  font-size: 0.75rem;
-  font-weight: 700;
-  color: rgba(226, 232, 240, 0.65);
-  min-width: 34px;
-  text-align: center;
-}
-
-.temporary-marker-item-icon {
-  width: 36px;
-  height: 36px;
+.marker-icon-button {
+  width: 16px;
+  height: 16px;
   border-radius: 999px;
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
-  color: #0b1220;
-  box-shadow: 0 16px 34px rgba(59, 130, 246, 0.35);
-  background: linear-gradient(135deg, #38bdf8, #818cf8);
+  border: 2px solid rgba(15, 23, 42, 0.9);
+  background: rgba(15, 23, 42, 0.6);
+  color: rgba(226, 232, 240, 0.95);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  padding: 0;
 }
 
-.temporary-marker-item-character .temporary-marker-item-icon {
-  background: linear-gradient(135deg, #818cf8, #c084fc);
-  box-shadow: 0 16px 36px rgba(129, 140, 248, 0.35);
+.marker-icon-button:hover,
+.marker-icon-button:focus-visible {
+  outline: none;
+  transform: scale(1.05);
+  border-color: rgba(56, 189, 248, 0.6);
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.25);
 }
 
-.temporary-marker-item-object .temporary-marker-item-icon {
-  background: linear-gradient(135deg, #38bdf8, #34d399);
-  box-shadow: 0 16px 36px rgba(45, 212, 191, 0.35);
+.marker-icon-button svg {
+  width: 12px;
+  height: 12px;
+  display: block;
+}
+.marker-card.repositioning .room-row,
+.marker-card.repositioning .room-card-body {
+  border-color: rgba(56, 189, 248, 0.35);
 }
 
-.temporary-marker-item-icon svg {
-  width: 20px;
-  height: 20px;
+.marker-card.repositioning .marker-reposition-button {
+  background: rgba(56, 189, 248, 0.18);
+  color: rgba(226, 232, 240, 0.92);
+  box-shadow: none;
+}
+
+.marker-card.repositioning .marker-reposition-button:hover {
+  transform: none;
+  box-shadow: none;
+  opacity: 0.85;
+}
+
+.marker-icon-menu {
+  position: absolute;
+  top: 0;
+  left: 0;
+  padding: 12px;
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.95);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  box-shadow: 0 20px 45px rgba(2, 6, 23, 0.6);
+  z-index: 20;
+}
+
+.marker-icon-menu.hidden {
+  display: none;
+}
+
+.marker-icon-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 48px);
+  gap: 12px;
+}
+
+.marker-icon-option {
+  width: 48px;
+  height: 48px;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(15, 23, 42, 0.6);
+  color: rgba(226, 232, 240, 0.95);
+  cursor: pointer;
+  transition: transform 0.15s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.marker-icon-option svg {
+  width: 22px;
+  height: 22px;
   display: block;
 }
 
-.temporary-marker-item-content {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
+.marker-icon-option:hover,
+.marker-icon-option:focus-visible {
+  outline: none;
+  transform: translateY(-1px);
+  border-color: rgba(56, 189, 248, 0.8);
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.25);
 }
 
-.temporary-marker-item-label {
-  font-size: 0.85rem;
-  font-weight: 600;
-  color: rgba(226, 232, 240, 0.92);
-}
-
-.temporary-marker-item-coordinates {
-  font-size: 0.76rem;
-  letter-spacing: 0.01em;
-  color: rgba(148, 163, 184, 0.78);
+.marker-icon-option.selected {
+  border-color: rgba(56, 189, 248, 0.9);
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.25);
 }
 
 .rooms-list {
@@ -640,69 +643,8 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 14px;
   flex-shrink: 0;
-}
-
-.toolbar-switch-tab {
-  margin-left: 0;
-  width: 36px;
-  min-width: 36px;
-  justify-content: center;
-  background: rgba(22, 32, 51, 0.95);
-  border-color: rgba(96, 165, 250, 0.45);
-  box-shadow: 0 12px 32px rgba(59, 130, 246, 0.35);
-  transition: transform 0.25s ease, box-shadow 0.25s ease, background 0.25s ease,
-    border-color 0.25s ease;
-}
-
-.toolbar-switch-tab[data-target-tab="temporary-markers"] {
-  background: linear-gradient(135deg, rgba(56, 189, 248, 0.92), rgba(129, 140, 248, 0.92));
-  color: #0b1220;
-  border-color: transparent;
-}
-
-.toolbar-switch-tab[data-target-tab="rooms"] {
-  background: linear-gradient(135deg, rgba(244, 114, 182, 0.88), rgba(251, 191, 36, 0.82));
-  color: rgba(15, 23, 42, 0.92);
-  border-color: transparent;
-  box-shadow: 0 12px 32px rgba(244, 114, 182, 0.35);
-}
-
-.toolbar-switch-tab:hover:not(:disabled),
-.toolbar-switch-tab:focus-visible:not(:disabled) {
-  width: 36px;
-  transform: translateY(-1px);
-  box-shadow: 0 16px 38px rgba(56, 189, 248, 0.4);
-}
-
-.toolbar-switch-tab[data-target-tab="rooms"]:hover:not(:disabled),
-.toolbar-switch-tab[data-target-tab="rooms"]:focus-visible:not(:disabled) {
-  box-shadow: 0 16px 38px rgba(244, 114, 182, 0.42);
-}
-
-.toolbar-switch-tab:active:not(:disabled) {
-  transform: translateY(0);
-  box-shadow: 0 10px 24px rgba(56, 189, 248, 0.28);
-}
-
-.toolbar-switch-tab .toolbar-button-icon {
-  opacity: 1;
-  width: 18px;
-  height: 18px;
-  transform: none;
-}
-
-.toolbar-switch-tab .toolbar-button-icon svg {
-  width: 18px;
-  height: 18px;
-}
-
-.toolbar-switch-tab:hover:not(:disabled) .toolbar-button-icon,
-.toolbar-switch-tab:focus-visible:not(:disabled) .toolbar-button-icon {
-  opacity: 1;
-  width: 18px;
-  transform: none;
+  gap: 14px;
 }
 
 .toolbar {
@@ -1095,6 +1037,10 @@
   z-index: 2;
 }
 
+.temporary-markers-layer.is-repositioning {
+  pointer-events: auto;
+}
+
 .temporary-marker {
   position: absolute;
   width: 32px;
@@ -1107,6 +1053,19 @@
   color: #0b1220;
   box-shadow: 0 18px 40px rgba(15, 23, 42, 0.5);
   pointer-events: none;
+}
+
+.temporary-markers-layer.is-repositioning .temporary-marker {
+  pointer-events: auto;
+  cursor: grab;
+}
+
+.temporary-marker.is-dragging {
+  cursor: grabbing;
+}
+
+.temporary-marker.is-reposition-target {
+  box-shadow: 0 22px 46px rgba(56, 189, 248, 0.45);
 }
 
 .temporary-marker-character {


### PR DESCRIPTION
## Summary
- mirror the room sidebar interactions for markers by focusing new entries, sharing the select logic, and collapsing cards via the save action
- extend the existing delete confirmation dialog to markers with dynamic messaging, type tracking, and shared confirm handling

## Testing
- npm run build *(fails: repository has no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_69038f946a548323932c844c2ef4400a