### PR TITLE
Add live session websocket syncing

### DIFF
--- a/apps/pages/src/types.ts
+++ b/apps/pages/src/types.ts
@@ -111,6 +111,16 @@ export interface SessionState {
   lastUpdated?: string;
 }
 
+export interface SessionLiveMarker {
+  id: string;
+  label: string;
+  x: number;
+  y: number;
+  color?: string | null;
+  iconKey?: string | null;
+  notes?: string | null;
+}
+
 export interface LobbySessionSummary {
   id: string;
   name: string;


### PR DESCRIPTION
## Summary
- add session-level WebSocket state in App to subscribe to reveal and marker broadcasts
- forward live reveal and marker data to the DM and player viewers so previews stay in sync
- let the DM rooms tab trigger reveal/hide broadcasts after confirmation prompts

## Testing
- npm --prefix apps/pages test -- --run *(fails: missing jsdom dependency)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d70a250048323bca4672187c7afcc)