### PR TITLE
Sync map markers from DefineRoom editor

### DIFF
--- a/apps/pages/src/define-rooms/DefineRoom.tsx
+++ b/apps/pages/src/define-rooms/DefineRoom.tsx
@@ -57,6 +57,20 @@ type TemporaryMarker = {
   linkedRoomId: string | null;
 };
 
+export type DefineRoomMarkerType = TemporaryMarkerType;
+
+export interface DefineRoomMarker {
+  id: string;
+  type: DefineRoomMarkerType;
+  name: string;
+  description: string;
+  tags: string;
+  visibleAtStart: boolean;
+  x: number;
+  y: number;
+  linkedRoomId: string | null;
+}
+
 type MarkerDisplayMetrics = {
   offsetX: number;
   offsetY: number;
@@ -1100,6 +1114,20 @@ export class DefineRoom {
       ...room,
       mask: room.mask.slice(),
       colorVector: [...room.colorVector] as [number, number, number],
+    }));
+  }
+
+  public getMarkers(): DefineRoomMarker[] {
+    return this.temporaryMarkers.map((marker) => ({
+      id: marker.id,
+      type: marker.type,
+      name: marker.name,
+      description: marker.description,
+      tags: marker.tags,
+      visibleAtStart: marker.visibleAtStart,
+      x: marker.x,
+      y: marker.y,
+      linkedRoomId: marker.linkedRoomId,
     }));
   }
 


### PR DESCRIPTION
## Summary
- export DefineRoom markers and expose a getter for embedded editor marker data
- normalise DefineRoom markers inside the map creation wizard and keep local draft state in sync
- submit markers captured in DefineRoom when creating maps, preserving geometry handling and region lookups

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690a4f3f71888323a769e6678d4c3e6c