### PR TITLE
Fix player fog mask to reveal all starting rooms

### DIFF
--- a/apps/pages/src/components/PlayerView.tsx
+++ b/apps/pages/src/components/PlayerView.tsx
@@ -63,19 +63,13 @@ const PlayerView: React.FC<PlayerViewProps> = ({ mapImageUrl, width, height, reg
           filterUnits="userSpaceOnUse"
           colorInterpolationFilters="sRGB"
         >
-          <feComponentTransfer result="inverted">
-            <feFuncR type="table" tableValues="1 0" />
-            <feFuncG type="table" tableValues="1 0" />
-            <feFuncB type="table" tableValues="1 0" />
-            <feFuncA type="table" tableValues="1 1" />
+          <feComponentTransfer result="opaqueRegion">
+            <feFuncR type="table" tableValues="0 0" />
+            <feFuncG type="table" tableValues="0 0" />
+            <feFuncB type="table" tableValues="0 0" />
+            <feFuncA type="table" tableValues="0 1" />
           </feComponentTransfer>
-          <feGaussianBlur in="inverted" stdDeviation={featherRadius} result="feathered" />
-          <feComponentTransfer in="feathered">
-            <feFuncR type="identity" />
-            <feFuncG type="identity" />
-            <feFuncB type="identity" />
-            <feFuncA type="table" tableValues="1 1" />
-          </feComponentTransfer>
+          <feGaussianBlur in="opaqueRegion" stdDeviation={featherRadius} />
         </filter>
         <mask id={fogMaskId} maskUnits="userSpaceOnUse" maskContentUnits="userSpaceOnUse" maskType="luminance">
           <rect x={0} y={0} width={viewWidth} height={viewHeight} fill="white" />


### PR DESCRIPTION
## Summary
- adjust the player view fog filter so revealed room masks only draw their interiors
- ensure multiple starting regions carve holes through the fog simultaneously

## Testing
- npm --prefix apps/pages test *(fails: project is missing the jsdom dependency)*

------
https://chatgpt.com/codex/tasks/task_e_690ceb0e1c708323973bde7d74fb9527