### PR TITLE
Adjust player view sizing containment

### DIFF
--- a/apps/pages/src/components/PlayerSessionView.tsx
+++ b/apps/pages/src/components/PlayerSessionView.tsx
@@ -79,13 +79,15 @@ const PlayerSessionView: React.FC<PlayerSessionViewProps> = ({
       </header>
       <div className="relative flex min-h-0 min-w-0 flex-1 overflow-hidden bg-slate-950/70 p-3 sm:p-4">
         <div className="flex min-h-0 min-w-0 flex-1 overflow-hidden rounded-xl border border-white/20 bg-slate-900/80 shadow-inner shadow-black/30 dark:border-slate-800/70">
-          <PlayerView
-            mapImageUrl={mapImageUrl ?? undefined}
-            width={mapWidth ?? map?.width ?? undefined}
-            height={mapHeight ?? map?.height ?? undefined}
-            regions={regions}
-            revealedRegionIds={playerRevealedRegionIds}
-          />
+          <div className="flex max-h-full max-w-full flex-1 overflow-hidden object-contain">
+            <PlayerView
+              mapImageUrl={mapImageUrl ?? undefined}
+              width={mapWidth ?? map?.width ?? undefined}
+              height={mapHeight ?? map?.height ?? undefined}
+              regions={regions}
+              revealedRegionIds={playerRevealedRegionIds}
+            />
+          </div>
         </div>
       </div>
     </div>

--- a/apps/pages/src/components/PlayerView.tsx
+++ b/apps/pages/src/components/PlayerView.tsx
@@ -52,7 +52,10 @@ const PlayerView: React.FC<PlayerViewProps> = ({ mapImageUrl, width, height, reg
   }, [regions, revealedRegionIds, viewHeight, viewWidth]);
 
   return (
-    <svg viewBox={`0 0 ${viewWidth} ${viewHeight}`} className="block h-full w-full">
+    <svg
+      viewBox={`0 0 ${viewWidth} ${viewHeight}`}
+      className="block h-full w-auto max-h-full max-w-full object-contain"
+    >
       <defs>
         <filter
           id={maskFilterId}


### PR DESCRIPTION
## Summary
- wrap the player view in a max-size flex container so it respects the viewport bounds
- tune the player SVG classes to maintain aspect ratio within the constrained wrapper

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_690cb250b930832392fef96af65523ff