### PR TITLE
Remove polygon usage for region masks

### DIFF
--- a/apps/pages/src/api/client.ts
+++ b/apps/pages/src/api/client.ts
@@ -14,11 +14,9 @@ import type {
   User,
 } from '../types';
 import {
-  createRoomMaskFromPolygon,
   decodeRoomMaskFromDataUrl,
   encodeRoomMaskToDataUrl,
   emptyRoomMask,
-  roomMaskToVector,
   type RoomMask,
 } from '../utils/roomMask';
 
@@ -406,7 +404,6 @@ const parseBooleanLike = (value: unknown): boolean | undefined => {
 };
 
 const normalizeRegion = (raw: any): Region => {
-  const polygon = polygonPointsFromRaw(raw?.polygon);
   let mask: RoomMask | null = null;
   const rawMask = raw?.mask;
   if (rawMask && typeof rawMask === 'object') {
@@ -428,9 +425,6 @@ const normalizeRegion = (raw: any): Region => {
         mask = null;
       }
     }
-  }
-  if (!mask && polygon.length) {
-    mask = createRoomMaskFromPolygon(polygon, { resolution: 256 });
   }
   if (!mask) {
     mask = emptyRoomMask();
@@ -501,7 +495,6 @@ const serializeRegionPayload = (payload: Partial<RegionPayload>) => {
       height: payload.mask.height,
       bounds: payload.mask.bounds,
     };
-    body.polygon = roomMaskToVector(payload.mask);
   }
   if (payload.maskManifest !== undefined) {
     body.maskManifest = payload.maskManifest;

--- a/apps/pages/src/components/MapCreationWizard.tsx
+++ b/apps/pages/src/components/MapCreationWizard.tsx
@@ -16,7 +16,7 @@ import {
   computeDisplayMetrics,
   type ImageDisplayMetrics,
 } from '../utils/imageProcessing';
-import { roomMaskToPolygon, type RoomMask } from '../utils/roomMask';
+import { roomMaskContainsPoint, type RoomMask } from '../utils/roomMask';
 import type { Campaign, MapRecord, Marker, Region } from '../types';
 import {
   getMapMarkerIconDefinition,
@@ -558,18 +558,14 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
     setDefineRoomContainer(node);
   }, []);
 
-  const roomPolygonById = useMemo(() => {
-    const polygons = new Map<string, Array<{ x: number; y: number }>>();
+  const roomMaskById = useMemo(() => {
+    const masks = new Map<string, RoomMask>();
     for (const room of definedRooms) {
-      if (!room.mask) {
-        continue;
-      }
-      const polygon = roomMaskToPolygon(room.mask);
-      if (polygon.length >= 3) {
-        polygons.set(room.id, polygon);
+      if (room.mask) {
+        masks.set(room.id, room.mask);
       }
     }
-    return polygons;
+    return masks;
   }, [definedRooms]);
 
   const findContainingRoomId = useCallback(
@@ -577,14 +573,14 @@ const MapCreationWizard: React.FC<MapCreationWizardProps> = ({
       if (!point) {
         return null;
       }
-      for (const [roomId, polygon] of roomPolygonById) {
-        if (isPointInPolygon(point, polygon)) {
+      for (const [roomId, mask] of roomMaskById) {
+        if (roomMaskContainsPoint(mask, point)) {
           return roomId;
         }
       }
       return null;
     },
-    [roomPolygonById],
+    [roomMaskById],
   );
 
   const applyAutoAssociation = useCallback(

--- a/schema/d1.sql
+++ b/schema/d1.sql
@@ -35,7 +35,6 @@ CREATE TABLE IF NOT EXISTS regions (
     id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
     map_id TEXT NOT NULL REFERENCES maps(id) ON DELETE CASCADE,
     name TEXT NOT NULL,
-    polygon TEXT NOT NULL,
     notes TEXT,
     reveal_order INTEGER DEFAULT 0,
     mask_manifest TEXT,

--- a/seed-data.json
+++ b/seed-data.json
@@ -27,12 +27,6 @@
     {
       "mapName": "Warren Overview",
       "name": "Entrance Tunnel",
-      "polygon": [
-        {"x": 0.12, "y": 0.18},
-        {"x": 0.18, "y": 0.17},
-        {"x": 0.21, "y": 0.26},
-        {"x": 0.15, "y": 0.28}
-      ],
       "notes": "Crumbling stone stairs lead into the earth.",
       "revealOrder": 1,
       "color": "#facc15"
@@ -40,13 +34,6 @@
     {
       "mapName": "Warren Overview",
       "name": "Goblin Market",
-      "polygon": [
-        {"x": 0.42, "y": 0.45},
-        {"x": 0.51, "y": 0.44},
-        {"x": 0.56, "y": 0.52},
-        {"x": 0.48, "y": 0.56},
-        {"x": 0.41, "y": 0.52}
-      ],
       "notes": "Bartering goblins trade junk and trinkets.",
       "revealOrder": 2,
       "color": "#fb7185"
@@ -54,13 +41,6 @@
     {
       "mapName": "Warren Overview",
       "name": "Boss Lair",
-      "polygon": [
-        {"x": 0.72, "y": 0.22},
-        {"x": 0.8, "y": 0.22},
-        {"x": 0.83, "y": 0.28},
-        {"x": 0.79, "y": 0.34},
-        {"x": 0.71, "y": 0.32}
-      ],
       "notes": "The goblin boss plans his raids here.",
       "revealOrder": 3,
       "color": "#38bdf8"


### PR DESCRIPTION
## Summary
- remove the region polygon column from the schema and API handlers so regions are stored strictly with raster mask metadata
- update the client utilities and front-end components to draw and interact with region masks directly from their PNG data instead of converting to polygons
- add helper functions for mask hit-testing and centroids while dropping polygon data from the seed fixtures

## Testing
- pnpm --filter apps/pages lint *(fails: No projects matched the filters in /workspace/dand)*

------
https://chatgpt.com/codex/tasks/task_e_690bbbef222c8323a721cc811806f070