### PR TITLE
Reduce Player View feather radius

### DIFF
--- a/apps/pages/src/components/PlayerView.tsx
+++ b/apps/pages/src/components/PlayerView.tsx
@@ -29,7 +29,7 @@ const PlayerView: React.FC<PlayerViewProps> = ({ mapImageUrl, width, height, reg
   const maskFilterId = `${maskPrefix}-mask-filter`;
   const fogMaskId = `${maskPrefix}-fog-mask`;
   const largestDimension = Math.max(viewWidth, viewHeight);
-  const featherRadius = largestDimension * 0.06;
+  const featherRadius = largestDimension * 0.006;
   const maskPadding = largestDimension * 0.01;
   const filterPadding = maskPadding + featherRadius;
 


### PR DESCRIPTION
## Summary
- decrease the gaussian blur feather radius in the player view mask to tighten the fog transition

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690d162532b88323bf706105a0a5ba19