### PR TITLE
Enable marker reveal controls in DM session viewer

### DIFF
--- a/apps/pages/src/types.ts
+++ b/apps/pages/src/types.ts
@@ -105,6 +105,7 @@ export interface SessionState {
   name: string | null;
   status: string;
   revealedRegions: string[];
+  revealedMarkers: string[];
   markers: Record<string, Marker>;
   metadata: Record<string, unknown>;
   players: Array<{ id: string; role: string; name: string }>;


### PR DESCRIPTION
## Summary
- track revealed marker ids through the session durable object and websocket client
- surface reveal controls for hidden markers in the DM session viewer and honor their state in player view
- reset and forward revealed marker information when switching sessions or roles

## Testing
- npm run test -- --run *(fails: missing `jsdom` dependency in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e1dee3c3c8323bfbbfb6e243ff80e)