### PR TITLE
Render colored regions in DM session viewer

### DIFF
--- a/apps/pages/src/types.ts
+++ b/apps/pages/src/types.ts
@@ -46,6 +46,7 @@ export interface Region {
   maskManifest?: RoomMaskManifestEntry | null;
   notes?: string | null;
   revealOrder?: number | null;
+  color?: string | null;
 }
 
 export type MarkerPoint = { x: number; y: number };


### PR DESCRIPTION
## Summary
- add optional color support when normalizing and serializing map regions
- render DM session regions with the same color palette used in the map creation wizard, including readable labels

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_690a53b80a08832391ad28939cf154fe