### PR TITLE
Auto-tag markers with containing rooms

### DIFF
--- a/apps/pages/src/define-rooms/styles.css
+++ b/apps/pages/src/define-rooms/styles.css
@@ -290,6 +290,29 @@
   display: block;
   fill: currentColor;
 }
+.marker-room-association {
+  gap: 4px;
+}
+
+.marker-room-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(56, 189, 248, 0.2);
+  color: rgba(226, 232, 240, 0.92);
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 600;
+  align-self: flex-start;
+}
+
+.marker-room-chip.is-unassigned {
+  background: rgba(148, 163, 184, 0.18);
+  color: rgba(148, 163, 184, 0.75);
+}
 .marker-card.repositioning .room-row,
 .marker-card.repositioning .room-card-body {
   border-color: rgba(56, 189, 248, 0.35);


### PR DESCRIPTION
## Summary
- automatically associate embedded wizard markers with the room underneath them and keep the association up to date when rooms change or markers move
- surface the detected room in each marker card and add styling for the room badge in the sidebar

## Testing
- npm run test -- --run *(fails: requires optional `jsdom` dependency)*

------
https://chatgpt.com/codex/tasks/task_e_690534c1d73083238551828895941430