### PR TITLE
Display shared marker icons in session views

### DIFF
--- a/apps/pages/src/App.tsx
+++ b/apps/pages/src/App.tsx
@@ -605,6 +605,7 @@ const App: React.FC = () => {
                 mapWidth={activeSessionMap?.width}
                 mapHeight={activeSessionMap?.height}
                 regions={regions}
+                markers={markers}
                 onLeave={handleLeaveSession}
               />
             </div>

--- a/apps/pages/src/components/MapMaskCanvas.tsx
+++ b/apps/pages/src/components/MapMaskCanvas.tsx
@@ -1,6 +1,13 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import type { Marker, Region } from '../types';
 import { isPointInRoomMask, roomMaskHasCoverage } from '../utils/roomMask';
+import {
+  getReadableTextColor,
+  normalizeHexColor,
+  normaliseMarkers,
+  resolveMarkerBaseColor,
+  rgbaFromNormalizedHex,
+} from '../utils/markerUtils';
 import { getMapMarkerIconDefinition, type MapMarkerIconDefinition } from './mapMarkerIcons';
 
 interface MapMaskCanvasProps {
@@ -15,69 +22,6 @@ interface MapMaskCanvasProps {
   onPlaceMarker?: (coords: { x: number; y: number }) => void;
   onSelectMarker?: (markerId: string) => void;
 }
-
-const normaliseMarkers = (markers?: Record<string, Marker> | Marker[]) => {
-  if (!markers) return [] as Marker[];
-  if (Array.isArray(markers)) return markers;
-  return Object.values(markers);
-};
-
-const HEX_COLOR_REGEX = /^#([0-9a-f]{3}|[0-9a-f]{6})$/i;
-
-const normalizeHexColor = (value: string | null | undefined): string | null => {
-  if (!value) {
-    return null;
-  }
-  const trimmed = value.trim();
-  const match = HEX_COLOR_REGEX.exec(trimmed);
-  if (!match) {
-    return null;
-  }
-  const hex = match[1];
-  if (hex.length === 3) {
-    const [r, g, b] = hex.split('');
-    return `#${r}${r}${g}${g}${b}${b}`.toLowerCase();
-  }
-  return `#${hex.toLowerCase()}`;
-};
-
-const rgbFromNormalizedHex = (hex: string) => {
-  const value = hex.slice(1);
-  return {
-    r: parseInt(value.slice(0, 2), 16),
-    g: parseInt(value.slice(2, 4), 16),
-    b: parseInt(value.slice(4, 6), 16),
-  };
-};
-
-const rgbaFromNormalizedHex = (hex: string, alpha: number) => {
-  const { r, g, b } = rgbFromNormalizedHex(hex);
-  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
-};
-
-const getReadableTextColor = (hex: string) => {
-  const { r, g, b } = rgbFromNormalizedHex(hex);
-  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
-  return luminance > 0.65 ? '#0f172a' : '#f8fafc';
-};
-
-const resolveMarkerBaseColor = (
-  marker: Marker,
-  definition?: MapMarkerIconDefinition,
-): string => {
-  const candidates: Array<string | null | undefined> = [
-    marker.color,
-    definition?.defaultColor,
-    '#facc15',
-  ];
-  for (const candidate of candidates) {
-    const normalized = normalizeHexColor(candidate);
-    if (normalized) {
-      return normalized;
-    }
-  }
-  return '#facc15';
-};
 
 const createMaskCanvas = (mask: Region['mask']): HTMLCanvasElement | null => {
   if (typeof document === 'undefined') {

--- a/apps/pages/src/components/PlayerSessionView.tsx
+++ b/apps/pages/src/components/PlayerSessionView.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import type { MapRecord, Region, SessionRecord } from '../types';
+import type { MapRecord, Marker, Region, SessionRecord } from '../types';
 import PlayerView from './PlayerView';
 
 interface PlayerSessionViewProps {
@@ -12,6 +12,8 @@ interface PlayerSessionViewProps {
   mapHeight?: number | null;
   regions: Region[];
   revealedRegionIds?: string[] | null;
+  markers?: Record<string, Marker> | Marker[];
+  sessionMarkers?: Record<string, Marker> | Marker[];
   onLeave?: () => void;
 }
 
@@ -25,6 +27,8 @@ const PlayerSessionView: React.FC<PlayerSessionViewProps> = ({
   mapHeight,
   regions,
   revealedRegionIds,
+  markers,
+  sessionMarkers,
   onLeave,
 }) => {
   const playerRevealedRegionIds = useMemo(
@@ -85,6 +89,8 @@ const PlayerSessionView: React.FC<PlayerSessionViewProps> = ({
             height={mapHeight ?? map?.height ?? undefined}
             regions={regions}
             revealedRegionIds={playerRevealedRegionIds}
+            markers={markers}
+            sessionMarkers={sessionMarkers}
           />
         </div>
       </div>

--- a/apps/pages/src/components/PlayerView.tsx
+++ b/apps/pages/src/components/PlayerView.tsx
@@ -1,6 +1,13 @@
 import React, { useId, useMemo } from 'react';
-import type { Region } from '../types';
+import type { Marker, Region } from '../types';
 import { encodeRoomMaskToDataUrl, roomMaskHasCoverage } from '../utils/roomMask';
+import {
+  getReadableTextColor,
+  normaliseMarkers,
+  resolveMarkerBaseColor,
+  rgbaFromNormalizedHex,
+} from '../utils/markerUtils';
+import { getMapMarkerIconDefinition } from './mapMarkerIcons';
 
 interface PlayerViewProps {
   mapImageUrl?: string | null;
@@ -8,6 +15,8 @@ interface PlayerViewProps {
   height?: number | null;
   regions: Region[];
   revealedRegionIds?: string[] | null;
+  markers?: Record<string, Marker> | Marker[];
+  sessionMarkers?: Record<string, Marker> | Marker[];
 }
 
 interface RevealedMask {
@@ -22,7 +31,15 @@ interface RevealedMask {
 const fogTextureUrl =
   'https://www.motionforgepictures.com/wp-content/uploads/2023/02/Noise-Texture-featured-image_compressed-2-e1676823834686.jpg';
 
-const PlayerView: React.FC<PlayerViewProps> = ({ mapImageUrl, width, height, regions, revealedRegionIds }) => {
+const PlayerView: React.FC<PlayerViewProps> = ({
+  mapImageUrl,
+  width,
+  height,
+  regions,
+  revealedRegionIds,
+  markers,
+  sessionMarkers,
+}) => {
   const viewWidth = width ?? 1000;
   const viewHeight = height ?? 1000;
   const maskPrefix = useId();
@@ -60,70 +77,142 @@ const PlayerView: React.FC<PlayerViewProps> = ({ mapImageUrl, width, height, reg
       });
   }, [maskPadding, regions, revealedRegionIds, viewHeight, viewWidth]);
 
+  const markerBadges = useMemo(() => {
+    const revealedSet = new Set(revealedRegionIds ?? []);
+    regions.forEach((region) => {
+      if (region.visibleAtStart) {
+        revealedSet.add(region.id);
+      }
+    });
+
+    const baseMarkers = normaliseMarkers(markers).filter((marker) => {
+      if (marker.visibleAtStart) {
+        return true;
+      }
+      const linkedRegionId = marker.regionId?.trim();
+      if (linkedRegionId && revealedSet.has(linkedRegionId)) {
+        return true;
+      }
+      return false;
+    });
+
+    const sessionMarkerEntries = normaliseMarkers(sessionMarkers);
+
+    const combined = [...baseMarkers, ...sessionMarkerEntries];
+
+    return combined.map((marker) => {
+      const iconDefinition = getMapMarkerIconDefinition(marker.iconKey);
+      const baseColor = resolveMarkerBaseColor(marker, iconDefinition);
+      const displayLabel = marker.label?.trim().length ? marker.label.trim() : 'Marker';
+      const textColor = getReadableTextColor(baseColor);
+      return {
+        id: marker.id,
+        label: displayLabel.toUpperCase(),
+        left: `${(marker.x ?? 0) * 100}%`,
+        top: `${(marker.y ?? 0) * 100}%`,
+        baseColor,
+        backgroundColor: rgbaFromNormalizedHex(baseColor, 0.65),
+        borderColor: rgbaFromNormalizedHex(baseColor, 0.85),
+        textColor,
+        icon: iconDefinition
+          ? React.cloneElement(iconDefinition.icon, {
+              className: undefined,
+              width: 16,
+              height: 16,
+              style: { display: 'block', color: textColor },
+            })
+          : null,
+      };
+    });
+  }, [markers, regions, revealedRegionIds, sessionMarkers]);
+
   return (
-    <svg viewBox={`0 0 ${viewWidth} ${viewHeight}`} className="block h-full w-full">
-      <defs>
-        <filter
-          id={maskFilterId}
-          x={-filterPadding}
-          y={-filterPadding}
-          width={viewWidth + filterPadding * 2}
-          height={viewHeight + filterPadding * 2}
-          filterUnits="userSpaceOnUse"
-          colorInterpolationFilters="sRGB"
-        >
-          <feComponentTransfer result="inverted">
-            <feFuncR type="table" tableValues="1 0" />
-            <feFuncG type="table" tableValues="1 0" />
-            <feFuncB type="table" tableValues="1 0" />
-            <feFuncA type="table" tableValues="1 1" />
-          </feComponentTransfer>
-          <feGaussianBlur in="inverted" stdDeviation={featherRadius} result="feathered" />
-          <feColorMatrix
-            in="feathered"
-            type="matrix"
-            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 -1 0 0 0 1"
-          />
-        </filter>
-        <mask id={fogMaskId} maskUnits="userSpaceOnUse" maskContentUnits="userSpaceOnUse" maskType="luminance">
-          <rect x={0} y={0} width={viewWidth} height={viewHeight} fill="white" />
-          {revealedMasks.map((mask) => (
-            <image
-              key={mask.id}
-              href={mask.dataUrl}
-              x={mask.x}
-              y={mask.y}
-              width={mask.width}
-              height={mask.height}
-              preserveAspectRatio="none"
-              filter={`url(#${maskFilterId})`}
+    <div className="relative h-full w-full">
+      <svg viewBox={`0 0 ${viewWidth} ${viewHeight}`} className="block h-full w-full">
+        <defs>
+          <filter
+            id={maskFilterId}
+            x={-filterPadding}
+            y={-filterPadding}
+            width={viewWidth + filterPadding * 2}
+            height={viewHeight + filterPadding * 2}
+            filterUnits="userSpaceOnUse"
+            colorInterpolationFilters="sRGB"
+          >
+            <feComponentTransfer result="inverted">
+              <feFuncR type="table" tableValues="1 0" />
+              <feFuncG type="table" tableValues="1 0" />
+              <feFuncB type="table" tableValues="1 0" />
+              <feFuncA type="table" tableValues="1 1" />
+            </feComponentTransfer>
+            <feGaussianBlur in="inverted" stdDeviation={featherRadius} result="feathered" />
+            <feColorMatrix
+              in="feathered"
+              type="matrix"
+              values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 -1 0 0 0 1"
             />
+          </filter>
+          <mask id={fogMaskId} maskUnits="userSpaceOnUse" maskContentUnits="userSpaceOnUse" maskType="luminance">
+            <rect x={0} y={0} width={viewWidth} height={viewHeight} fill="white" />
+            {revealedMasks.map((mask) => (
+              <image
+                key={mask.id}
+                href={mask.dataUrl}
+                x={mask.x}
+                y={mask.y}
+                width={mask.width}
+                height={mask.height}
+                preserveAspectRatio="none"
+                filter={`url(#${maskFilterId})`}
+              />
+            ))}
+          </mask>
+        </defs>
+        {mapImageUrl && (
+          <image
+            href={mapImageUrl}
+            x={0}
+            y={0}
+            width={viewWidth}
+            height={viewHeight}
+            preserveAspectRatio="xMidYMid meet"
+          />
+        )}
+        <g mask={`url(#${fogMaskId})`}>
+          <rect x={0} y={0} width={viewWidth} height={viewHeight} fill="#0f172a" />
+          <image
+            href={fogTextureUrl}
+            x={0}
+            y={0}
+            width={viewWidth}
+            height={viewHeight}
+            preserveAspectRatio="xMidYMid slice"
+            opacity={1}
+          />
+        </g>
+      </svg>
+      {markerBadges.length > 0 && (
+        <div className="pointer-events-none absolute inset-0">
+          {markerBadges.map((marker) => (
+            <div
+              key={marker.id}
+              className="absolute flex -translate-x-1/2 -translate-y-full items-center gap-1 rounded-full border px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.35em] shadow"
+              style={{
+                left: marker.left,
+                top: marker.top,
+                backgroundColor: marker.backgroundColor,
+                borderColor: marker.borderColor,
+                color: marker.textColor,
+              }}
+            >
+              <span className="inline-block h-2 w-2 rounded-full" style={{ backgroundColor: marker.baseColor }} />
+              {marker.icon && <span className="flex h-4 w-4 items-center justify-center">{marker.icon}</span>}
+              {marker.label}
+            </div>
           ))}
-        </mask>
-      </defs>
-      {mapImageUrl && (
-        <image
-          href={mapImageUrl}
-          x={0}
-          y={0}
-          width={viewWidth}
-          height={viewHeight}
-          preserveAspectRatio="xMidYMid meet"
-        />
+        </div>
       )}
-      <g mask={`url(#${fogMaskId})`}>
-        <rect x={0} y={0} width={viewWidth} height={viewHeight} fill="#0f172a" />
-        <image
-          href={fogTextureUrl}
-          x={0}
-          y={0}
-          width={viewWidth}
-          height={viewHeight}
-          preserveAspectRatio="xMidYMid slice"
-          opacity={1}
-        />
-      </g>
-    </svg>
+    </div>
   );
 };
 

--- a/apps/pages/src/utils/markerUtils.ts
+++ b/apps/pages/src/utils/markerUtils.ts
@@ -1,0 +1,70 @@
+import type { Marker } from '../types';
+import type { MapMarkerIconDefinition } from '../components/mapMarkerIcons';
+
+const HEX_COLOR_REGEX = /^#([0-9a-f]{3}|[0-9a-f]{6})$/i;
+
+export const normalizeHexColor = (value: string | null | undefined): string | null => {
+  if (!value) {
+    return null;
+  }
+  const trimmed = value.trim();
+  const match = HEX_COLOR_REGEX.exec(trimmed);
+  if (!match) {
+    return null;
+  }
+  const hex = match[1];
+  if (hex.length === 3) {
+    const [r, g, b] = hex.split('');
+    return `#${r}${r}${g}${g}${b}${b}`.toLowerCase();
+  }
+  return `#${hex.toLowerCase()}`;
+};
+
+const rgbFromNormalizedHex = (hex: string) => {
+  const value = hex.slice(1);
+  return {
+    r: parseInt(value.slice(0, 2), 16),
+    g: parseInt(value.slice(2, 4), 16),
+    b: parseInt(value.slice(4, 6), 16),
+  };
+};
+
+export const rgbaFromNormalizedHex = (hex: string, alpha: number) => {
+  const { r, g, b } = rgbFromNormalizedHex(hex);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+};
+
+export const getReadableTextColor = (hex: string) => {
+  const { r, g, b } = rgbFromNormalizedHex(hex);
+  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+  return luminance > 0.65 ? '#0f172a' : '#f8fafc';
+};
+
+export const resolveMarkerBaseColor = (
+  marker: Marker,
+  definition?: MapMarkerIconDefinition,
+): string => {
+  const candidates: Array<string | null | undefined> = [
+    marker.color,
+    definition?.defaultColor,
+    '#facc15',
+  ];
+  for (const candidate of candidates) {
+    const normalized = normalizeHexColor(candidate);
+    if (normalized) {
+      return normalized;
+    }
+  }
+  return '#facc15';
+};
+
+export const normaliseMarkers = <T extends { id: string }>(markers?: Record<string, T> | T[]): T[] => {
+  if (!markers) {
+    return [];
+  }
+  if (Array.isArray(markers)) {
+    return markers;
+  }
+  return Object.values(markers);
+};
+


### PR DESCRIPTION
## Summary
- surface revealed room markers in the player view using the shared map marker icons
- reuse marker color utilities across the editor and session viewers
- render DM session viewer markers with the same SVG icons used in the map wizard

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_690d220555108323ae3a0f311b457cdc