### PR TITLE
Add mask URL support and render PNG region overlays

### DIFF
--- a/apps/pages/src/components/MapMaskCanvas.tsx
+++ b/apps/pages/src/components/MapMaskCanvas.tsx
@@ -112,7 +112,10 @@ const MapMaskCanvas: React.FC<MapMaskCanvasProps> = ({
     () =>
       regions.map((region) => ({
         region,
-        polygon: roomMaskToPolygon(region.mask),
+        polygon:
+          region.polygon && region.polygon.length >= 3
+            ? region.polygon
+            : roomMaskToPolygon(region.mask),
       })),
     [regions]
   );

--- a/apps/pages/src/types.ts
+++ b/apps/pages/src/types.ts
@@ -1,3 +1,4 @@
+import type { Bounds, Point } from './types/geometry';
 import type { RoomMask } from './utils/roomMask';
 
 export interface User {
@@ -35,13 +36,18 @@ export interface MapRecord {
 export interface RoomMaskManifestEntry {
   roomId: string;
   key: string;
-  dataUrl: string;
+  url?: string | null;
+  dataUrl?: string;
+  width?: number;
+  height?: number;
+  bounds?: Bounds;
 }
 
 export interface Region {
   id: string;
   mapId: string;
   name: string;
+  polygon: Point[];
   mask: RoomMask;
   maskManifest?: RoomMaskManifestEntry | null;
   description?: string | null;


### PR DESCRIPTION
## Summary
- generate signed GET URLs for region masks in the maps regions API and keep them in mask manifests
- preserve provided mask URLs on the pages client, only rasterizing polygons when a PNG is unavailable
- update the DM session viewer to layer tinted PNG mask overlays (with polygon fallback) and ensure canvas tools consume stored polygons

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_690bb535bb8c8323aab5b37bf9323862