### PR TITLE
Clamp DM sidebar body height

### DIFF
--- a/apps/pages/src/components/DMSessionViewer.tsx
+++ b/apps/pages/src/components/DMSessionViewer.tsx
@@ -480,7 +480,10 @@ const DMSessionViewer: React.FC<DMSessionViewerProps> = ({
               Other
             </button>
           </div>
-          <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+          <div
+            className="flex min-h-0 flex-1 flex-col overflow-hidden"
+            style={{ maxHeight: '84vh' }}
+          >
             {activeTab === 'rooms' && (
               <div className="min-h-0 flex-1 overflow-y-auto p-4">
                 {sortedRegions.length === 0 ? (


### PR DESCRIPTION
## Summary
- limit the sidebar tab content height in the DM session viewer so overflowing lists scroll within the panel

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e17879158832395e4e11f2894ce51)