### PR TITLE
Deactivate marker placement after single placement

### DIFF
--- a/apps/pages/src/define-rooms/DefineRoom.tsx
+++ b/apps/pages/src/define-rooms/DefineRoom.tsx
@@ -1245,6 +1245,10 @@ export class DefineRoom {
     this.markerDragElement = null;
     this.renderTemporaryMarkers();
     this.selectMarker(marker.id, { focusName: true });
+
+    if (this.interactionMode === "marker-placement") {
+      this.endMarkerPlacement();
+    }
   }
 
   private renderTemporaryMarkers(): void {
@@ -1587,6 +1591,8 @@ export class DefineRoom {
 
     this.markerDragPointerId = event.pointerId;
     this.markerDragElement = markerElement;
+
+    this.updateMarkerPositionFromPointer(event);
   }
 
   private handleMarkerDragPointerMove = (event: PointerEvent): void => {


### PR DESCRIPTION
## Summary
- exit marker placement mode after dropping a marker so the add-marker buttons must be pressed again
- snap the marker icon to the pointer when grabbing it so the marker position lines up with the icon centre

## Testing
- npm --prefix apps/pages test -- --run *(fails: missing jsdom dependency)*

------
https://chatgpt.com/codex/tasks/task_e_6904b9c3f1d083238b14fcb070f9133a