### PR TITLE
Add player session view component

### DIFF
--- a/apps/pages/src/App.tsx
+++ b/apps/pages/src/App.tsx
@@ -594,8 +594,8 @@ const App: React.FC = () => {
         <div aria-hidden className="pointer-events-none absolute -top-32 right-12 h-72 w-72 rounded-full bg-amber-300/25 blur-3xl dark:bg-amber-500/20 animate-float-slow" />
         <div aria-hidden className="pointer-events-none absolute bottom-[-10rem] left-[-6rem] h-96 w-96 rounded-full bg-orange-300/20 blur-[120px] dark:bg-orange-500/20 animate-float-slow" />
         <div className="relative isolate min-h-screen">
-          <div className="flex min-h-full flex-col gap-6">
-            <div className="flex min-h-0 w-full flex-1 overflow-hidden rounded-3xl border border-white/60 bg-white/75 p-3 shadow-2xl shadow-amber-500/10 backdrop-blur-xl dark:border-slate-800/70 dark:bg-slate-950/70 dark:shadow-black/40">
+          <div className="flex min-h-full min-w-0 flex-1 flex-col gap-6 overflow-hidden">
+            <div className="flex min-h-0 min-w-0 w-full flex-1 overflow-hidden rounded-3xl border border-white/60 bg-white/75 p-3 shadow-2xl shadow-amber-500/10 backdrop-blur-xl dark:border-slate-800/70 dark:bg-slate-950/70 dark:shadow-black/40">
               <PlayerSessionView
                 session={activeSession}
                 campaignName={activeSessionCampaignName}
@@ -621,8 +621,8 @@ const App: React.FC = () => {
         <div aria-hidden className="pointer-events-none absolute -top-32 right-12 h-72 w-72 rounded-full bg-amber-300/25 blur-3xl dark:bg-amber-500/20 animate-float-slow" />
         <div aria-hidden className="pointer-events-none absolute bottom-[-10rem] left-[-6rem] h-96 w-96 rounded-full bg-orange-300/20 blur-[120px] dark:bg-orange-500/20 animate-float-slow" />
         <div className="relative isolate min-h-screen">
-          <div className="flex min-h-full flex-col gap-6">
-            <div className="flex min-h-0 w-full flex-1 rounded-3xl border border-white/60 bg-white/75 p-3 shadow-2xl shadow-amber-500/10 backdrop-blur-xl dark:border-slate-800/70 dark:bg-slate-950/70 dark:shadow-black/40">
+          <div className="flex min-h-full min-w-0 flex-1 flex-col gap-6">
+            <div className="flex min-h-0 min-w-0 w-full flex-1 rounded-3xl border border-white/60 bg-white/75 p-3 shadow-2xl shadow-amber-500/10 backdrop-blur-xl dark:border-slate-800/70 dark:bg-slate-950/70 dark:shadow-black/40">
               <DMSessionViewer
                 session={activeSession}
                 mapImageUrl={selectedMap ? apiClient.buildMapDisplayUrl(selectedMap.id) : undefined}

--- a/apps/pages/src/components/PlayerSessionView.tsx
+++ b/apps/pages/src/components/PlayerSessionView.tsx
@@ -39,8 +39,8 @@ const PlayerSessionView: React.FC<PlayerSessionViewProps> = ({
   const resolvedMapName = mapName ?? session.mapName ?? map?.name ?? 'Unknown Map';
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border border-white/50 bg-white/60 shadow-xl shadow-amber-500/10 backdrop-blur-xl dark:border-slate-800/70 dark:bg-slate-950/70 dark:shadow-black/40">
-      <header className="flex flex-wrap items-center justify-between gap-4 border-b border-white/40 bg-white/50 px-5 py-3 text-[11px] uppercase tracking-[0.35em] text-slate-600 dark:border-slate-800 dark:bg-slate-900/60 dark:text-slate-300">
+    <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-2xl border border-white/50 bg-white/60 shadow-xl shadow-amber-500/10 backdrop-blur-xl dark:border-slate-800/70 dark:bg-slate-950/70 dark:shadow-black/40">
+      <header className="flex flex-wrap items-center justify-between gap-4 overflow-hidden border-b border-white/40 bg-white/50 px-5 py-3 text-[11px] uppercase tracking-[0.35em] text-slate-600 dark:border-slate-800 dark:bg-slate-900/60 dark:text-slate-300">
         <div className="flex flex-wrap items-center gap-6">
           <div className="flex flex-col">
             <span className="text-[10px] font-semibold uppercase tracking-[0.45em] text-slate-500 dark:text-slate-400">
@@ -77,8 +77,8 @@ const PlayerSessionView: React.FC<PlayerSessionViewProps> = ({
           </button>
         )}
       </header>
-      <div className="relative flex min-h-0 flex-1 overflow-hidden bg-slate-950/70 p-3 sm:p-4">
-        <div className="flex min-h-0 flex-1 overflow-hidden rounded-xl border border-white/20 bg-slate-900/80 shadow-inner shadow-black/30 dark:border-slate-800/70">
+      <div className="relative flex min-h-0 min-w-0 flex-1 overflow-hidden bg-slate-950/70 p-3 sm:p-4">
+        <div className="flex min-h-0 min-w-0 flex-1 overflow-hidden rounded-xl border border-white/20 bg-slate-900/80 shadow-inner shadow-black/30 dark:border-slate-800/70">
           <PlayerView
             mapImageUrl={mapImageUrl ?? undefined}
             width={mapWidth ?? map?.width ?? undefined}

--- a/apps/pages/src/components/PlayerView.tsx
+++ b/apps/pages/src/components/PlayerView.tsx
@@ -52,7 +52,7 @@ const PlayerView: React.FC<PlayerViewProps> = ({ mapImageUrl, width, height, reg
   }, [regions, revealedRegionIds, viewHeight, viewWidth]);
 
   return (
-    <svg viewBox={`0 0 ${viewWidth} ${viewHeight}`} className="h-full w-full">
+    <svg viewBox={`0 0 ${viewWidth} ${viewHeight}`} className="block h-full w-full">
       <defs>
         <filter
           id={maskFilterId}


### PR DESCRIPTION
## Summary
- introduce a PlayerSessionView wrapper that renders the existing PlayerView with session context and leave controls
- wire the new component into the player session experience and derive campaign/map labels for the header

## Testing
- npm run test -- --run *(fails: missing jsdom dependency prompt)*

------
https://chatgpt.com/codex/tasks/task_e_690c16b4f4148323a8d66fb1242307b9