### PR TITLE
Animate fog reveal after assets load in PlayerView

### DIFF
--- a/apps/pages/src/components/PlayerView.tsx
+++ b/apps/pages/src/components/PlayerView.tsx
@@ -192,7 +192,7 @@ const PlayerView: React.FC<PlayerViewProps> = ({ mapImageUrl, width, height, reg
           {revealedMasks.map((mask) => {
             const isAnimating = animatingMaskIdSet.has(mask.id);
             const isComplete = completedMaskIdSet.has(mask.id);
-            const maskOpacity = isComplete ? 1 : isAnimating ? 1 - revealOpacity : 0;
+            const maskOpacity = isComplete ? 0 : isAnimating ? revealOpacity : 1;
 
             return (
               <image
@@ -206,6 +206,9 @@ const PlayerView: React.FC<PlayerViewProps> = ({ mapImageUrl, width, height, reg
                 filter={`url(#${maskFilterId})`}
                 opacity={maskOpacity}
                 onLoad={() => {
+                  setLoadedMaskIds((prev) => (prev.includes(mask.id) ? prev : [...prev, mask.id]));
+                }}
+                onError={() => {
                   setLoadedMaskIds((prev) => (prev.includes(mask.id) ? prev : [...prev, mask.id]));
                 }}
               />


### PR DESCRIPTION
## Summary
- track fog texture and region mask load events before revealing the map
- animate a reveal opacity state to fade masks once all assets are ready
- queue additional reveals so later rooms also fade in smoothly

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690cce8050388323b8ae321e29b2a438