### PR TITLE
Add edit map button for campaign admin actions

### DIFF
--- a/apps/pages/src/App.tsx
+++ b/apps/pages/src/App.tsx
@@ -581,6 +581,11 @@ const App: React.FC = () => {
     setShowMapWizard(true);
   };
 
+  const handleEditMap = () => {
+    if (!selectedCampaign || !selectedMap) return;
+    setShowMapWizard(true);
+  };
+
   const handleCloseMapWizard = () => {
     setShowMapWizard(false);
   };
@@ -1273,6 +1278,14 @@ const App: React.FC = () => {
                       onClick={handleBackToManage}
                     >
                       Campaign List
+                    </button>
+                    <button
+                      type="button"
+                      className="rounded-full border border-sky-400/70 bg-sky-200/40 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-sky-700 transition hover:bg-sky-200/60 dark:border-sky-400/40 dark:bg-sky-500/20 dark:text-sky-100 dark:hover:bg-sky-500/30"
+                      onClick={handleEditMap}
+                      disabled={!selectedMap}
+                    >
+                      Edit Map
                     </button>
                     <button
                       type="button"


### PR DESCRIPTION
## Summary
- add an Edit Map button alongside the campaign management actions
- allow campaign admins to reopen the map creation wizard from the selected map card

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e591e42788323aaad706c425c403a)