### PR TITLE
Fix fog mask to reveal all initially visible rooms

### DIFF
--- a/apps/pages/src/components/PlayerView.tsx
+++ b/apps/pages/src/components/PlayerView.tsx
@@ -70,12 +70,11 @@ const PlayerView: React.FC<PlayerViewProps> = ({ mapImageUrl, width, height, reg
             <feFuncA type="table" tableValues="1 1" />
           </feComponentTransfer>
           <feGaussianBlur in="inverted" stdDeviation={featherRadius} result="feathered" />
-          <feComponentTransfer in="feathered">
-            <feFuncR type="identity" />
-            <feFuncG type="identity" />
-            <feFuncB type="identity" />
-            <feFuncA type="table" tableValues="1 1" />
-          </feComponentTransfer>
+          <feColorMatrix
+            in="feathered"
+            type="matrix"
+            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 -1 0 0 0 1"
+          />
         </filter>
         <mask id={fogMaskId} maskUnits="userSpaceOnUse" maskContentUnits="userSpaceOnUse" maskType="luminance">
           <rect x={0} y={0} width={viewWidth} height={viewHeight} fill="white" />


### PR DESCRIPTION
## Summary
- adjust the fog mask filter to preserve transparency outside each room mask
- ensure multiple visible regions can cut through the fog simultaneously

## Testing
- npm test -- --runInBand *(fails: vitest CLI does not support --runInBand option)*
- npm test *(fails: missing optional dependency jsdom)*

------
https://chatgpt.com/codex/tasks/task_e_690ceb0e1c708323973bde7d74fb9527