### PR TITLE
Add structured metadata fields to regions

### DIFF
--- a/apps/pages/src/api/client.ts
+++ b/apps/pages/src/api/client.ts
@@ -52,6 +52,9 @@ interface RegionPayload {
   name: string;
   mask: RoomMask;
   maskManifest?: RoomMaskManifestEntry | null;
+  description?: string | null;
+  tags?: string | null;
+  visibleAtStart?: boolean;
   notes?: string;
   revealOrder?: number;
   color?: string | null;
@@ -336,6 +339,28 @@ const ensureManifest = (
 ): RoomMaskManifestEntry =>
   manifest ?? { roomId, key: `room-masks/${roomId}.png`, dataUrl: encodeRoomMaskToDataUrl(mask) };
 
+const parseBooleanLike = (value: unknown): boolean | undefined => {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  if (typeof value === 'number') {
+    return value > 0;
+  }
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (!normalized) {
+      return undefined;
+    }
+    if (['true', '1', 'yes'].includes(normalized)) {
+      return true;
+    }
+    if (['false', '0', 'no'].includes(normalized)) {
+      return false;
+    }
+  }
+  return undefined;
+};
+
 const normalizeRegion = (raw: any): Region => {
   const polygon = polygonPointsFromRaw(raw?.polygon);
   let mask: RoomMask | null = null;
@@ -373,6 +398,19 @@ const normalizeRegion = (raw: any): Region => {
     name: typeof raw?.name === 'string' ? raw.name : 'Room',
     mask,
     maskManifest: manifest,
+    description:
+      typeof raw?.description === 'string'
+        ? raw.description
+        : raw?.description === null
+          ? null
+          : undefined,
+    tags:
+      typeof raw?.tags === 'string'
+        ? raw.tags
+        : raw?.tags === null
+          ? null
+          : undefined,
+    visibleAtStart: parseBooleanLike(raw?.visibleAtStart),
     notes: typeof raw?.notes === 'string' ? raw.notes : raw?.notes ?? null,
     revealOrder: raw?.revealOrder ?? null,
     color:
@@ -391,6 +429,15 @@ const serializeRegionPayload = (payload: Partial<RegionPayload>) => {
   }
   if (payload.notes !== undefined) {
     body.notes = payload.notes;
+  }
+  if (payload.description !== undefined) {
+    body.description = payload.description;
+  }
+  if (payload.tags !== undefined) {
+    body.tags = payload.tags;
+  }
+  if (payload.visibleAtStart !== undefined) {
+    body.visibleAtStart = payload.visibleAtStart;
   }
   if (payload.color !== undefined) {
     if (payload.color === null) {

--- a/apps/pages/src/components/MapCreationWizard.tsx
+++ b/apps/pages/src/components/MapCreationWizard.tsx
@@ -1702,6 +1702,9 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
         const region = await apiClient.createRegion(map.id, {
           name: room.name.trim() || `Room ${index + 1}`,
           mask: room.mask,
+          description: trimmedDescription || undefined,
+          tags: trimmedTags || undefined,
+          visibleAtStart: room.visibleAtStart,
           notes: notesValue,
           revealOrder: room.visibleAtStart ? index : undefined,
           color: colorValue ? colorValue.toLowerCase() : undefined,

--- a/apps/pages/src/types.ts
+++ b/apps/pages/src/types.ts
@@ -44,6 +44,9 @@ export interface Region {
   name: string;
   mask: RoomMask;
   maskManifest?: RoomMaskManifestEntry | null;
+  description?: string | null;
+  tags?: string | null;
+  visibleAtStart?: boolean;
   notes?: string | null;
   revealOrder?: number | null;
   color?: string | null;

--- a/schema/d1.sql
+++ b/schema/d1.sql
@@ -40,6 +40,9 @@ CREATE TABLE IF NOT EXISTS regions (
     reveal_order INTEGER DEFAULT 0,
     mask_manifest TEXT,
     color TEXT,
+    description TEXT,
+    tags TEXT,
+    visible_at_start INTEGER NOT NULL DEFAULT 0,
     created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
 );
 

--- a/schema/migrations/005_add_region_metadata.sql
+++ b/schema/migrations/005_add_region_metadata.sql
@@ -1,0 +1,3 @@
+ALTER TABLE regions ADD COLUMN description TEXT;
+ALTER TABLE regions ADD COLUMN tags TEXT;
+ALTER TABLE regions ADD COLUMN visible_at_start INTEGER NOT NULL DEFAULT 0;


### PR DESCRIPTION
## Summary
- add description, tags, and visibleAtStart fields to region payloads and the map creation wizard
- update the API worker and database schema to store the new region metadata
- include the structured region metadata in region responses alongside legacy notes

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_690b6664d0f48323a29b8afcbe37fc55