### PR TITLE
Deactivate marker placement after a marker drop

### DIFF
--- a/apps/pages/src/define-rooms/DefineRoom.tsx
+++ b/apps/pages/src/define-rooms/DefineRoom.tsx
@@ -1245,6 +1245,7 @@ export class DefineRoom {
     this.markerDragElement = null;
     this.renderTemporaryMarkers();
     this.selectMarker(marker.id, { focusName: true });
+    this.endMarkerPlacement();
   }
 
   private renderTemporaryMarkers(): void {
@@ -1587,6 +1588,8 @@ export class DefineRoom {
 
     this.markerDragPointerId = event.pointerId;
     this.markerDragElement = markerElement;
+
+    this.updateMarkerPositionFromPointer(event);
   }
 
   private handleMarkerDragPointerMove = (event: PointerEvent): void => {


### PR DESCRIPTION
## Summary
- end marker placement mode after a marker is dropped so the Add Markers tools deactivate automatically
- snap repositioned markers to the grab location immediately so the marker icon stays centered on its position

## Testing
- npm test -- --runTestsByPath src/components/Toolbar.test.tsx *(fails: vitest does not accept the flag)*
- npm test -- src/components/Toolbar.test.tsx *(fails: missing jsdom dependency)*

------
https://chatgpt.com/codex/tasks/task_e_6904b9c3f1d083238b14fcb070f9133a