### PR TITLE
Fix fog mask blending for multiple visible rooms

### DIFF
--- a/apps/pages/src/components/PlayerView.tsx
+++ b/apps/pages/src/components/PlayerView.tsx
@@ -67,14 +67,14 @@ const PlayerView: React.FC<PlayerViewProps> = ({ mapImageUrl, width, height, reg
             <feFuncR type="table" tableValues="1 0" />
             <feFuncG type="table" tableValues="1 0" />
             <feFuncB type="table" tableValues="1 0" />
-            <feFuncA type="table" tableValues="1 1" />
+            <feFuncA type="table" tableValues="0 1" />
           </feComponentTransfer>
           <feGaussianBlur in="inverted" stdDeviation={featherRadius} result="feathered" />
           <feComponentTransfer in="feathered">
             <feFuncR type="identity" />
             <feFuncG type="identity" />
             <feFuncB type="identity" />
-            <feFuncA type="table" tableValues="1 1" />
+            <feFuncA type="identity" />
           </feComponentTransfer>
         </filter>
         <mask id={fogMaskId} maskUnits="userSpaceOnUse" maskContentUnits="userSpaceOnUse" maskType="luminance">


### PR DESCRIPTION
## Summary
- ensure the fog mask filter only punches out areas covered by visible room masks instead of repainting the mask background
- allow multiple initially visible rooms to simultaneously cut through the fog in the Player View

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_690ceb0e1c708323973bde7d74fb9527