### PR TITLE
Ensure DM session sidebar tabs scroll

### DIFF
--- a/apps/pages/src/components/DMSessionViewer.tsx
+++ b/apps/pages/src/components/DMSessionViewer.tsx
@@ -480,16 +480,15 @@ const DMSessionViewer: React.FC<DMSessionViewerProps> = ({
               Other
             </button>
           </div>
-          <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+          <div className="flex min-h-0 flex-1 flex-col">
             {activeTab === 'rooms' && (
-              <div className="min-h-0 flex-1 overflow-hidden">
-                <div className="h-full overflow-y-auto p-4">
-                  {sortedRegions.length === 0 ? (
-                    <p className="rounded-2xl border border-dashed border-white/60 bg-white/40 px-4 py-6 text-center text-xs uppercase tracking-[0.3em] text-slate-500 dark:border-slate-700 dark:bg-slate-900/40 dark:text-slate-400">
-                      No rooms defined for this map.
-                    </p>
-                  ) : (
-                    <div className="space-y-3">
+              <div className="flex-1 overflow-y-auto p-4">
+                {sortedRegions.length === 0 ? (
+                  <p className="rounded-2xl border border-dashed border-white/60 bg-white/40 px-4 py-6 text-center text-xs uppercase tracking-[0.3em] text-slate-500 dark:border-slate-700 dark:bg-slate-900/40 dark:text-slate-400">
+                    No rooms defined for this map.
+                  </p>
+                ) : (
+                  <div className="space-y-3">
                     {sortedRegions.map((region) => {
                       const isExpanded = expandedRegionIds.has(region.id);
                       const tags = parseTagList(region.tags);
@@ -621,17 +620,15 @@ const DMSessionViewer: React.FC<DMSessionViewerProps> = ({
                     })}
                   </div>
                 )}
-                </div>
               </div>
             )}
             {activeTab === 'markers' && (
-              <div className="min-h-0 flex-1 overflow-hidden">
-                <div className="h-full overflow-y-auto p-4">
-                  {sortedMarkers.length === 0 ? (
-                    <p className="rounded-2xl border border-dashed border-white/60 bg-white/40 px-4 py-6 text-center text-xs uppercase tracking-[0.3em] text-slate-500 dark:border-slate-700 dark:bg-slate-900/40 dark:text-slate-400">
-                      No markers placed on this map.
-                    </p>
-                  ) : (
+              <div className="flex-1 overflow-y-auto p-4">
+                {sortedMarkers.length === 0 ? (
+                  <p className="rounded-2xl border border-dashed border-white/60 bg-white/40 px-4 py-6 text-center text-xs uppercase tracking-[0.3em] text-slate-500 dark:border-slate-700 dark:bg-slate-900/40 dark:text-slate-400">
+                    No markers placed on this map.
+                  </p>
+                ) : (
                   <div className="space-y-3">
                     {sortedMarkers.map((marker) => {
                       const tags = parseTagList(marker.tags);
@@ -717,7 +714,6 @@ const DMSessionViewer: React.FC<DMSessionViewerProps> = ({
                     })}
                   </div>
                 )}
-                </div>
               </div>
             )}
             {activeTab === 'other' && (


### PR DESCRIPTION
## Summary
- wrap the Rooms and Markers tab content in fixed-height containers so their cards can scroll inside the DM session viewer sidebar

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d84bcead08323ac67202346d204ad)