### PR TITLE
Add edit map button to campaign admin controls

### DIFF
--- a/apps/pages/src/App.tsx
+++ b/apps/pages/src/App.tsx
@@ -634,6 +634,14 @@ const App: React.FC = () => {
     setActiveView('manage');
   };
 
+  const handleEditMap = () => {
+    if (!selectedMap) {
+      window.alert('Select a map to edit first.');
+      return;
+    }
+    handleOpenMapWizard();
+  };
+
   const handleDeleteCampaign = async () => {
     if (!selectedCampaign) return;
     const confirmDelete = window.confirm(
@@ -1280,6 +1288,13 @@ const App: React.FC = () => {
                       onClick={handleDeleteCampaign}
                     >
                       Delete Campaign
+                    </button>
+                    <button
+                      type="button"
+                      className="rounded-full border border-emerald-400/70 bg-emerald-300/70 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-emerald-300/80 dark:border-emerald-400/50 dark:bg-emerald-400/20 dark:text-emerald-100 dark:hover:bg-emerald-400/30"
+                      onClick={handleEditMap}
+                    >
+                      Edit Map
                     </button>
                     <button
                       type="button"


### PR DESCRIPTION
## Summary
- add an Edit Map control to the campaign management action bar so DMs can reopen the map wizard
- prevent launching the wizard without a selected map by prompting the user to choose one first

## Testing
- npm test -- --run *(fails: Vitest prompts to install jsdom but npm registry access is forbidden in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e591e42788323aaad706c425c403a)