### PR TITLE
Update investigation marker icon and sizing

### DIFF
--- a/apps/pages/src/define-rooms/styles.css
+++ b/apps/pages/src/define-rooms/styles.css
@@ -1075,27 +1075,27 @@
 }
 
 .temporary-marker-character {
-  background: linear-gradient(135deg, rgba(250, 204, 21, 0.92), rgba(253, 224, 71, 0.9));
+  background-color: rgba(250, 204, 21, 0.5);
 }
 
 .temporary-marker-monster {
-  background: linear-gradient(135deg, rgba(249, 115, 22, 0.92), rgba(251, 146, 60, 0.9));
+  background-color: rgba(249, 115, 22, 0.5);
 }
 
 .temporary-marker-object {
-  background: linear-gradient(135deg, rgba(56, 189, 248, 0.92), rgba(125, 211, 252, 0.9));
+  background-color: rgba(56, 189, 248, 0.5);
 }
 
 .temporary-marker-trap {
-  background: linear-gradient(135deg, rgba(248, 113, 113, 0.92), rgba(252, 165, 165, 0.9));
+  background-color: rgba(248, 113, 113, 0.5);
 }
 
 .temporary-marker-investigation {
-  background: linear-gradient(135deg, rgba(168, 85, 247, 0.92), rgba(196, 181, 253, 0.9));
+  background-color: rgba(168, 85, 247, 0.5);
 }
 
 .temporary-marker-area {
-  background: linear-gradient(135deg, rgba(34, 197, 94, 0.92), rgba(74, 222, 128, 0.9));
+  background-color: rgba(34, 197, 94, 0.5);
 }
 
 .temporary-marker-icon {
@@ -1105,8 +1105,8 @@
 }
 
 .temporary-marker-icon svg {
-  width: 18px;
-  height: 18px;
+  width: 24px;
+  height: 24px;
   display: block;
   fill: currentColor;
 }


### PR DESCRIPTION
## Summary
- update temporary marker styles to use solid fills instead of gradients
- ensure each marker background color renders at 50% opacity across types
- swap the investigation marker icon for a question mark and enlarge marker icon rendering within markers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690521b0ad588323bdd01d6cc719f627